### PR TITLE
Added safe JSON parse in manager

### DIFF
--- a/horusec-manager/.semver.yaml
+++ b/horusec-manager/.semver.yaml
@@ -1,4 +1,4 @@
 alpha: 0
 beta: 0
 rc: 0
-release: v1.7.2
+release: v1.7.3

--- a/horusec-manager/src/helpers/localStorage/currentLanguage.ts
+++ b/horusec-manager/src/helpers/localStorage/currentLanguage.ts
@@ -18,11 +18,12 @@ import { localStorageKeys } from 'helpers/enums/localStorageKeys';
 import { Language } from 'helpers/interfaces/Language';
 
 const getCurrentLanguage = (): Language | null => {
-  const localData: Language = JSON.parse(
-    window.localStorage.getItem(localStorageKeys.LANGUAGE)
-  );
-
-  return localData;
+  try {
+    const localData = window.localStorage.getItem(localStorageKeys.LANGUAGE);
+    return localData ? JSON.parse(localData) : null;
+  } catch (e) {
+    return null;
+  }
 };
 
 const setCurrentLanguage = (value: Language) => {

--- a/horusec-manager/src/helpers/localStorage/currentUser.ts
+++ b/horusec-manager/src/helpers/localStorage/currentUser.ts
@@ -19,11 +19,12 @@ import { User } from 'helpers/interfaces/User';
 import { getCurrentConfig } from './horusecConfig';
 
 const getCurrentUser = (): User | null => {
-  const localData: User = JSON.parse(
-    window.localStorage.getItem(localStorageKeys.USER)
-  );
-
-  return localData;
+  try {
+    const localData = window.localStorage.getItem(localStorageKeys.USER);
+    return localData ? JSON.parse(localData) : null;
+  } catch (e) {
+    return null;
+  }
 };
 
 const setCurrentUser = (value: User) => {

--- a/horusec-manager/src/helpers/localStorage/horusecConfig.ts
+++ b/horusec-manager/src/helpers/localStorage/horusecConfig.ts
@@ -18,14 +18,18 @@ import { localStorageKeys } from 'helpers/enums/localStorageKeys';
 import { HorusecConfig } from 'helpers/interfaces/HorusecConfig';
 
 const initialValues: HorusecConfig = {
-  authType: null,
+  authType: 'horusec',
   applicationAdminEnable: false,
-  disabledBroker: false,
+  disabledBroker: true,
 };
 
 const getCurrentConfig = (): HorusecConfig => {
-  const config = window.localStorage.getItem(localStorageKeys.CONFIG);
-  return config ? JSON.parse(config) : initialValues;
+  try {
+    const config = window.localStorage.getItem(localStorageKeys.CONFIG);
+    return config ? JSON.parse(config) : initialValues;
+  } catch (e) {
+    return initialValues;
+  }
 };
 
 const setCurrenConfig = (value: HorusecConfig) => {


### PR DESCRIPTION
Changed the functions in the manager that use JSON.parse so that you can use it in a safer way and not cause an error in the application if something unexpected occurs.