### PR TITLE
Add new leak regular rule: WPConfig file exposed

### DIFF
--- a/development-kit/pkg/engines/examples/leaks-php/wp-config.php
+++ b/development-kit/pkg/engines/examples/leaks-php/wp-config.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ *  * The base configuration for WordPress
+ *   *
+ *    * The wp-config.php creation script uses this file during the
+ *     * installation. You don't have to use the web site, you can
+ *      * copy this file to "wp-config.php" and fill in the values.
+ *       *
+ *        * This file contains the following configurations:
+ *         *
+ *          * * MySQL settings
+ *           * * Secret keys
+ *            * * Database table prefix
+ *             * * ABSPATH
+ *              *
+ *               * @link https://wordpress.org/support/article/editing-wp-config-php/
+ *                *
+ *                 * @package WordPress
+ *                  */
+
+// ** MySQL settings - You can get this info from your web host ** //
+/** The name of the database for WordPress */
+define( 'DB_NAME', 'mkllel' );
+
+/** MySQL database username */
+define( 'DB_USER', 'mkllel' );
+
+/** MySQL database password */
+define( 'DB_PASSWORD', 'wen0221!' );
+
+/** MySQL hostname */
+define( 'DB_HOST', 'localhost' );
+
+/** Database Charset to use in creating database tables. */
+define( 'DB_CHARSET', 'utf8' );
+
+/** The Database Collate type. Don't change this if in doubt. */
+define( 'DB_COLLATE', '' );
+
+/**#@+
+ * Authentication Unique Keys and Salts.
+ *
+ * Change these to different unique phrases!
+ * You can generate these using the {@link https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org secret-key service}
+ * You can change these at any point in time to invalidate all existing cookies. This will force all users to have to log in again.
+ *
+ * @since 2.6.0
+ */
+define( 'AUTH_KEY',         'put your unique phrase here' );
+define( 'SECURE_AUTH_KEY',  'put your unique phrase here' );
+define( 'LOGGED_IN_KEY',    'put your unique phrase here' );
+define( 'NONCE_KEY',        'put your unique phrase here' );
+define( 'AUTH_SALT',        'put your unique phrase here' );
+define( 'SECURE_AUTH_SALT', 'put your unique phrase here' );
+define( 'LOGGED_IN_SALT',   'put your unique phrase here' );
+define( 'NONCE_SALT',       'put your unique phrase here' );
+
+/**#@-*/
+
+/**
+ * WordPress Database Table prefix.
+ *
+ * You can have multiple installations in one database if you give each
+ * a unique prefix. Only numbers, letters, and underscores please!
+ */
+$table_prefix = 'wp_';
+
+/**
+ * For developers: WordPress debugging mode.
+ *
+ * Change this to true to enable the display of notices during development.
+ * It is strongly recommended that plugin and theme developers use WP_DEBUG
+ * in their development environments.
+ *
+ * For information on other constants that can be used for debugging,
+ * visit the documentation.
+ *
+ * @link https://wordpress.org/support/article/debugging-in-wordpress/
+ */
+define( 'WP_DEBUG', false );
+
+/* That's all, stop editing! Happy publishing. */
+
+/** Absolute path to the WordPress directory. */
+if ( ! defined( 'ABSPATH' ) ) {
+    define( 'ABSPATH', __DIR__ . '/' );
+}
+
+/** Sets up WordPress vars and included files. */
+require_once ABSPATH . 'wp-settings.php';

