### PR TITLE
create default rule manager

### DIFF
--- a/internal/services/engines/csharp/rules.go
+++ b/internal/services/engines/csharp/rules.go
@@ -16,55 +16,64 @@ package csharp
 
 import (
 	engine "github.com/ZupIT/horusec-engine"
-	"github.com/ZupIT/horusec-engine/text"
+	"github.com/ZupIT/horusec/internal/services/engines"
 	"github.com/ZupIT/horusec/internal/services/engines/csharp/and"
 	"github.com/ZupIT/horusec/internal/services/engines/csharp/or"
 	"github.com/ZupIT/horusec/internal/services/engines/csharp/regular"
 )
 
-type Rules struct{}
-
-func NewRules() *Rules {
-	return &Rules{}
+func NewRules() *engines.RuleManager {
+	return engines.NewRuleManager(rules(), extensions())
 }
 
-func (r *Rules) GetAllRules() (rules []engine.Rule) {
-	for _, rule := range allRulesCsharpAnd() {
-		rules = append(rules, rule)
-	}
-
-	for _, rule := range allRulesCsharpOr() {
-		rules = append(rules, rule)
-	}
-
-	for _, rule := range allRulesCsharpRegular() {
-		rules = append(rules, rule)
-	}
-
-	return rules
-}
-
-func (r *Rules) GetTextUnitByRulesExt(projectPath string) ([]engine.Unit, error) {
-	textUnits, err := text.LoadDirIntoMultiUnit(projectPath, 5, r.getExtensions())
-	if err != nil {
-		return []engine.Unit{}, err
-	}
-	return r.parseTextUnitsToUnits(textUnits), nil
-}
-
-func (r *Rules) parseTextUnitsToUnits(textUnits []text.TextUnit) (units []engine.Unit) {
-	for index := range textUnits {
-		units = append(units, textUnits[index])
-	}
-	return units
-}
-
-func (r *Rules) getExtensions() []string {
+func extensions() []string {
 	return []string{".cs", ".vb", ".cshtml", ".csproj", ".xml"}
 }
 
-func allRulesCsharpRegular() []text.TextRule {
-	return []text.TextRule{
+func rules() []engine.Rule {
+	return []engine.Rule{
+		// And rules
+		and.NewCsharpAndCommandInjection(),
+		and.NewCsharpAndXPathInjection(),
+		and.NewCsharpAndExternalEntityInjection(),
+		and.NewCsharpAndPathTraversal(),
+		and.NewCsharpAndSQLInjectionWebControls(),
+		and.NewCsharpAndFormsAuthenticationCookielessMode(),
+		and.NewCsharpAndFormsAuthenticationWeakCookieProtection(),
+		and.NewCsharpAndFormsAuthenticationCrossAppRedirects(),
+		and.NewCsharpAndWeakCipherOrCBCOrECBMode(),
+		and.NewCsharpAndFormsAuthenticationWeakTimeout(),
+		and.NewCsharpAndHeaderCheckingDisabled(),
+		and.NewCsharpAndVersionHeaderEnabled(),
+		and.NewCsharpAndEventValidationDisabled(),
+		and.NewCsharpAndWeakSessionTimeout(),
+		and.NewCsharpAndStateServerMode(),
+		and.NewCsharpAndJwtSignatureValidationDisabled(),
+		and.NewCsharpAndInsecureHttpCookieTransport(),
+		and.NewCsharpAndHttpCookieAccessibleViaScript(),
+		and.NewCsharpAndDirectoryListingEnabled(),
+		and.NewCsharpAndLdapAuthenticationDisabled(),
+		and.NewCsharpAndCertificateValidationDisabled(),
+		and.NewCsharpAndActionRequestValidationDisabled(),
+		and.NewCsharpAndXmlDocumentExternalEntityExpansion(),
+		and.NewCsharpAndLdapInjectionFilterAssignment(),
+		and.NewCsharpAndSqlInjectionDynamicNHibernateQuery(),
+		and.NewCsharpAndLdapInjectionDirectorySearcher(),
+		and.NewCsharpAndLdapInjectionPathAssignment(),
+
+		// Or rules
+		or.NewCsharpOrLDAPInjection(),
+		or.NewCsharpOrSQLInjectionLinq(),
+		or.NewCsharpOrInsecureDeserialization(),
+		or.NewCsharpOrCookieWithoutSSLFlag(),
+		or.NewCsharpOrCookieWithoutHttpOnlyFlag(),
+		or.NewCsharpOrSQLInjectionEnterpriseLibraryData(),
+		or.NewCsharpOrCQLInjectionCassandra(),
+		or.NewCsharpOrPasswordComplexity(),
+		or.NewCsharpOrNoInputVariable(),
+		or.NewCsharpOrIdentityWeakPasswordComplexity(),
+
+		// Regular rules
 		regular.NewCsharpRegularNoLogSensitiveInformationInConsole(),
 		regular.NewCsharpRegularOutputCacheConflict(),
 		regular.NewCsharpRegularOpenRedirect(),
@@ -102,52 +111,5 @@ func allRulesCsharpRegular() []text.TextRule {
 		regular.NewCsharpRegularWeakRsaKeyLength(),
 		regular.NewCsharpRegularXmlReaderExternalEntityExpansion(),
 		regular.NewCsharpRegularLdapInjectionDirectoryEntry(),
-	}
-}
-
-func allRulesCsharpAnd() []text.TextRule {
-	return []text.TextRule{
-		and.NewCsharpAndCommandInjection(),
-		and.NewCsharpAndXPathInjection(),
-		and.NewCsharpAndExternalEntityInjection(),
-		and.NewCsharpAndPathTraversal(),
-		and.NewCsharpAndSQLInjectionWebControls(),
-		and.NewCsharpAndFormsAuthenticationCookielessMode(),
-		and.NewCsharpAndFormsAuthenticationWeakCookieProtection(),
-		and.NewCsharpAndFormsAuthenticationCrossAppRedirects(),
-		and.NewCsharpAndWeakCipherOrCBCOrECBMode(),
-		and.NewCsharpAndFormsAuthenticationWeakTimeout(),
-		and.NewCsharpAndHeaderCheckingDisabled(),
-		and.NewCsharpAndVersionHeaderEnabled(),
-		and.NewCsharpAndEventValidationDisabled(),
-		and.NewCsharpAndWeakSessionTimeout(),
-		and.NewCsharpAndStateServerMode(),
-		and.NewCsharpAndJwtSignatureValidationDisabled(),
-		and.NewCsharpAndInsecureHttpCookieTransport(),
-		and.NewCsharpAndHttpCookieAccessibleViaScript(),
-		and.NewCsharpAndDirectoryListingEnabled(),
-		and.NewCsharpAndLdapAuthenticationDisabled(),
-		and.NewCsharpAndCertificateValidationDisabled(),
-		and.NewCsharpAndActionRequestValidationDisabled(),
-		and.NewCsharpAndXmlDocumentExternalEntityExpansion(),
-		and.NewCsharpAndLdapInjectionFilterAssignment(),
-		and.NewCsharpAndSqlInjectionDynamicNHibernateQuery(),
-		and.NewCsharpAndLdapInjectionDirectorySearcher(),
-		and.NewCsharpAndLdapInjectionPathAssignment(),
-	}
-}
-
-func allRulesCsharpOr() []text.TextRule {
-	return []text.TextRule{
-		or.NewCsharpOrLDAPInjection(),
-		or.NewCsharpOrSQLInjectionLinq(),
-		or.NewCsharpOrInsecureDeserialization(),
-		or.NewCsharpOrCookieWithoutSSLFlag(),
-		or.NewCsharpOrCookieWithoutHttpOnlyFlag(),
-		or.NewCsharpOrSQLInjectionEnterpriseLibraryData(),
-		or.NewCsharpOrCQLInjectionCassandra(),
-		or.NewCsharpOrPasswordComplexity(),
-		or.NewCsharpOrNoInputVariable(),
-		or.NewCsharpOrIdentityWeakPasswordComplexity(),
 	}
 }

--- a/internal/services/engines/csharp/rules_test.go
+++ b/internal/services/engines/csharp/rules_test.go
@@ -19,12 +19,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ZupIT/horusec-engine/text"
+	"github.com/ZupIT/horusec/internal/services/engines"
 )
 
 func TestNewRules(t *testing.T) {
-	assert.IsType(t, NewRules(), &Rules{})
+	assert.IsType(t, NewRules(), &engines.RuleManager{})
 }
 
 func TestRules_GetAllRules(t *testing.T) {
@@ -43,23 +45,24 @@ func TestRules_GetAllRules(t *testing.T) {
 }
 
 func TestRulesEnum(t *testing.T) {
-	var totalRules []text.TextRule
-
-	totalRules = append(totalRules, allRulesCsharpOr()...)
-	totalRules = append(totalRules, allRulesCsharpAnd()...)
-	totalRules = append(totalRules, allRulesCsharpRegular()...)
+	totalRules := rules()
 	lenExpectedTotalRules := 74
 
 	t.Run("Should not exists duplicated ID in rules and return lenExpectedTotalRules in csharp", func(t *testing.T) {
 		encountered := map[string]bool{}
 
-		for v := range totalRules {
-			if encountered[totalRules[v].ID] == true {
-				msg := fmt.Sprintf("This rules in Csharp is duplicated ID(%s) => Name: %s, Description: %s, Type: %v", totalRules[v].ID, totalRules[v].Name, totalRules[v].Description, totalRules[v].Type)
-				assert.False(t, encountered[totalRules[v].ID], msg)
+		for _, rule := range totalRules {
+			r, ok := rule.(text.TextRule)
+			require.True(t, ok, "Expected TextRule type, got %T", rule)
+
+			if encountered[r.ID] == true {
+				msg := fmt.Sprintf(
+					"This rules in Csharp is duplicated ID(%s) => Name: %s, Description: %s, Type: %v", r.ID, r.Name, r.Description, r.Type,
+				)
+				assert.False(t, encountered[r.ID], msg)
 			} else {
 				// Record this element as an encountered element.
-				encountered[totalRules[v].ID] = true
+				encountered[r.ID] = true
 			}
 		}
 

--- a/internal/services/engines/dart/rules.go
+++ b/internal/services/engines/dart/rules.go
@@ -16,36 +16,29 @@ package dart
 
 import (
 	engine "github.com/ZupIT/horusec-engine"
-	"github.com/ZupIT/horusec-engine/text"
+	"github.com/ZupIT/horusec/internal/services/engines"
 	"github.com/ZupIT/horusec/internal/services/engines/dart/and"
 	"github.com/ZupIT/horusec/internal/services/engines/dart/or"
 	"github.com/ZupIT/horusec/internal/services/engines/dart/regular"
 )
 
-type Rules struct{}
-
-func NewRules() *Rules {
-	return &Rules{}
+func NewRules() *engines.RuleManager {
+	return engines.NewRuleManager(rules(), extensions())
 }
 
-func (r *Rules) GetAllRules() (rules []engine.Rule) {
-	for _, rule := range allRulesDartAnd() {
-		rules = append(rules, rule)
-	}
+func rules() []engine.Rule {
+	return []engine.Rule{
+		// And Rules
+		and.NewDartAndUsageLocalDataWithoutCryptography(),
+		and.NewDartAndNoSendSensitiveInformation(),
+		and.NewDartAndNoUseBiometricsTypeIOS(),
+		and.NewDartAndXmlReaderExternalEntityExpansion(),
 
-	for _, rule := range allRulesDartOr() {
-		rules = append(rules, rule)
-	}
+		// Or rules
+		or.NewDartOrNoUseConnectionWithoutSSL(),
+		or.NewDartOrSendSMS(),
 
-	for _, rule := range allRulesDartRegular() {
-		rules = append(rules, rule)
-	}
-
-	return rules
-}
-
-func allRulesDartRegular() []text.TextRule {
-	return []text.TextRule{
+		// Regular rules
 		regular.NewDartRegularXSSAttack(),
 		regular.NewDartRegularNoLogSensitive(),
 		regular.NewDartRegularWeakHashingFunctionMd5OrSha1(),
@@ -60,37 +53,6 @@ func allRulesDartRegular() []text.TextRule {
 	}
 }
 
-func allRulesDartAnd() []text.TextRule {
-	return []text.TextRule{
-		and.NewDartAndUsageLocalDataWithoutCryptography(),
-		and.NewDartAndNoSendSensitiveInformation(),
-		and.NewDartAndNoUseBiometricsTypeIOS(),
-		and.NewDartAndXmlReaderExternalEntityExpansion(),
-	}
-}
-
-func allRulesDartOr() []text.TextRule {
-	return []text.TextRule{
-		or.NewDartOrNoUseConnectionWithoutSSL(),
-		or.NewDartOrSendSMS(),
-	}
-}
-
-func (r *Rules) GetTextUnitByRulesExt(projectPath string) ([]engine.Unit, error) {
-	textUnits, err := text.LoadDirIntoMultiUnit(projectPath, 5, r.getExtensions())
-	if err != nil {
-		return []engine.Unit{}, err
-	}
-	return r.parseTextUnitsToUnits(textUnits), nil
-}
-
-func (r *Rules) parseTextUnitsToUnits(textUnits []text.TextUnit) (units []engine.Unit) {
-	for index := range textUnits {
-		units = append(units, textUnits[index])
-	}
-	return units
-}
-
-func (r *Rules) getExtensions() []string {
+func extensions() []string {
 	return []string{".dart"}
 }

--- a/internal/services/engines/dart/rules_test.go
+++ b/internal/services/engines/dart/rules_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ZupIT/horusec-engine/text"
 )
@@ -38,23 +39,25 @@ func TestRules_GetAllRules(t *testing.T) {
 	})
 }
 func TestRulesEnum(t *testing.T) {
-	var totalRules []text.TextRule
+	totalRules := rules()
 
-	totalRules = append(totalRules, allRulesDartAnd()...)
-	totalRules = append(totalRules, allRulesDartOr()...)
-	totalRules = append(totalRules, allRulesDartRegular()...)
 	lenExpectedTotalRules := 17
 
 	t.Run("Should not exists duplicated ID in rules and return lenExpectedTotalRules in dart", func(t *testing.T) {
 		encountered := map[string]bool{}
 
-		for v := range totalRules {
-			if encountered[totalRules[v].ID] == true {
-				msg := fmt.Sprintf("This rules in dart is duplicated ID(%s) => Name: %s, Description: %s, Type: %v", totalRules[v].ID, totalRules[v].Name, totalRules[v].Description, totalRules[v].Type)
-				assert.False(t, encountered[totalRules[v].ID], msg)
+		for _, rule := range totalRules {
+			r, ok := rule.(text.TextRule)
+			require.True(t, ok, "Expected TextRule type, got %T", rule)
+
+			if encountered[r.ID] == true {
+				msg := fmt.Sprintf(
+					"This rules in dart is duplicated ID(%s) => Name: %s, Description: %s, Type: %v", r.ID, r.Name, r.Description, r.Type,
+				)
+				assert.False(t, encountered[r.ID], msg)
 			} else {
 				// Record this element as an encountered element.
-				encountered[totalRules[v].ID] = true
+				encountered[r.ID] = true
 			}
 		}
 		assert.Equal(t, len(totalRules), lenExpectedTotalRules, "totalRules in dart is not equal the expected")

--- a/internal/services/engines/java/rules.go
+++ b/internal/services/engines/java/rules.go
@@ -16,112 +16,24 @@ package java
 
 import (
 	engine "github.com/ZupIT/horusec-engine"
-	"github.com/ZupIT/horusec-engine/text"
+	"github.com/ZupIT/horusec/internal/services/engines"
 	"github.com/ZupIT/horusec/internal/services/engines/java/and"
 	"github.com/ZupIT/horusec/internal/services/engines/java/or"
 	"github.com/ZupIT/horusec/internal/services/engines/java/regular"
 	"github.com/ZupIT/horusec/internal/services/engines/jvm"
 )
 
-type Rules struct {
-	jvmRules *jvm.Rules
+func NewRules() *engines.RuleManager {
+	return engines.NewRuleManager(rules(), extensions())
 }
 
-func NewRules() *Rules {
-	return &Rules{
-		jvmRules: jvm.NewRules(),
-	}
-}
-
-func (r *Rules) GetAllRules() (rules []engine.Rule) {
-	rules = r.addJavaRules(rules)
-	rules = r.jvmRules.GetAllRules(rules)
-	return rules
-}
-
-func (r *Rules) addJavaRules(rules []engine.Rule) []engine.Rule {
-	for _, rule := range allRulesJavaAnd() {
-		rules = append(rules, rule)
-	}
-
-	for _, rule := range allRulesJavaOr() {
-		rules = append(rules, rule)
-	}
-
-	for _, rule := range allRulesJavaRegular() {
-		rules = append(rules, rule)
-	}
-
-	return rules
-}
-
-func (r *Rules) GetTextUnitByRulesExt(projectPath string) ([]engine.Unit, error) {
-	textUnits, err := text.LoadDirIntoMultiUnit(projectPath, 5, r.getExtensions())
-	if err != nil {
-		return []engine.Unit{}, err
-	}
-	return r.parseTextUnitsToUnits(textUnits), nil
-}
-
-func (r *Rules) parseTextUnitsToUnits(textUnits []text.TextUnit) (units []engine.Unit) {
-	for index := range textUnits {
-		units = append(units, textUnits[index])
-	}
-	return units
-}
-
-func (r *Rules) getExtensions() []string {
+func extensions() []string {
 	return []string{".java"}
 }
 
-func allRulesJavaRegular() []text.TextRule {
-	return []text.TextRule{
-		regular.NewJavaRegularHiddenElements(),
-		regular.NewJavaRegularWeakCypherBlockMode(),
-		regular.NewJavaRegularPossibleFileWithVulnerabilityWhenOpen(),
-		regular.NewJavaRegularWeakHash(),
-		regular.NewJavaRegularSensitiveInformationNotEncrypted(),
-		regular.NewJavaRegularInsecureRandomNumberGenerator(),
-		regular.NewJavaRegularNoDefaultJavaHash(),
-		regular.NewJavaRegularLayoutParamsFlagSecure(),
-		regular.NewJavaRegularNoUseSQLCipher(),
-		regular.NewJavaRegularPreventTapJackingAttacks(),
-		regular.NewJavaRegularPreventWriteSensitiveInformationInTmpFile(),
-		regular.NewJavaRegularGetWindowFlagSecure(),
-		regular.NewJavaRegularLoadingNativeCode(),
-		regular.NewJavaRegularDynamicClassAndDexloading(),
-		regular.NewJavaRegularCryptoImport(),
-		regular.NewJavaRegularStartingService(),
-		regular.NewJavaRegularSendingBroadcast(),
-		regular.NewJavaRegularLocalFileOperations(),
-		regular.NewJavaRegularInterProcessCommunication(),
-		regular.NewJavaRegularURLRewritingMethod(),
-		regular.NewJavaRegularOverlyPermissiveCORSPolicy(),
-		regular.NewJavaRegularHostnameVerifierThatAcceptAnySignedCertificates(),
-		regular.NewJavaRegularDefaultHttpClient(),
-		regular.NewJavaRegularWeakSSLContext(),
-		regular.NewJavaRegularSQLInjection(),
-		regular.NewJavaRegularDisablingHTMLEscaping(),
-		regular.NewJavaRegularSQLInjectionWithTurbine(),
-		regular.NewJavaRegularSQLInjectionWithHibernate(),
-		regular.NewJavaRegularSQLInjectionWithJDO(),
-		regular.NewJavaRegularSQLInjectionWithJPA(),
-		regular.NewJavaRegularSQLInjectionWithSpringJDBC(),
-		regular.NewJavaRegularSQLInjectionWithJDBC(),
-		regular.NewJavaRegularLDAPInjection(),
-		regular.NewJavaRegularUnsafeHashEquals(),
-		regular.NewJavaRegularPotentialExternalControl(),
-		regular.NewJavaRegularBadHexadecimalConcatenation(),
-		regular.NewJavaRegularNullCipherInsecure(),
-		regular.NewJavaRegularUnvalidatedRedirect(),
-		regular.NewJavaRegularRequestMappingMethodsNotPublic(),
-		regular.NewJavaRegularLDAPDeserializationNotDisabled(),
-		regular.NewJavaRegularDatabasesPasswordNotProtected(),
-	}
-}
-
-func allRulesJavaAnd() []text.TextRule {
-	return []text.TextRule{
+func rules() []engine.Rule {
+	java := []engine.Rule{
+		// And rules
 		and.NewJavaAndMessageDigestIsCustom(),
 		and.NewJavaAndInsecureImplementationOfSSL(),
 		and.NewJavaAndWebViewLoadFilesFromExternalStorage(),
@@ -216,11 +128,8 @@ func allRulesJavaAnd() []text.TextRule {
 		and.NewJavaAndOpenSAML2ShouldBeConfiguredToPreventAuthenticationBypass(),
 		and.NewJavaAndHttpServletRequestGetRequestedSessionIdShouldNotBeUsed(),
 		and.NewJavaAndWebApplicationsShouldHotHaveAMainMethod(),
-	}
-}
 
-func allRulesJavaOr() []text.TextRule {
-	return []text.TextRule{
+		// Or Rules
 		or.NewJavaOrFileIsWorldReadable(),
 		or.NewJavaOrFileIsWorldWritable(),
 		or.NewJavaOrNoWriteExternalContent(),
@@ -231,5 +140,49 @@ func allRulesJavaOr() []text.TextRule {
 		or.NewJavaOrMessageDigest(),
 		or.NewJavaOrOverlyPermissiveFilePermission(),
 		or.NewJavaOrCipherGetInstanceInsecure(),
+
+		// Regular rules
+		regular.NewJavaRegularHiddenElements(),
+		regular.NewJavaRegularWeakCypherBlockMode(),
+		regular.NewJavaRegularPossibleFileWithVulnerabilityWhenOpen(),
+		regular.NewJavaRegularWeakHash(),
+		regular.NewJavaRegularSensitiveInformationNotEncrypted(),
+		regular.NewJavaRegularInsecureRandomNumberGenerator(),
+		regular.NewJavaRegularNoDefaultJavaHash(),
+		regular.NewJavaRegularLayoutParamsFlagSecure(),
+		regular.NewJavaRegularNoUseSQLCipher(),
+		regular.NewJavaRegularPreventTapJackingAttacks(),
+		regular.NewJavaRegularPreventWriteSensitiveInformationInTmpFile(),
+		regular.NewJavaRegularGetWindowFlagSecure(),
+		regular.NewJavaRegularLoadingNativeCode(),
+		regular.NewJavaRegularDynamicClassAndDexloading(),
+		regular.NewJavaRegularCryptoImport(),
+		regular.NewJavaRegularStartingService(),
+		regular.NewJavaRegularSendingBroadcast(),
+		regular.NewJavaRegularLocalFileOperations(),
+		regular.NewJavaRegularInterProcessCommunication(),
+		regular.NewJavaRegularURLRewritingMethod(),
+		regular.NewJavaRegularOverlyPermissiveCORSPolicy(),
+		regular.NewJavaRegularHostnameVerifierThatAcceptAnySignedCertificates(),
+		regular.NewJavaRegularDefaultHttpClient(),
+		regular.NewJavaRegularWeakSSLContext(),
+		regular.NewJavaRegularSQLInjection(),
+		regular.NewJavaRegularDisablingHTMLEscaping(),
+		regular.NewJavaRegularSQLInjectionWithTurbine(),
+		regular.NewJavaRegularSQLInjectionWithHibernate(),
+		regular.NewJavaRegularSQLInjectionWithJDO(),
+		regular.NewJavaRegularSQLInjectionWithJPA(),
+		regular.NewJavaRegularSQLInjectionWithSpringJDBC(),
+		regular.NewJavaRegularSQLInjectionWithJDBC(),
+		regular.NewJavaRegularLDAPInjection(),
+		regular.NewJavaRegularUnsafeHashEquals(),
+		regular.NewJavaRegularPotentialExternalControl(),
+		regular.NewJavaRegularBadHexadecimalConcatenation(),
+		regular.NewJavaRegularNullCipherInsecure(),
+		regular.NewJavaRegularUnvalidatedRedirect(),
+		regular.NewJavaRegularRequestMappingMethodsNotPublic(),
+		regular.NewJavaRegularLDAPDeserializationNotDisabled(),
+		regular.NewJavaRegularDatabasesPasswordNotProtected(),
 	}
+	return append(java, jvm.Rules()...)
 }

--- a/internal/services/engines/java/rules_test.go
+++ b/internal/services/engines/java/rules_test.go
@@ -19,12 +19,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ZupIT/horusec-engine/text"
+	"github.com/ZupIT/horusec/internal/services/engines"
 )
 
 func TestNewRules(t *testing.T) {
-	assert.IsType(t, NewRules(), &Rules{})
+	assert.IsType(t, NewRules(), &engines.RuleManager{})
 }
 
 func TestRules_GetAllRules(t *testing.T) {
@@ -43,23 +45,24 @@ func TestRules_GetAllRules(t *testing.T) {
 }
 
 func TestRulesEnum(t *testing.T) {
-	var totalRules []text.TextRule
-
-	totalRules = append(totalRules, allRulesJavaRegular()...)
-	totalRules = append(totalRules, allRulesJavaAnd()...)
-	totalRules = append(totalRules, allRulesJavaOr()...)
-	lenExpectedTotalRules := 145
+	totalRules := rules()
+	lenExpectedTotalRules := 185
 
 	t.Run("Should not exists duplicated ID in rules and return lenExpectedTotalRules in java", func(t *testing.T) {
 		encountered := map[string]bool{}
 
-		for v := range totalRules {
-			if encountered[totalRules[v].ID] == true {
-				msg := fmt.Sprintf("This rules in Java is duplicated ID(%s) => Name: %s, Description: %s, Type: %v", totalRules[v].ID, totalRules[v].Name, totalRules[v].Description, totalRules[v].Type)
-				assert.False(t, encountered[totalRules[v].ID], msg)
+		for _, rule := range totalRules {
+			r, ok := rule.(text.TextRule)
+			require.True(t, ok, "Expected TextRule type, got %T", rule)
+
+			if encountered[r.ID] == true {
+				msg := fmt.Sprintf(
+					"This rules in Java is duplicated ID(%s) => Name: %s, Description: %s, Type: %v", r.ID, r.Name, r.Description, r.Type,
+				)
+				assert.False(t, encountered[r.ID], msg)
 			} else {
 				// Record this element as an encountered element.
-				encountered[totalRules[v].ID] = true
+				encountered[r.ID] = true
 			}
 		}
 

--- a/internal/services/engines/jvm/rules.go
+++ b/internal/services/engines/jvm/rules.go
@@ -16,36 +16,14 @@ package jvm
 
 import (
 	engine "github.com/ZupIT/horusec-engine"
-	"github.com/ZupIT/horusec-engine/text"
 	"github.com/ZupIT/horusec/internal/services/engines/jvm/and"
 	"github.com/ZupIT/horusec/internal/services/engines/jvm/or"
 	"github.com/ZupIT/horusec/internal/services/engines/jvm/regular"
 )
 
-type Rules struct{}
-
-func NewRules() *Rules {
-	return &Rules{}
-}
-
-func (r *Rules) GetAllRules(rules []engine.Rule) []engine.Rule {
-	for _, rule := range allRulesJvmAnd() {
-		rules = append(rules, rule)
-	}
-
-	for _, rule := range allRulesJvmOr() {
-		rules = append(rules, rule)
-	}
-
-	for _, rule := range allRulesJvmRegular() {
-		rules = append(rules, rule)
-	}
-
-	return rules
-}
-
-func allRulesJvmRegular() []text.TextRule {
-	return []text.TextRule{
+func Rules() []engine.Rule {
+	return []engine.Rule{
+		// Regular rules
 		regular.NewJvmRegularHTTPRequestsConnectionsAndSessions(),
 		regular.NewJvmRegularNoUsesSafetyNetAPI(),
 		regular.NewJvmRegularNoUsesContentProvider(),
@@ -62,11 +40,8 @@ func allRulesJvmRegular() []text.TextRule {
 		regular.NewJvmRegularNoUseNSTemporaryDirectory(),
 		regular.NewJvmRegularNoCopiesDataToTheClipboard(),
 		regular.NewJvmRegularNoLogSensitiveInformation(),
-	}
-}
 
-func allRulesJvmAnd() []text.TextRule {
-	return []text.TextRule{
+		// And rules
 		and.NewJvmAndNoDownloadFileUsingAndroidDownloadManager(),
 		and.NewJvmAndSQLInjectionWithSQLite(),
 		and.NewJvmAndAndroidKeystore(),
@@ -86,11 +61,8 @@ func allRulesJvmAnd() []text.TextRule {
 		and.NewJvmAndWeakSha1HashUsing(),
 		and.NewJvmAndWeakECBEncryptionAlgorithmUsing(),
 		and.NewJvmAndUsingPtrace(),
-	}
-}
 
-func allRulesJvmOr() []text.TextRule {
-	return []text.TextRule{
+		// Or rules
 		or.NewJvmOrSuperUserPrivileges(),
 		or.NewJvmOrSendSMS(),
 		or.NewJvmOrBase64Encode(),

--- a/internal/services/engines/jvm/rules_test.go
+++ b/internal/services/engines/jvm/rules_test.go
@@ -19,13 +19,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ZupIT/horusec-engine/text"
 )
 
 func TestRules_GetAllRules(t *testing.T) {
 	t.Run("should return all rules enable", func(t *testing.T) {
-		rules := NewRules().GetAllRules(nil)
+		rules := Rules()
 		totalRegexes := 0
 
 		for i := range rules {
@@ -38,23 +39,24 @@ func TestRules_GetAllRules(t *testing.T) {
 	})
 }
 func TestRulesEnum(t *testing.T) {
-	var totalRules []text.TextRule
-
-	totalRules = append(totalRules, allRulesJvmAnd()...)
-	totalRules = append(totalRules, allRulesJvmOr()...)
-	totalRules = append(totalRules, allRulesJvmRegular()...)
+	totalRules := Rules()
 	lenExpectedTotalRules := 40
 
 	t.Run("Should not exists duplicated ID in rules and return lenExpectedTotalRules in jvm", func(t *testing.T) {
 		encountered := map[string]bool{}
 
-		for v := range totalRules {
-			if encountered[totalRules[v].ID] == true {
-				msg := fmt.Sprintf("This rules in Jvm is duplicated ID(%s) => Name: %s, Description: %s, Type: %v", totalRules[v].ID, totalRules[v].Name, totalRules[v].Description, totalRules[v].Type)
-				assert.False(t, encountered[totalRules[v].ID], msg)
+		for _, rule := range totalRules {
+			r, ok := rule.(text.TextRule)
+			require.True(t, ok, "Expected TextRule type, got %T", rule)
+
+			if encountered[r.ID] == true {
+				msg := fmt.Sprintf(
+					"This rules in Jvm is duplicated ID(%s) => Name: %s, Description: %s, Type: %v", r.ID, r.Name, r.Description, r.Type,
+				)
+				assert.False(t, encountered[r.ID], msg)
 			} else {
 				// Record this element as an encountered element.
-				encountered[totalRules[v].ID] = true
+				encountered[r.ID] = true
 			}
 		}
 		assert.Equal(t, len(totalRules), lenExpectedTotalRules, "totalRules in jvm is not equal the expected")

--- a/internal/services/engines/kotlin/rules.go
+++ b/internal/services/engines/kotlin/rules.go
@@ -16,52 +16,18 @@ package kotlin
 
 import (
 	engine "github.com/ZupIT/horusec-engine"
-	"github.com/ZupIT/horusec-engine/text"
+	"github.com/ZupIT/horusec/internal/services/engines"
 	"github.com/ZupIT/horusec/internal/services/engines/jvm"
 )
 
-type Rules struct {
-	jvmRules *jvm.Rules
+func NewRules() *engines.RuleManager {
+	return engines.NewRuleManager(rules(), extensions())
 }
 
-func NewRules() *Rules {
-	return &Rules{
-		jvmRules: jvm.NewRules(),
-	}
-}
-
-func (r *Rules) GetAllRules() (rules []engine.Rule) {
-	rules = r.jvmRules.GetAllRules(rules)
-	return rules
-}
-
-func (r *Rules) GetTextUnitByRulesExt(projectPath string) ([]engine.Unit, error) {
-	textUnits, err := text.LoadDirIntoMultiUnit(projectPath, 5, r.getExtensions())
-	if err != nil {
-		return []engine.Unit{}, err
-	}
-	return r.parseTextUnitsToUnits(textUnits), nil
-}
-
-func (r *Rules) parseTextUnitsToUnits(textUnits []text.TextUnit) (units []engine.Unit) {
-	for index := range textUnits {
-		units = append(units, textUnits[index])
-	}
-	return units
-}
-
-func (r *Rules) getExtensions() []string {
+func extensions() []string {
 	return []string{".kt", ".kts"}
 }
 
-func allRulesKotlinRegular() []text.TextRule {
-	return []text.TextRule{}
-}
-
-func allRulesKotlinAnd() []text.TextRule {
-	return []text.TextRule{}
-}
-
-func allRulesKotlinOr() []text.TextRule {
-	return []text.TextRule{}
+func rules() []engine.Rule {
+	return jvm.Rules()
 }

--- a/internal/services/engines/kotlin/rules_test.go
+++ b/internal/services/engines/kotlin/rules_test.go
@@ -19,12 +19,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ZupIT/horusec-engine/text"
+	"github.com/ZupIT/horusec/internal/services/engines"
 )
 
 func TestNewRules(t *testing.T) {
-	assert.IsType(t, NewRules(), &Rules{})
+	assert.IsType(t, NewRules(), &engines.RuleManager{})
 }
 
 func TestRules_GetAllRules(t *testing.T) {
@@ -44,23 +46,25 @@ func TestRules_GetAllRules(t *testing.T) {
 }
 
 func TestRulesEnum(t *testing.T) {
-	var totalRules []text.TextRule
+	totalRules := rules()
 
-	totalRules = append(totalRules, allRulesKotlinAnd()...)
-	totalRules = append(totalRules, allRulesKotlinOr()...)
-	totalRules = append(totalRules, allRulesKotlinRegular()...)
-	lenExpectedTotalRules := 0
+	lenExpectedTotalRules := 40
 
 	t.Run("Should not exists duplicated ID in rules and return lenExpectedTotalRules in kotlin", func(t *testing.T) {
 		encountered := map[string]bool{}
 
-		for v := range totalRules {
-			if encountered[totalRules[v].ID] == true {
-				msg := fmt.Sprintf("This rules in kotlin is duplicated ID(%s) => Name: %s, Description: %s, Type: %v", totalRules[v].ID, totalRules[v].Name, totalRules[v].Description, totalRules[v].Type)
-				assert.False(t, encountered[totalRules[v].ID], msg)
+		for _, rule := range totalRules {
+			r, ok := rule.(text.TextRule)
+			require.True(t, ok, "Expected TextRule type, got %T", rule)
+
+			if encountered[r.ID] == true {
+				msg := fmt.Sprintf(
+					"This rules in kotlin is duplicated ID(%s) => Name: %s, Description: %s, Type: %v", r.ID, r.Name, r.Description, r.Type,
+				)
+				assert.False(t, encountered[r.ID], msg)
 			} else {
 				// Record this element as an encountered element.
-				encountered[totalRules[v].ID] = true
+				encountered[r.ID] = true
 			}
 		}
 

--- a/internal/services/engines/kubernetes/rules.go
+++ b/internal/services/engines/kubernetes/rules.go
@@ -16,73 +16,35 @@ package kubernetes
 
 import (
 	engine "github.com/ZupIT/horusec-engine"
-	"github.com/ZupIT/horusec-engine/text"
+	"github.com/ZupIT/horusec/internal/services/engines"
 	"github.com/ZupIT/horusec/internal/services/engines/kubernetes/and"
 	"github.com/ZupIT/horusec/internal/services/engines/kubernetes/or"
 	"github.com/ZupIT/horusec/internal/services/engines/kubernetes/regular"
 )
 
-type Rules struct{}
-
-func NewRules() *Rules {
-	return &Rules{}
+func NewRules() *engines.RuleManager {
+	return engines.NewRuleManager(rules(), extensions())
 }
 
-func (r *Rules) GetAllRules() (rules []engine.Rule) {
-	for index := range allRulesKubernetesAnd() {
-		rules = append(rules, allRulesKubernetesAnd()[index])
-	}
-
-	for index := range allRulesKubernetesOr() {
-		rules = append(rules, allRulesKubernetesOr()[index])
-	}
-
-	for index := range allRulesKubernetesRegular() {
-		rules = append(rules, allRulesKubernetesRegular()[index])
-	}
-
-	return rules
-}
-
-func (r *Rules) GetTextUnitByRulesExt(projectPath string) ([]engine.Unit, error) {
-	textUnits, err := text.LoadDirIntoMultiUnit(projectPath, 5, r.getExtensions())
-	if err != nil {
-		return []engine.Unit{}, err
-	}
-	return r.parseTextUnitsToUnits(textUnits), nil
-}
-
-func (r *Rules) parseTextUnitsToUnits(textUnits []text.TextUnit) (units []engine.Unit) {
-	for index := range textUnits {
-		units = append(units, textUnits[index])
-	}
-	return units
-}
-
-func (r *Rules) getExtensions() []string {
+func extensions() []string {
 	return []string{".yaml", ".yml"}
 }
 
-func allRulesKubernetesRegular() []text.TextRule {
-	return []text.TextRule{
+func rules() []engine.Rule {
+	return []engine.Rule{
+		// Regular rules
 		regular.NewKubernetesRegularHostIPC(),
 		regular.NewKubernetesRegularHostPID(),
 		regular.NewKubernetesRegularHostNetwork(),
-	}
-}
 
-func allRulesKubernetesAnd() []text.TextRule {
-	return []text.TextRule{
+		// And rules
 		and.NewKubernetesAndAllowPrivilegeEscalation(),
 		and.NewKubernetesAndHostAliases(),
 		and.NewKubernetesAndDockerSock(),
 		and.NewKubernetesAndCapabilitySystemAdmin(),
 		and.NewKubernetesAndPrivilegedContainer(),
-	}
-}
 
-func allRulesKubernetesOr() []text.TextRule {
-	return []text.TextRule{
+		// Or rules
 		or.NewKubernetesOrSeccompUnconfined(),
 	}
 }

--- a/internal/services/engines/kubernetes/rules_test.go
+++ b/internal/services/engines/kubernetes/rules_test.go
@@ -19,12 +19,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ZupIT/horusec-engine/text"
+	"github.com/ZupIT/horusec/internal/services/engines"
 )
 
 func TestNewRules(t *testing.T) {
-	assert.IsType(t, NewRules(), &Rules{})
+	assert.IsType(t, NewRules(), &engines.RuleManager{})
 }
 
 func TestRules_GetAllRules(t *testing.T) {
@@ -43,23 +45,25 @@ func TestRules_GetAllRules(t *testing.T) {
 }
 
 func TestRulesEnum(t *testing.T) {
-	var totalRules []text.TextRule
+	totalRules := rules()
 
-	totalRules = append(totalRules, allRulesKubernetesRegular()...)
-	totalRules = append(totalRules, allRulesKubernetesAnd()...)
-	totalRules = append(totalRules, allRulesKubernetesOr()...)
 	lenExpectedTotalRules := 9
 
 	t.Run("should not exists duplicated ID in rules and return lenExpectedTotalRules in kubernetes", func(t *testing.T) {
 		encountered := map[string]bool{}
 
-		for v := range totalRules {
-			if encountered[totalRules[v].ID] == true {
-				msg := fmt.Sprintf("This rules in kubernetes is duplicated ID(%s) => Name: %s, Description: %s, Type: %v", totalRules[v].ID, totalRules[v].Name, totalRules[v].Description, totalRules[v].Type)
-				assert.False(t, encountered[totalRules[v].ID], msg)
+		for _, rule := range totalRules {
+			r, ok := rule.(text.TextRule)
+			require.True(t, ok, "Expected TextRule type, got %T", rule)
+
+			if encountered[r.ID] == true {
+				msg := fmt.Sprintf(
+					"This rules in kubernetes is duplicated ID(%s) => Name: %s, Description: %s, Type: %v", r.ID, r.Name, r.Description, r.Type,
+				)
+				assert.False(t, encountered[r.ID], msg)
 			} else {
 				// Record this element as an encountered element.
-				encountered[totalRules[v].ID] = true
+				encountered[r.ID] = true
 			}
 		}
 

--- a/internal/services/engines/leaks/rules.go
+++ b/internal/services/engines/leaks/rules.go
@@ -16,49 +16,21 @@ package leaks
 
 import (
 	engine "github.com/ZupIT/horusec-engine"
-	"github.com/ZupIT/horusec-engine/text"
+	"github.com/ZupIT/horusec/internal/services/engines"
 	"github.com/ZupIT/horusec/internal/services/engines/leaks/regular"
 )
 
-type Rules struct{}
-
-func NewRules() *Rules {
-	return &Rules{}
+func NewRules() *engines.RuleManager {
+	return engines.NewRuleManager(rules(), extensions())
 }
 
-func (r *Rules) GetAllRules() (rules []engine.Rule) {
-	rules = r.addLeaksRules(rules)
-	return rules
-}
-
-func (r *Rules) addLeaksRules(rules []engine.Rule) []engine.Rule {
-	for _, rule := range allRulesLeaksRegular() {
-		rules = append(rules, rule)
-	}
-
-	return rules
-}
-
-func (r *Rules) GetTextUnitByRulesExt(projectPath string) ([]engine.Unit, error) {
-	textUnits, err := text.LoadDirIntoMultiUnit(projectPath, 5, r.getExtensions())
-	units := r.parseTextUnitsToUnits(textUnits)
-	return units, err
-}
-
-func (r *Rules) getExtensions() []string {
+func extensions() []string {
 	return []string{"**"}
 }
 
-func (r *Rules) parseTextUnitsToUnits(textUnits []text.TextUnit) (units []engine.Unit) {
-	for index := range textUnits {
-		units = append(units, textUnits[index])
-	}
-
-	return units
-}
-
-func allRulesLeaksRegular() []text.TextRule {
-	return []text.TextRule{
+func rules() []engine.Rule {
+	return []engine.Rule{
+		// Regular rules
 		regular.NewLeaksRegularAWSManagerID(),
 		regular.NewLeaksRegularAWSSecretKey(),
 		regular.NewLeaksRegularAWSMWSKey(),
@@ -88,12 +60,4 @@ func allRulesLeaksRegular() []text.TextRule {
 		regular.NewLeaksRegularPasswordExposedInHardcodedURL(),
 		regular.NewLeaksRegularWPConfig(),
 	}
-}
-
-func allRulesLeaksAnd() []text.TextRule {
-	return []text.TextRule{}
-}
-
-func allRulesLeaksOr() []text.TextRule {
-	return []text.TextRule{}
 }

--- a/internal/services/engines/leaks/rules_test.go
+++ b/internal/services/engines/leaks/rules_test.go
@@ -19,12 +19,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ZupIT/horusec-engine/text"
+	"github.com/ZupIT/horusec/internal/services/engines"
 )
 
 func TestNewRules(t *testing.T) {
-	assert.IsType(t, NewRules(), &Rules{})
+	assert.IsType(t, NewRules(), &engines.RuleManager{})
 }
 
 func TestRules_GetAllRules(t *testing.T) {
@@ -43,23 +45,24 @@ func TestRules_GetAllRules(t *testing.T) {
 }
 
 func TestRulesEnum(t *testing.T) {
-	var totalRules []text.TextRule
-
-	totalRules = append(totalRules, allRulesLeaksRegular()...)
-	totalRules = append(totalRules, allRulesLeaksAnd()...)
-	totalRules = append(totalRules, allRulesLeaksOr()...)
+	totalRules := rules()
 	lenExpectedTotalRules := 28
 
 	t.Run("should not exists duplicated ID in rules and return lenExpectedTotalRules in leaks", func(t *testing.T) {
 		encountered := map[string]bool{}
 
-		for v := range totalRules {
-			if encountered[totalRules[v].ID] == true {
-				msg := fmt.Sprintf("This rules in Leaks is duplicated ID(%s) => Name: %s, Description: %s, Type: %v", totalRules[v].ID, totalRules[v].Name, totalRules[v].Description, totalRules[v].Type)
-				assert.False(t, encountered[totalRules[v].ID], msg)
+		for _, rule := range totalRules {
+			r, ok := rule.(text.TextRule)
+			require.True(t, ok, "Expected TextRule type, got %T", rule)
+
+			if encountered[r.ID] == true {
+				msg := fmt.Sprintf(
+					"This rules in Leaks is duplicated ID(%s) => Name: %s, Description: %s, Type: %v", r.ID, r.Name, r.Description, r.Type,
+				)
+				assert.False(t, encountered[r.ID], msg)
 			} else {
 				// Record this element as an encountered element.
-				encountered[totalRules[v].ID] = true
+				encountered[r.ID] = true
 			}
 		}
 

--- a/internal/services/engines/nginx/rules.go
+++ b/internal/services/engines/nginx/rules.go
@@ -17,45 +17,21 @@ package nginx
 
 import (
 	engine "github.com/ZupIT/horusec-engine"
-	"github.com/ZupIT/horusec-engine/text"
+	"github.com/ZupIT/horusec/internal/services/engines"
 	"github.com/ZupIT/horusec/internal/services/engines/nginx/not"
 )
 
-type Rules struct{}
-
-func NewRules() *Rules {
-	return &Rules{}
+func NewRules() *engines.RuleManager {
+	return engines.NewRuleManager(rules(), extensions())
 }
 
-func (r *Rules) GetAllRules() (rules []engine.Rule) {
-	for _, rule := range allNginxNotRules() {
-		rules = append(rules, rule)
-	}
-
-	return rules
-}
-
-func (r *Rules) GetTextUnitByRulesExt(projectPath string) ([]engine.Unit, error) {
-	textUnits, err := text.LoadDirIntoMultiUnit(projectPath, 5, r.getExtensions())
-	if err != nil {
-		return []engine.Unit{}, err
-	}
-	return r.parseTextUnitsToUnits(textUnits), nil
-}
-
-func (r *Rules) parseTextUnitsToUnits(textUnits []text.TextUnit) (units []engine.Unit) {
-	for index := range textUnits {
-		units = append(units, textUnits[index])
-	}
-	return units
-}
-
-func (r *Rules) getExtensions() []string {
+func extensions() []string {
 	return []string{".nginx", "nginxconf", ".vhost"}
 }
 
-func allNginxNotRules() []text.TextRule {
-	return []text.TextRule{
+func rules() []engine.Rule {
+	return []engine.Rule{
+		// Not rules
 		not.NewNginxNotIncludeXFrameOptionsHeader(),
 		not.NewNginxNotIncludeXContentTypeOptionsHeader(),
 		not.NewNginxNotIncludeContentSecurityPolicyHeader(),

--- a/internal/services/engines/nginx/rules_test.go
+++ b/internal/services/engines/nginx/rules_test.go
@@ -5,12 +5,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ZupIT/horusec-engine/text"
+	"github.com/ZupIT/horusec/internal/services/engines"
 )
 
 func TestNewRules(t *testing.T) {
-	assert.IsType(t, NewRules(), &Rules{})
+	assert.IsType(t, NewRules(), &engines.RuleManager{})
 }
 
 func TestRules_GetAllRules(t *testing.T) {
@@ -29,21 +31,24 @@ func TestRules_GetAllRules(t *testing.T) {
 }
 
 func TestRulesEnum(t *testing.T) {
-	var totalRules []text.TextRule
-
-	totalRules = append(totalRules, allNginxNotRules()...)
+	totalRules := rules()
 	lenExpectedTotalRules := 4
 
 	t.Run("should not exists duplicated ID in rules and return lenExpectedTotalRules in nginx", func(t *testing.T) {
 		encountered := map[string]bool{}
 
-		for v := range totalRules {
-			if encountered[totalRules[v].ID] == true {
-				msg := fmt.Sprintf("This rules in Ngingx is duplicated ID(%s) => Name: %s, Description: %s, Type: %v", totalRules[v].ID, totalRules[v].Name, totalRules[v].Description, totalRules[v].Type)
-				assert.False(t, encountered[totalRules[v].ID], msg)
+		for _, rule := range totalRules {
+			r, ok := rule.(text.TextRule)
+			require.True(t, ok, "Expected TextRule type, got %T", rule)
+
+			if encountered[r.ID] == true {
+				msg := fmt.Sprintf(
+					"This rules in Ngingx is duplicated ID(%s) => Name: %s, Description: %s, Type: %v", r.ID, r.Name, r.Description, r.Type,
+				)
+				assert.False(t, encountered[r.ID], msg)
 			} else {
 				// Record this element as an encountered element.
-				encountered[totalRules[v].ID] = true
+				encountered[r.ID] = true
 			}
 		}
 

--- a/internal/services/engines/nodejs/rules.go
+++ b/internal/services/engines/nodejs/rules.go
@@ -16,59 +16,23 @@ package nodejs
 
 import (
 	engine "github.com/ZupIT/horusec-engine"
-	"github.com/ZupIT/horusec-engine/text"
+	"github.com/ZupIT/horusec/internal/services/engines"
 	"github.com/ZupIT/horusec/internal/services/engines/nodejs/and"
 	"github.com/ZupIT/horusec/internal/services/engines/nodejs/or"
 	"github.com/ZupIT/horusec/internal/services/engines/nodejs/regular"
 )
 
-type Rules struct{}
-
-func NewRules() *Rules {
-	return &Rules{}
+func NewRules() *engines.RuleManager {
+	return engines.NewRuleManager(rules(), extensions())
 }
 
-func (r *Rules) GetAllRules() (rules []engine.Rule) {
-	rules = r.addRules(rules)
-	return rules
-}
-
-func (r *Rules) addRules(rules []engine.Rule) []engine.Rule {
-	for _, rule := range allRulesNodeJSAnd() {
-		rules = append(rules, rule)
-	}
-
-	for _, rule := range allRulesNodeJSOr() {
-		rules = append(rules, rule)
-	}
-
-	for _, rule := range allRulesNodeJSRegular() {
-		rules = append(rules, rule)
-	}
-
-	return rules
-}
-
-func (r *Rules) GetTextUnitByRulesExt(projectPath string) ([]engine.Unit, error) {
-	textUnits, err := text.LoadDirIntoMultiUnit(projectPath, 5, r.getExtensions())
-	units := r.parseTextUnitsToUnits(textUnits)
-	return units, err
-}
-
-func (r *Rules) getExtensions() []string {
+func extensions() []string {
 	return []string{".js", ".ts", ".jsx", ".tsx"}
 }
 
-func (r *Rules) parseTextUnitsToUnits(textUnits []text.TextUnit) (units []engine.Unit) {
-	for index := range textUnits {
-		units = append(units, textUnits[index])
-	}
-
-	return units
-}
-
-func allRulesNodeJSRegular() []text.TextRule {
-	return []text.TextRule{
+func rules() []engine.Rule {
+	return []engine.Rule{
+		// Regular rules
 		regular.NewNodeJSRegularNoUseEval(),
 		regular.NewNodeJSRegularNoDisableTlsRejectUnauthorized(),
 		regular.NewNodeJSRegularNoUseMD5Hashing(),
@@ -90,11 +54,8 @@ func allRulesNodeJSRegular() []text.TextRule {
 		regular.NewNodeJSRegularReadingTheStandardInput(),
 		regular.NewNodeJSRegularUsingCommandLineArguments(),
 		regular.NewNodeJSRegularNoLogSensitiveInformationInConsole(),
-	}
-}
 
-func allRulesNodeJSAnd() []text.TextRule {
-	return []text.TextRule{
+		// And rules
 		and.NewNodeJSAndNoUseGetMethodUsingDataFromRequestOfUserInput(),
 		and.NewNodeJSAndNoUseRequestMethodUsingDataFromRequestOfUserInput(),
 		and.NewNodeJSAndCryptographicRsaShouldBeRobust(),
@@ -117,11 +78,8 @@ func allRulesNodeJSAnd() []text.TextRule {
 		and.NewNodeJSAndCreatingCookiesWithoutTheHttpOnlyFlag(),
 		and.NewNodeJSAndCreatingCookiesWithoutTheSecureFlag(),
 		and.NewNodeJSAndNoUseSocketManually(),
-	}
-}
 
-func allRulesNodeJSOr() []text.TextRule {
-	return []text.TextRule{
+		// Or rules
 		or.NewNodeJSOrEncryptionAlgorithmsWeak(),
 		or.NewNodeJSOrFileUploadsShouldBeRestricted(),
 		or.NewNodeJSOrAllowingRequestsWithExcessiveContentLengthSecurity(),

--- a/internal/services/engines/nodejs/rules_test.go
+++ b/internal/services/engines/nodejs/rules_test.go
@@ -19,12 +19,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ZupIT/horusec-engine/text"
+	"github.com/ZupIT/horusec/internal/services/engines"
 )
 
 func TestNewRules(t *testing.T) {
-	assert.IsType(t, NewRules(), &Rules{})
+	assert.IsType(t, NewRules(), &engines.RuleManager{})
 }
 
 func TestRules_GetAllRules(t *testing.T) {
@@ -43,23 +45,24 @@ func TestRules_GetAllRules(t *testing.T) {
 }
 
 func TestRulesEnum(t *testing.T) {
-	var totalRules []text.TextRule
-
-	totalRules = append(totalRules, allRulesNodeJSRegular()...)
-	totalRules = append(totalRules, allRulesNodeJSAnd()...)
-	totalRules = append(totalRules, allRulesNodeJSOr()...)
+	totalRules := rules()
 	lenExpectedTotalRules := 48
 
 	t.Run("should not exists duplicated ID in rules and return lenExpectedTotalRules in kotlin", func(t *testing.T) {
 		encountered := map[string]bool{}
 
-		for v := range totalRules {
-			if encountered[totalRules[v].ID] == true {
-				msg := fmt.Sprintf("This rules in kotlin is duplicated ID(%s) => Name: %s, Description: %s, Type: %v", totalRules[v].ID, totalRules[v].Name, totalRules[v].Description, totalRules[v].Type)
-				assert.False(t, encountered[totalRules[v].ID], msg)
+		for _, rule := range totalRules {
+			r, ok := rule.(text.TextRule)
+			require.True(t, ok, "Expected TextRule type, got %T", rule)
+
+			if encountered[r.ID] == true {
+				msg := fmt.Sprintf(
+					"This rules in kotlin is duplicated ID(%s) => Name: %s, Description: %s, Type: %v", r.ID, r.Name, r.Description, r.Type,
+				)
+				assert.False(t, encountered[r.ID], msg)
 			} else {
 				// Record this element as an encountered element.
-				encountered[totalRules[v].ID] = true
+				encountered[r.ID] = true
 			}
 		}
 

--- a/internal/services/engines/rules.go
+++ b/internal/services/engines/rules.go
@@ -1,0 +1,40 @@
+package engines
+
+import (
+	engine "github.com/ZupIT/horusec-engine"
+	"github.com/ZupIT/horusec-engine/text"
+)
+
+// RuleManager is a generic implementation of formatters.RuleManager
+// that can be reused between all engines to load rules
+type RuleManager struct {
+	rules      []engine.Rule
+	extensions []string
+}
+
+func NewRuleManager(rules []engine.Rule, extensions []string) *RuleManager {
+	return &RuleManager{
+		rules:      rules,
+		extensions: extensions,
+	}
+}
+
+func (r *RuleManager) GetAllRules() []engine.Rule {
+	return r.rules
+}
+
+func (r *RuleManager) GetTextUnitByRulesExt(src string) ([]engine.Unit, error) {
+	textUnits, err := text.LoadDirIntoMultiUnit(src, 5, r.extensions)
+	if err != nil {
+		return []engine.Unit{}, err
+	}
+	return r.parseTextUnitsToUnits(textUnits), nil
+}
+
+func (r *RuleManager) parseTextUnitsToUnits(textUnits []text.TextUnit) []engine.Unit {
+	units := make([]engine.Unit, 0, len(textUnits))
+	for _, t := range textUnits {
+		units = append(units, t)
+	}
+	return units
+}


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
Create a default rule manager implementation to be used between all
engines to load rules and text units. Previously each rule implements
its own version of RuleManager to load the rules and text units, with
common steps between them, just changing the GetRules implementation to
return the rules of specific language, with this new default
implementation we can just pass this rules to constructor and use the
same logic to all engines. 
I'm also update the tests of Kotlin and Java to count the rules of jvm, and make them more easily to read.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
