### PR TITLE
Improving cli to print error message by line, and removing missing pa…

### DIFF
--- a/development-kit/pkg/entities/horusec/analysis.go
+++ b/development-kit/pkg/entities/horusec/analysis.go
@@ -82,7 +82,7 @@ func (a *Analysis) SetAnalysisError(err error) {
 	if err != nil {
 		toAppend := ""
 		if len(a.Errors) > 0 {
-			a.Errors += ", " + err.Error()
+			a.Errors += "; " + err.Error()
 			return
 		}
 		a.Errors += toAppend + err.Error()

--- a/development-kit/pkg/entities/horusec/analysis_test.go
+++ b/development-kit/pkg/entities/horusec/analysis_test.go
@@ -88,9 +88,9 @@ func TestSetAnalysisError(t *testing.T) {
 		analysis.SetAnalysisError(errors.New("test"))
 		assert.Equal(t, "test", analysis.Errors)
 		analysis.SetAnalysisError(errors.New("test"))
-		assert.Equal(t, "test, test", analysis.Errors)
+		assert.Equal(t, "test; test", analysis.Errors)
 		analysis.SetAnalysisError(errors.New("test"))
-		assert.Equal(t, "test, test, test", analysis.Errors)
+		assert.Equal(t, "test; test; test", analysis.Errors)
 	})
 }
 

--- a/horusec-cli/internal/controllers/printresults/print_results.go
+++ b/horusec-cli/internal/controllers/printresults/print_results.go
@@ -275,9 +275,26 @@ func (pr *PrintResults) verifyRepositoryAuthorizationToken() {
 
 func (pr *PrintResults) checkIfExistsErrorsInAnalysis() {
 	if pr.analysis.HasErrors() {
-		logger.LogErrorWithLevel(messages.MsgErrorFoundErrorsInAnalysis, errors.New(pr.analysis.Errors), logger.ErrorLevel)
+		pr.logSeparator(true)
+		logger.LogWarnWithLevel(messages.MsgErrorFoundErrorsInAnalysis, logger.WarnLevel)
+		fmt.Print("\n")
+
+		for _, errorMessage := range strings.SplitAfter(pr.analysis.Errors, ";") {
+			pr.printErrors(errorMessage)
+		}
+
 		fmt.Print("\n")
 	}
+}
+
+func (pr *PrintResults) printErrors(errorMessage string) {
+	if strings.Contains(errorMessage, messages.MsgErrorPacketJSONNotFound) ||
+		strings.Contains(errorMessage, messages.MsgErrorYarnLockNotFound) {
+		logger.LogWarnWithLevel(strings.ReplaceAll(errorMessage, ";", ""), logger.WarnLevel)
+		return
+	}
+
+	logger.LogStringAsError(strings.ReplaceAll(errorMessage, ";", ""))
 }
 
 func (pr *PrintResults) printResponseAnalysis() {

--- a/horusec-cli/internal/helpers/messages/error.go
+++ b/horusec-cli/internal/helpers/messages/error.go
@@ -78,7 +78,7 @@ const (
 	// Fired when to be parse string of the WorkDir Entity and return error
 	MsgErrorParseStringToWorkDir = "{HORUSEC_CLI} Error when try parse workdir string to entity. Returning default values"
 	// Fired when finish analysis and send to print results and exists errors in analysis
-	MsgErrorFoundErrorsInAnalysis   = "{HORUSEC_CLI} Error when try run analysis we founded also errors."
+	MsgErrorFoundErrorsInAnalysis   = "{HORUSEC_CLI} During execution we found some problems:"
 	MsgErrorNotFoundRequirementsTxt = "{HORUSEC_CLI} Error The file requirements.txt " +
 		"not found in python project to start analysis"
 	MsgErrorPacketJSONNotFound = "{HORUSEC_CLI} Error It looks like your project " +

--- a/horusec-cli/internal/helpers/messages/info.go
+++ b/horusec-cli/internal/helpers/messages/info.go
@@ -33,7 +33,7 @@ const (
 	MsgInfoMonitorTimeoutIn = "Hold on! Horusec still analysis your code. Timeout in: "
 	// Fired in print results service when analysis is finished
 	MsgAnalysisFoundVulns = "[HORUSEC] %d VULNERABILITIES WERE FOUND IN YOUR CODE SENT TO HORUSEC, " +
-		"SEE MORE DETAILS IN DEBUG LEVEL AND TRY AGAIN"
+		"TO SEE MORE DETAILS USE THE LOG LEVEL AS DEBUG AND TRY AGAIN"
 	// Fired in print results service when analysis is finished
 	MsgAnalysisFinishedWithoutVulns = "YOUR ANALYSIS HAD FINISHED WITHOUT ANY VULNERABILITY!"
 	// Occurs when o docker is lower version than recommend


### PR DESCRIPTION
…ckge-lock or yarn-lock as errors, fixing some misspelling

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