--- a/development-kit/pkg/engines/leaks/analysis/analysis_test.go
+++ b/development-kit/pkg/engines/leaks/analysis/analysis_test.go
@@ -23,7 +23,6 @@ import (
 	engine "github.com/ZupIT/horusec-engine"
 	"github.com/ZupIT/horusec/development-kit/pkg/cli_standard/config"
 	"github.com/ZupIT/horusec/development-kit/pkg/enums/engine/advisories/leaks/regular"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -32,7 +31,7 @@ func TestNewAnalysis(t *testing.T) {
 }
 
 func TestAnalysis_StartAnalysis(t *testing.T) {
-	t.Run("Should return success when read all example analysis and return 4 vulnerabilities", func(t *testing.T) {
+	t.Run("Should return success when read all example analysis and return 14 vulnerabilities", func(t *testing.T) {
 		configs := config.NewConfig()
 		configs.SetOutputFilePath("./leaks-tmp1.output.json")
 		configs.SetProjectPath("../../examples")
@@ -41,9 +40,8 @@ func TestAnalysis_StartAnalysis(t *testing.T) {
 		fileBytes, err := ioutil.ReadFile("./leaks-tmp1.output.json")
 		data := []engine.Finding{}
 		_ = json.Unmarshal(fileBytes, &data)
-		spew.Dump(data)
 		assert.NoError(t, os.RemoveAll(configs.GetOutputFilePath()))
-		assert.Equal(t, len(data), 4)
+		assert.Equal(t, len(data), 14)
 	})
 	t.Run("Should return success when read analysis and return two vulnerabilities", func(t *testing.T) {
 		configs := config.NewConfig()
@@ -81,6 +79,9 @@ func TestAnalysis_StartAnalysis(t *testing.T) {
 		err := NewAnalysis(configs).StartAnalysis()
 		assert.Error(t, err)
 	})
+}
+
+func TestAnalysis_StartRegularAnalysis(t *testing.T) {
 	t.Run("Should return a vulnerability from PasswordExposedInHardcodeURL", func(t *testing.T) {
 		configs := config.NewConfig()
 		configs.SetOutputFilePath("./leaks-tmp4.output.json")
@@ -91,7 +92,6 @@ func TestAnalysis_StartAnalysis(t *testing.T) {
 		data := []engine.Finding{}
 		_ = json.Unmarshal(fileBytes, &data)
 		assert.NoError(t, os.RemoveAll(configs.GetOutputFilePath()))
-
 		vulnCounter := 0
 		for _, vuln := range data {
 			if vuln.ID == regular.NewLeaksRegularPasswordExposedInHardcodedURL().ID {
@@ -99,5 +99,24 @@ func TestAnalysis_StartAnalysis(t *testing.T) {
 			}
 		}
 		assert.Equal(t, vulnCounter, 1)
+	})
+
+	t.Run("Should return a vulnerability from WPConfig", func(t *testing.T) {
+		configs := config.NewConfig()
+		configs.SetOutputFilePath("./leaks-tmp5.output.json")
+		configs.SetProjectPath("../../examples/leaks-php")
+		err := NewAnalysis(configs).StartAnalysis()
+		assert.NoError(t, err)
+		fileBytes, err := ioutil.ReadFile("./leaks-tmp5.output.json")
+		data := []engine.Finding{}
+		_ = json.Unmarshal(fileBytes, &data)
+		assert.NoError(t, os.RemoveAll(configs.GetOutputFilePath()))
+		vulnCounter := 0
+		for _, vuln := range data {
+			if vuln.ID == regular.NewLeaksRegularWPConfig().ID {
+				vulnCounter++
+			}
+		}
+		assert.Equal(t, vulnCounter, 10)
 	})
 }

--- a/development-kit/pkg/enums/engine/advisories/leaks/leaks.go
+++ b/development-kit/pkg/enums/engine/advisories/leaks/leaks.go
@@ -49,6 +49,7 @@ func AllRulesLeaksRegular() []text.TextRule {
 		regular.NewLeaksRegularHardCodedCredentialGeneric(),
 		regular.NewLeaksRegularHardCodedPassword(),
 		regular.NewLeaksRegularPasswordExposedInHardcodedURL(),
+		regular.NewLeaksRegularWPConfig(),
 	}
 }
 

--- a/development-kit/pkg/enums/engine/advisories/leaks/leaks_test.go
+++ b/development-kit/pkg/enums/engine/advisories/leaks/leaks_test.go
@@ -27,7 +27,7 @@ func TestRulesEnum(t *testing.T) {
 	totalRules = append(totalRules, AllRulesLeaksRegular()...)
 	totalRules = append(totalRules, AllRulesLeaksAnd()...)
 	totalRules = append(totalRules, AllRulesLeaksOr()...)
-	lenExpectedTotalRules := 27
+	lenExpectedTotalRules := 28
 	t.Run("Should not exists duplicated ID in rules and return lenExpectedTotalRules in leaks", func(t *testing.T) {
 		encountered := map[string]bool{}
 

--- a/development-kit/pkg/enums/engine/advisories/leaks/regular/regular.go
+++ b/development-kit/pkg/enums/engine/advisories/leaks/regular/regular.go
@@ -461,3 +461,19 @@ func NewLeaksRegularPasswordExposedInHardcodedURL() text.TextRule {
 		},
 	}
 }
+
+func NewLeaksRegularWPConfig() text.TextRule {
+	return text.TextRule{
+		Metadata: engine.Metadata{
+			ID:          "5332204a-0d3d-4fe3-a73b-29525101afa0",
+			Name:        "Wordpress configuration file disclosure",
+			Description: "Wordpress configuration file exposed, this can lead to the leak of admin passowrds, database credentials and a lot of sensitive data about the system. Check CWE-200 (https://cwe.mitre.org/data/definitions/200.html) for more details.",
+			Severity:    severity.High.ToString(),
+			Confidence:  confidence.High.ToString(),
+		},
+		Type: text.Regular,
+		Expressions: []*regexp.Regexp{
+			regexp.MustCompile(`define(.{0,20})?(DB_CHARSET|NONCE_SALT|LOGGED_IN_SALT|AUTH_SALT|NONCE_KEY|DB_HOST|DB_PASSWORD|AUTH_KEY|SECURE_AUTH_KEY|LOGGED_IN_KEY|DB_NAME|DB_USER)(.{0,20})?[''|"].{10,120}[''|"]`),
+		},
+	}
+}


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
Add a new leak regular rule to find wp-config expressions.

**- How to verify it**
There is a new example file and a new unit test, run: ` go test -v ./development-kit/pkg/engines/leaks/analysis -timeout=2m -parallel=1 -failfast -short`
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
