### PR TITLE
create default formatter to all horusec engines (#465)

### DIFF
--- a/internal/services/engines/csharp/rules.go
+++ b/internal/services/engines/csharp/rules.go
@@ -22,14 +22,9 @@ import (
 	"github.com/ZupIT/horusec/internal/services/engines/csharp/regular"
 )
 
-type Interface interface {
-	GetAllRules() (rules []engine.Rule)
-	GetTextUnitByRulesExt(projectPath string) ([]engine.Unit, error)
-}
-
 type Rules struct{}
 
-func NewRules() Interface {
+func NewRules() *Rules {
 	return &Rules{}
 }
 

--- a/internal/services/engines/dart/rules.go
+++ b/internal/services/engines/dart/rules.go
@@ -22,14 +22,9 @@ import (
 	"github.com/ZupIT/horusec/internal/services/engines/dart/regular"
 )
 
-type Interface interface {
-	GetAllRules() []engine.Rule
-	GetTextUnitByRulesExt(projectPath string) ([]engine.Unit, error)
-}
-
 type Rules struct{}
 
-func NewRules() Interface {
+func NewRules() *Rules {
 	return &Rules{}
 }
 

--- a/internal/services/engines/java/rules.go
+++ b/internal/services/engines/java/rules.go
@@ -23,16 +23,11 @@ import (
 	"github.com/ZupIT/horusec/internal/services/engines/jvm"
 )
 
-type Interface interface {
-	GetAllRules() (rules []engine.Rule)
-	GetTextUnitByRulesExt(projectPath string) ([]engine.Unit, error)
-}
-
 type Rules struct {
-	jvmRules jvm.Interface
+	jvmRules *jvm.Rules
 }
 
-func NewRules() Interface {
+func NewRules() *Rules {
 	return &Rules{
 		jvmRules: jvm.NewRules(),
 	}

--- a/internal/services/engines/jvm/rules.go
+++ b/internal/services/engines/jvm/rules.go
@@ -22,13 +22,9 @@ import (
 	"github.com/ZupIT/horusec/internal/services/engines/jvm/regular"
 )
 
-type Interface interface {
-	GetAllRules(rules []engine.Rule) []engine.Rule
-}
-
 type Rules struct{}
 
-func NewRules() Interface {
+func NewRules() *Rules {
 	return &Rules{}
 }
 

--- a/internal/services/engines/kotlin/rules.go
+++ b/internal/services/engines/kotlin/rules.go
@@ -20,16 +20,11 @@ import (
 	"github.com/ZupIT/horusec/internal/services/engines/jvm"
 )
 
-type Interface interface {
-	GetAllRules() (rules []engine.Rule)
-	GetTextUnitByRulesExt(projectPath string) ([]engine.Unit, error)
-}
-
 type Rules struct {
-	jvmRules jvm.Interface
+	jvmRules *jvm.Rules
 }
 
-func NewRules() Interface {
+func NewRules() *Rules {
 	return &Rules{
 		jvmRules: jvm.NewRules(),
 	}

--- a/internal/services/engines/kubernetes/rules.go
+++ b/internal/services/engines/kubernetes/rules.go
@@ -22,14 +22,9 @@ import (
 	"github.com/ZupIT/horusec/internal/services/engines/kubernetes/regular"
 )
 
-type Interface interface {
-	GetAllRules() (rules []engine.Rule)
-	GetTextUnitByRulesExt(projectPath string) ([]engine.Unit, error)
-}
-
 type Rules struct{}
 
-func NewRules() Interface {
+func NewRules() *Rules {
 	return &Rules{}
 }
 

--- a/internal/services/engines/leaks/rules.go
+++ b/internal/services/engines/leaks/rules.go
@@ -20,14 +20,9 @@ import (
 	"github.com/ZupIT/horusec/internal/services/engines/leaks/regular"
 )
 
-type Interface interface {
-	GetAllRules() (rules []engine.Rule)
-	GetTextUnitByRulesExt(projectPath string) ([]engine.Unit, error)
-}
-
 type Rules struct{}
 
-func NewRules() Interface {
+func NewRules() *Rules {
 	return &Rules{}
 }
 

--- a/internal/services/engines/nginx/rules.go
+++ b/internal/services/engines/nginx/rules.go
@@ -21,14 +21,9 @@ import (
 	"github.com/ZupIT/horusec/internal/services/engines/nginx/not"
 )
 
-type Interface interface {
-	GetAllRules() (rules []engine.Rule)
-	GetTextUnitByRulesExt(projectPath string) ([]engine.Unit, error)
-}
-
 type Rules struct{}
 
-func NewRules() Interface {
+func NewRules() *Rules {
 	return &Rules{}
 }
 

--- a/internal/services/engines/nodejs/rules.go
+++ b/internal/services/engines/nodejs/rules.go
@@ -22,14 +22,9 @@ import (
 	"github.com/ZupIT/horusec/internal/services/engines/nodejs/regular"
 )
 
-type Interface interface {
-	GetAllRules() (rules []engine.Rule)
-	GetTextUnitByRulesExt(projectPath string) ([]engine.Unit, error)
-}
-
 type Rules struct{}
 
-func NewRules() Interface {
+func NewRules() *Rules {
 	return &Rules{}
 }
 

--- a/internal/services/formatters/csharp/horuseccsharp/formatter.go
+++ b/internal/services/formatters/csharp/horuseccsharp/formatter.go
@@ -16,55 +16,10 @@ package horuseccsharp
 
 import (
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
-	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
-	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
-	engine "github.com/ZupIT/horusec-engine"
-	"github.com/ZupIT/horusec/internal/enums/engines"
-	"github.com/ZupIT/horusec/internal/helpers/messages"
 	"github.com/ZupIT/horusec/internal/services/engines/csharp"
 	"github.com/ZupIT/horusec/internal/services/formatters"
 )
 
-type Formatter struct {
-	formatters.IService
-	csharp.Interface
-}
-
 func NewFormatter(service formatters.IService) formatters.IFormatter {
-	return &Formatter{
-		service,
-		csharp.NewRules(),
-	}
-}
-
-func (f *Formatter) StartAnalysis(projectSubPath string) {
-	if f.ToolIsToIgnore(tools.HorusecEngine) {
-		logger.LogDebugWithLevel(messages.MsgDebugToolIgnored + tools.HorusecEngine.ToString())
-		return
-	}
-
-	f.SetAnalysisError(f.execEngineAndParseResults(projectSubPath), tools.HorusecEngine, projectSubPath)
-	f.LogDebugWithReplace(messages.MsgDebugToolFinishAnalysis, tools.HorusecEngine, languages.CSharp)
-	f.SetToolFinishedAnalysis()
-}
-
-func (f *Formatter) execEngineAndParseResults(projectSubPath string) error {
-	f.LogDebugWithReplace(messages.MsgDebugToolStartAnalysis, tools.HorusecEngine, languages.CSharp)
-
-	findings, err := f.execEngineAnalysis(projectSubPath)
-	if err != nil {
-		return err
-	}
-
-	return f.ParseFindingsToVulnerabilities(findings, tools.HorusecEngine, languages.CSharp)
-}
-
-func (f *Formatter) execEngineAnalysis(projectSubPath string) ([]engine.Finding, error) {
-	textUnit, err := f.GetTextUnitByRulesExt(f.GetProjectPathWithWorkdir(projectSubPath))
-	if err != nil {
-		return nil, err
-	}
-
-	allRules := append(f.GetAllRules(), f.GetCustomRulesByLanguage(languages.CSharp)...)
-	return engine.RunMaxUnitsByAnalysis(textUnit, allRules, engines.DefaultMaxUnitsPerAnalysis), nil
+	return formatters.NewDefaultFormatter(service, csharp.NewRules(), languages.CSharp)
 }

--- a/internal/services/formatters/dart/horusecdart/formatter.go
+++ b/internal/services/formatters/dart/horusecdart/formatter.go
@@ -16,55 +16,10 @@ package hrousecdart
 
 import (
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
-	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
-	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
-	engine "github.com/ZupIT/horusec-engine"
-	"github.com/ZupIT/horusec/internal/enums/engines"
-	"github.com/ZupIT/horusec/internal/helpers/messages"
 	"github.com/ZupIT/horusec/internal/services/engines/dart"
 	"github.com/ZupIT/horusec/internal/services/formatters"
 )
 
-type Formatter struct {
-	formatters.IService
-	dart.Interface
-}
-
 func NewFormatter(service formatters.IService) formatters.IFormatter {
-	return &Formatter{
-		service,
-		dart.NewRules(),
-	}
-}
-
-func (f *Formatter) StartAnalysis(projectSubPath string) {
-	if f.ToolIsToIgnore(tools.HorusecEngine) {
-		logger.LogDebugWithLevel(messages.MsgDebugToolIgnored + tools.HorusecEngine.ToString())
-		return
-	}
-
-	f.SetAnalysisError(f.execEngineAndParseResults(projectSubPath), tools.HorusecEngine, projectSubPath)
-	f.LogDebugWithReplace(messages.MsgDebugToolFinishAnalysis, tools.HorusecEngine, languages.Dart)
-	f.SetToolFinishedAnalysis()
-}
-
-func (f *Formatter) execEngineAndParseResults(projectSubPath string) error {
-	f.LogDebugWithReplace(messages.MsgDebugToolStartAnalysis, tools.HorusecEngine, languages.Dart)
-
-	findings, err := f.execEngineAnalysis(projectSubPath)
-	if err != nil {
-		return err
-	}
-
-	return f.ParseFindingsToVulnerabilities(findings, tools.HorusecEngine, languages.Dart)
-}
-
-func (f *Formatter) execEngineAnalysis(projectSubPath string) ([]engine.Finding, error) {
-	textUnit, err := f.GetTextUnitByRulesExt(f.GetProjectPathWithWorkdir(projectSubPath))
-	if err != nil {
-		return nil, err
-	}
-
-	allRules := append(f.GetAllRules(), f.GetCustomRulesByLanguage(languages.Dart)...)
-	return engine.RunMaxUnitsByAnalysis(textUnit, allRules, engines.DefaultMaxUnitsPerAnalysis), nil
+	return formatters.NewDefaultFormatter(service, dart.NewRules(), languages.Dart)
 }

--- a/internal/services/formatters/default_engine_formatter.go
+++ b/internal/services/formatters/default_engine_formatter.go
@@ -1,0 +1,61 @@
+package formatters
+
+import (
+	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
+	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
+	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
+	engine "github.com/ZupIT/horusec-engine"
+	"github.com/ZupIT/horusec/internal/enums/engines"
+	"github.com/ZupIT/horusec/internal/helpers/messages"
+)
+
+type RuleManager interface {
+	GetAllRules() []engine.Rule
+	GetTextUnitByRulesExt(src string) ([]engine.Unit, error)
+}
+
+// DefaultFormatter is a formatter that can be used with horusec engines implementation
+type DefaultFormatter struct {
+	svc      IService
+	manager  RuleManager
+	language languages.Language
+}
+
+func NewDefaultFormatter(svc IService, manager RuleManager, language languages.Language) IFormatter {
+	return &DefaultFormatter{
+		svc:      svc,
+		manager:  manager,
+		language: language,
+	}
+}
+
+func (f *DefaultFormatter) StartAnalysis(src string) {
+	if f.svc.ToolIsToIgnore(tools.HorusecEngine) {
+		logger.LogDebugWithLevel(messages.MsgDebugToolIgnored + tools.HorusecEngine.ToString())
+		return
+	}
+	f.svc.SetAnalysisError(f.execEngineAndParseResults(src), tools.HorusecEngine, src)
+	f.svc.LogDebugWithReplace(messages.MsgDebugToolFinishAnalysis, tools.HorusecEngine, f.language)
+	f.svc.SetToolFinishedAnalysis()
+}
+
+func (f *DefaultFormatter) execEngineAndParseResults(src string) error {
+	f.svc.LogDebugWithReplace(messages.MsgDebugToolStartAnalysis, tools.HorusecEngine, f.language)
+
+	findings, err := f.execEngineAnalysis(src)
+	if err != nil {
+		return err
+	}
+
+	return f.svc.ParseFindingsToVulnerabilities(findings, tools.HorusecEngine, f.language)
+}
+
+func (f *DefaultFormatter) execEngineAnalysis(src string) ([]engine.Finding, error) {
+	textUnit, err := f.manager.GetTextUnitByRulesExt(f.svc.GetProjectPathWithWorkdir(src))
+	if err != nil {
+		return nil, err
+	}
+
+	allRules := append(f.manager.GetAllRules(), f.svc.GetCustomRulesByLanguage(f.language)...)
+	return engine.RunMaxUnitsByAnalysis(textUnit, allRules, engines.DefaultMaxUnitsPerAnalysis), nil
+}

--- a/internal/services/formatters/java/horusecjava/formatter.go
+++ b/internal/services/formatters/java/horusecjava/formatter.go
@@ -16,55 +16,10 @@ package horusecjava
 
 import (
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
-	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
-	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
-	engine "github.com/ZupIT/horusec-engine"
-	"github.com/ZupIT/horusec/internal/enums/engines"
-	"github.com/ZupIT/horusec/internal/helpers/messages"
 	"github.com/ZupIT/horusec/internal/services/engines/java"
 	"github.com/ZupIT/horusec/internal/services/formatters"
 )
 
-type Formatter struct {
-	formatters.IService
-	java.Interface
-}
-
 func NewFormatter(service formatters.IService) formatters.IFormatter {
-	return &Formatter{
-		service,
-		java.NewRules(),
-	}
-}
-
-func (f *Formatter) StartAnalysis(projectSubPath string) {
-	if f.ToolIsToIgnore(tools.HorusecEngine) {
-		logger.LogDebugWithLevel(messages.MsgDebugToolIgnored + tools.HorusecEngine.ToString())
-		return
-	}
-
-	f.SetAnalysisError(f.execEngineAndParseResults(projectSubPath), tools.HorusecEngine, projectSubPath)
-	f.LogDebugWithReplace(messages.MsgDebugToolFinishAnalysis, tools.HorusecEngine, languages.Java)
-	f.SetToolFinishedAnalysis()
-}
-
-func (f *Formatter) execEngineAndParseResults(projectSubPath string) error {
-	f.LogDebugWithReplace(messages.MsgDebugToolStartAnalysis, tools.HorusecEngine, languages.Java)
-
-	findings, err := f.execEngineAnalysis(projectSubPath)
-	if err != nil {
-		return err
-	}
-
-	return f.ParseFindingsToVulnerabilities(findings, tools.HorusecEngine, languages.Java)
-}
-
-func (f *Formatter) execEngineAnalysis(projectSubPath string) ([]engine.Finding, error) {
-	textUnit, err := f.GetTextUnitByRulesExt(f.GetProjectPathWithWorkdir(projectSubPath))
-	if err != nil {
-		return nil, err
-	}
-
-	allRules := append(f.GetAllRules(), f.GetCustomRulesByLanguage(languages.Java)...)
-	return engine.RunMaxUnitsByAnalysis(textUnit, allRules, engines.DefaultMaxUnitsPerAnalysis), nil
+	return formatters.NewDefaultFormatter(service, java.NewRules(), languages.Java)
 }

--- a/internal/services/formatters/javascript/horusecnodejs/formatter.go
+++ b/internal/services/formatters/javascript/horusecnodejs/formatter.go
@@ -16,55 +16,10 @@ package horusecnodejs
 
 import (
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
-	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
-	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
-	engine "github.com/ZupIT/horusec-engine"
-	"github.com/ZupIT/horusec/internal/enums/engines"
-	"github.com/ZupIT/horusec/internal/helpers/messages"
 	"github.com/ZupIT/horusec/internal/services/engines/nodejs"
 	"github.com/ZupIT/horusec/internal/services/formatters"
 )
 
-type Formatter struct {
-	formatters.IService
-	nodejs.Interface
-}
-
 func NewFormatter(service formatters.IService) formatters.IFormatter {
-	return &Formatter{
-		service,
-		nodejs.NewRules(),
-	}
-}
-
-func (f *Formatter) StartAnalysis(projectSubPath string) {
-	if f.ToolIsToIgnore(tools.HorusecEngine) {
-		logger.LogDebugWithLevel(messages.MsgDebugToolIgnored + tools.HorusecEngine.ToString())
-		return
-	}
-
-	f.SetAnalysisError(f.execEngineAndParseResults(projectSubPath), tools.HorusecEngine, projectSubPath)
-	f.LogDebugWithReplace(messages.MsgDebugToolFinishAnalysis, tools.HorusecEngine, languages.Javascript)
-	f.SetToolFinishedAnalysis()
-}
-
-func (f *Formatter) execEngineAndParseResults(projectSubPath string) error {
-	f.LogDebugWithReplace(messages.MsgDebugToolStartAnalysis, tools.HorusecEngine, languages.Javascript)
-
-	findings, err := f.execEngineAnalysis(projectSubPath)
-	if err != nil {
-		return err
-	}
-
-	return f.ParseFindingsToVulnerabilities(findings, tools.HorusecEngine, languages.Javascript)
-}
-
-func (f *Formatter) execEngineAnalysis(projectSubPath string) ([]engine.Finding, error) {
-	textUnit, err := f.GetTextUnitByRulesExt(f.GetProjectPathWithWorkdir(projectSubPath))
-	if err != nil {
-		return nil, err
-	}
-
-	allRules := append(f.GetAllRules(), f.GetCustomRulesByLanguage(languages.Javascript)...)
-	return engine.RunMaxUnitsByAnalysis(textUnit, allRules, engines.DefaultMaxUnitsPerAnalysis), nil
+	return formatters.NewDefaultFormatter(service, nodejs.NewRules(), languages.Javascript)
 }

--- a/internal/services/formatters/kotlin/horuseckotlin/formatter.go
+++ b/internal/services/formatters/kotlin/horuseckotlin/formatter.go
@@ -16,55 +16,10 @@ package horuseckotlin
 
 import (
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
-	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
-	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
-	engine "github.com/ZupIT/horusec-engine"
-	"github.com/ZupIT/horusec/internal/enums/engines"
-	"github.com/ZupIT/horusec/internal/helpers/messages"
 	"github.com/ZupIT/horusec/internal/services/engines/kotlin"
 	"github.com/ZupIT/horusec/internal/services/formatters"
 )
 
-type Formatter struct {
-	formatters.IService
-	kotlin.Interface
-}
-
 func NewFormatter(service formatters.IService) formatters.IFormatter {
-	return &Formatter{
-		service,
-		kotlin.NewRules(),
-	}
-}
-
-func (f *Formatter) StartAnalysis(projectSubPath string) {
-	if f.ToolIsToIgnore(tools.HorusecEngine) {
-		logger.LogDebugWithLevel(messages.MsgDebugToolIgnored + tools.HorusecEngine.ToString())
-		return
-	}
-
-	f.SetAnalysisError(f.execEngineAndParseResults(projectSubPath), tools.HorusecEngine, projectSubPath)
-	f.LogDebugWithReplace(messages.MsgDebugToolFinishAnalysis, tools.HorusecEngine, languages.Kotlin)
-	f.SetToolFinishedAnalysis()
-}
-
-func (f *Formatter) execEngineAndParseResults(projectSubPath string) error {
-	f.LogDebugWithReplace(messages.MsgDebugToolStartAnalysis, tools.HorusecEngine, languages.Kotlin)
-
-	findings, err := f.execEngineAnalysis(projectSubPath)
-	if err != nil {
-		return err
-	}
-
-	return f.ParseFindingsToVulnerabilities(findings, tools.HorusecEngine, languages.Kotlin)
-}
-
-func (f *Formatter) execEngineAnalysis(projectSubPath string) ([]engine.Finding, error) {
-	textUnit, err := f.GetTextUnitByRulesExt(f.GetProjectPathWithWorkdir(projectSubPath))
-	if err != nil {
-		return nil, err
-	}
-
-	allRules := append(f.GetAllRules(), f.GetCustomRulesByLanguage(languages.Kotlin)...)
-	return engine.RunMaxUnitsByAnalysis(textUnit, allRules, engines.DefaultMaxUnitsPerAnalysis), nil
+	return formatters.NewDefaultFormatter(service, kotlin.NewRules(), languages.Kotlin)
 }

--- a/internal/services/formatters/leaks/horusecleaks/formatter.go
+++ b/internal/services/formatters/leaks/horusecleaks/formatter.go
@@ -16,55 +16,10 @@ package horusecleaks
 
 import (
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
-	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
-	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
-	engine "github.com/ZupIT/horusec-engine"
-	"github.com/ZupIT/horusec/internal/enums/engines"
-	"github.com/ZupIT/horusec/internal/helpers/messages"
 	"github.com/ZupIT/horusec/internal/services/engines/leaks"
 	"github.com/ZupIT/horusec/internal/services/formatters"
 )
 
-type Formatter struct {
-	formatters.IService
-	leaks.Interface
-}
-
 func NewFormatter(service formatters.IService) formatters.IFormatter {
-	return &Formatter{
-		service,
-		leaks.NewRules(),
-	}
-}
-
-func (f *Formatter) StartAnalysis(projectSubPath string) {
-	if f.ToolIsToIgnore(tools.HorusecEngine) {
-		logger.LogDebugWithLevel(messages.MsgDebugToolIgnored + tools.HorusecEngine.ToString())
-		return
-	}
-
-	f.SetAnalysisError(f.execEngineAndParseResults(projectSubPath), tools.HorusecEngine, projectSubPath)
-	f.LogDebugWithReplace(messages.MsgDebugToolFinishAnalysis, tools.HorusecEngine, languages.Leaks)
-	f.SetToolFinishedAnalysis()
-}
-
-func (f *Formatter) execEngineAndParseResults(projectSubPath string) error {
-	f.LogDebugWithReplace(messages.MsgDebugToolStartAnalysis, tools.HorusecEngine, languages.Leaks)
-
-	findings, err := f.execEngineAnalysis(projectSubPath)
-	if err != nil {
-		return err
-	}
-
-	return f.ParseFindingsToVulnerabilities(findings, tools.HorusecEngine, languages.Leaks)
-}
-
-func (f *Formatter) execEngineAnalysis(projectSubPath string) ([]engine.Finding, error) {
-	textUnit, err := f.GetTextUnitByRulesExt(f.GetProjectPathWithWorkdir(projectSubPath))
-	if err != nil {
-		return nil, err
-	}
-
-	allRules := append(f.GetAllRules(), f.GetCustomRulesByLanguage(languages.Leaks)...)
-	return engine.RunMaxUnitsByAnalysis(textUnit, allRules, engines.DefaultMaxUnitsPerAnalysis), nil
+	return formatters.NewDefaultFormatter(service, leaks.NewRules(), languages.Leaks)
 }

--- a/internal/services/formatters/nginx/horusecnginx/formatter.go
+++ b/internal/services/formatters/nginx/horusecnginx/formatter.go
@@ -16,55 +16,10 @@ package horusecnginx
 
 import (
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
-	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
-	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
-	engine "github.com/ZupIT/horusec-engine"
-	"github.com/ZupIT/horusec/internal/enums/engines"
-	"github.com/ZupIT/horusec/internal/helpers/messages"
 	"github.com/ZupIT/horusec/internal/services/engines/nginx"
 	"github.com/ZupIT/horusec/internal/services/formatters"
 )
 
-type Formatter struct {
-	formatters.IService
-	nginx.Interface
-}
-
 func NewFormatter(service formatters.IService) formatters.IFormatter {
-	return &Formatter{
-		service,
-		nginx.NewRules(),
-	}
-}
-
-func (f *Formatter) StartAnalysis(projectSubPath string) {
-	if f.ToolIsToIgnore(tools.HorusecEngine) {
-		logger.LogDebugWithLevel(messages.MsgDebugToolIgnored + tools.HorusecEngine.ToString())
-		return
-	}
-
-	f.SetAnalysisError(f.execEngineAndParseResults(projectSubPath), tools.HorusecEngine, projectSubPath)
-	f.LogDebugWithReplace(messages.MsgDebugToolFinishAnalysis, tools.HorusecEngine, languages.Nginx)
-	f.SetToolFinishedAnalysis()
-}
-
-func (f *Formatter) execEngineAndParseResults(projectSubPath string) error {
-	f.LogDebugWithReplace(messages.MsgDebugToolStartAnalysis, tools.HorusecEngine, languages.Nginx)
-
-	findings, err := f.execEngineAnalysis(projectSubPath)
-	if err != nil {
-		return err
-	}
-
-	return f.ParseFindingsToVulnerabilities(findings, tools.HorusecEngine, languages.Nginx)
-}
-
-func (f *Formatter) execEngineAnalysis(projectSubPath string) ([]engine.Finding, error) {
-	textUnit, err := f.GetTextUnitByRulesExt(f.GetProjectPathWithWorkdir(projectSubPath))
-	if err != nil {
-		return nil, err
-	}
-
-	allRules := append(f.GetAllRules(), f.GetCustomRulesByLanguage(languages.Nginx)...)
-	return engine.RunMaxUnitsByAnalysis(textUnit, allRules, engines.DefaultMaxUnitsPerAnalysis), nil
+	return formatters.NewDefaultFormatter(service, nginx.NewRules(), languages.Nginx)
 }

--- a/internal/services/formatters/yaml/horuseckubernetes/formatter.go
+++ b/internal/services/formatters/yaml/horuseckubernetes/formatter.go
@@ -16,55 +16,10 @@ package horuseckubernetes
 
 import (
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
-	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
-	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
-	engine "github.com/ZupIT/horusec-engine"
-	"github.com/ZupIT/horusec/internal/enums/engines"
-	"github.com/ZupIT/horusec/internal/helpers/messages"
 	"github.com/ZupIT/horusec/internal/services/engines/kubernetes"
 	"github.com/ZupIT/horusec/internal/services/formatters"
 )
 
-type Formatter struct {
-	formatters.IService
-	kubernetes.Interface
-}
-
 func NewFormatter(service formatters.IService) formatters.IFormatter {
-	return &Formatter{
-		service,
-		kubernetes.NewRules(),
-	}
-}
-
-func (f *Formatter) StartAnalysis(projectSubPath string) {
-	if f.ToolIsToIgnore(tools.HorusecEngine) {
-		logger.LogDebugWithLevel(messages.MsgDebugToolIgnored + tools.HorusecEngine.ToString())
-		return
-	}
-
-	f.SetAnalysisError(f.execEngineAndParseResults(projectSubPath), tools.HorusecEngine, projectSubPath)
-	f.LogDebugWithReplace(messages.MsgDebugToolFinishAnalysis, tools.HorusecEngine, languages.Yaml)
-	f.SetToolFinishedAnalysis()
-}
-
-func (f *Formatter) execEngineAndParseResults(projectSubPath string) error {
-	f.LogDebugWithReplace(messages.MsgDebugToolStartAnalysis, tools.HorusecEngine, languages.Yaml)
-
-	findings, err := f.execEngineAnalysis(projectSubPath)
-	if err != nil {
-		return err
-	}
-
-	return f.ParseFindingsToVulnerabilities(findings, tools.HorusecEngine, languages.Yaml)
-}
-
-func (f *Formatter) execEngineAnalysis(projectSubPath string) ([]engine.Finding, error) {
-	textUnit, err := f.GetTextUnitByRulesExt(f.GetProjectPathWithWorkdir(projectSubPath))
-	if err != nil {
-		return nil, err
-	}
-
-	allRules := append(f.GetAllRules(), f.GetCustomRulesByLanguage(languages.Yaml)...)
-	return engine.RunMaxUnitsByAnalysis(textUnit, allRules, engines.DefaultMaxUnitsPerAnalysis), nil
+	return formatters.NewDefaultFormatter(service, kubernetes.NewRules(), languages.Yaml)
 }


### PR DESCRIPTION
Create a default formatter to be used on implementations of Horusec
engines. Previously each engine implement your own version of Formatter
with very common steps. This commit introduce a new formatter that can be
reused between all the engines just passing the rules and languages of
each engine.

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
