### PR TITLE
Added support to Alpine Linux

### DIFF
--- a/.github/workflows/cli-pipeline.yml
+++ b/.github/workflows/cli-pipeline.yml
@@ -40,11 +40,11 @@ jobs:
       - name: coverage
         run: make coverage-horusec-cli
       - name: build
-        run: go build -o "./tmp/bin/horusec-cli" ./horusec-cli/cmd/horusec/main.go
+        run: CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o "./tmp/bin/horusec-cli" ./horusec-cli/cmd/horusec/main.go
       - name: Running Horusec Security Running current version
         shell: bash
         run: |
-          go build -o horusec ./horusec-cli/cmd/horusec/main.go
+          CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo  -o horusec ./horusec-cli/cmd/horusec/main.go
           chmod +x horusec
           sudo mv horusec /usr/local/bin
           horusec start -p="./"

--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ install-semver:
 PATH_BINARY_BUILD_CLI ?= $(GOPATH)/bin
 build-install-cli:
 	rm -rf "$(PATH_BINARY_BUILD_CLI)/horusec" &> /dev/null
-	$(GO) build -o "$(PATH_BINARY_BUILD_CLI)/horusec" ./horusec-cli/cmd/horusec/main.go
+	CGO_ENABLED=0 GOOS=linux $(GO) build -a -installsuffix cgo -o "$(PATH_BINARY_BUILD_CLI)/horusec" ./horusec-cli/cmd/horusec/main.go
 	chmod +x "$(PATH_BINARY_BUILD_CLI)/horusec"
 	horusec version
 build-install-cli-windows:

--- a/horusec-cli/deployments/scripts/update-image.sh
+++ b/horusec-cli/deployments/scripts/update-image.sh
@@ -73,7 +73,7 @@ generateBinaries () {
     ACTUAL_RELEASE_FORMATTED=`tr '.' '-' <<<"$ACTUAL_RELEASE"`
 
     # Build for linux x86
-    env GOOS=linux GOARCH=386 go build -o "./horusec-cli/bin/horusec/$ACTUAL_RELEASE_FORMATTED/linux_x86/horusec" ./horusec-cli/cmd/horusec/main.go
+    env CGO_ENABLED=0 GOOS=linux GOARCH=386 go build -a -installsuffix cgo -o "./horusec-cli/bin/horusec/$ACTUAL_RELEASE_FORMATTED/linux_x86/horusec" ./horusec-cli/cmd/horusec/main.go
     if [[ $? -eq 0 ]]
     then
         echo "1/5 Binary generated with success in ./horusec-cli/bin/horusec/$ACTUAL_RELEASE_FORMATTED/linux_x86/horusec"
@@ -82,7 +82,7 @@ generateBinaries () {
     fi
 
     # Build for linux x64
-    env GOOS=linux GOARCH=amd64 go build -o "./horusec-cli/bin/horusec/$ACTUAL_RELEASE_FORMATTED/linux_x64/horusec" ./horusec-cli/cmd/horusec/main.go
+    env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -o "./horusec-cli/bin/horusec/$ACTUAL_RELEASE_FORMATTED/linux_x64/horusec" ./horusec-cli/cmd/horusec/main.go
     if [[ $? -eq 0 ]]
     then
         echo "2/5 Binary generated with success in ./horusec-cli/bin/horusec/$ACTUAL_RELEASE_FORMATTED/linux_x64/horusec"


### PR DESCRIPTION
**- What I did**
Added arguments to build the Horusec binary without dynamic link with libc. Alpine Linux doesn't have by default support to Glibc, `go build` link dynamically with it if you don't add explicit arguments to build without any dynamic link library.

**- How to verify it**
Build and copy Horusec binary to an Alpine container.

```
$ export GOPATH=$HOME/go
$ export PATH=$PATH:$GOPATH/bin
$ make build-install-cli
$ docker run -it -v $GOPATH:/go alpine:latest sh
$ cd /go/bin
$ ./horusec version
```

**- Description for the changelog**
Add arguments for the building binary without any dynamic link library (run to the Alpine Linux)