### PR TITLE
[Hotfix] - Horusec Logo in template emails.

### DIFF
--- a/horusec-messages/internal/controllers/email/templates/email_confirmation.go
+++ b/horusec-messages/internal/controllers/email/templates/email_confirmation.go
@@ -262,7 +262,7 @@ const EmailConfirmationTpl = `<!doctype html>
                   <tr>
                     <td>
                       <p class="align-center logo-wrapper">
-                        <img width="150px" src="https://horus-assets.s3.amazonaws.com/images/horus_logo_200921.svg">
+                        <img width="150px" src="https://horusec.io/images/logo/horus_principal.svg">
                       </p>
                       <h1 class="align-left">Hello, {{.Username}}!</h1>
                       <p>To start using Horusec, confirm your email.</p>

--- a/horusec-messages/internal/controllers/email/templates/organization_invite.go
+++ b/horusec-messages/internal/controllers/email/templates/organization_invite.go
@@ -260,7 +260,7 @@ const OrganizationInviteTpl = `<!doctype html>
                   <tr>
                     <td>
                       <p class="align-center logo-wrapper">
-                        <img width="150px" src="https://horus-assets.s3.amazonaws.com/images/horus_logo_200921.svg">
+                        <img width="150px" src="https://horusec.io/images/logo/horus_principal.svg">
                       </p>
                       <h1 class="align-left">Hello, {{.Username}}!</h1>
                       <p>You have been invited to join the organization {{.CompanyName}}.</p>

--- a/horusec-messages/internal/controllers/email/templates/reset_password.go
+++ b/horusec-messages/internal/controllers/email/templates/reset_password.go
@@ -269,7 +269,7 @@ const ResetPasswordTpl = `<!doctype html>
                   <tr>
                     <td>
                       <p class="align-center logo-wrapper">
-                        <img width="150px" src="https://horus-assets.s3.amazonaws.com/images/horus_logo_200921.svg">
+                        <img width="150px" src="https://horusec.io/images/logo/horus_principal.svg">
                       </p>
                       <h1 class="align-left">Hello, {{.Username}}!</h1>
                       <p>You have requested a password reset to access HORUSEC. The code is valid for 10 minutes


### PR DESCRIPTION
🛠  Fixing broken URL of horusec logo in template e-mail
