### PR TITLE
Fixing error where variable pointer is shared between processes

### DIFF
--- a/internal/controllers/analyzer/analyzer.go
+++ b/internal/controllers/analyzer/analyzer.go
@@ -188,7 +188,8 @@ func (a *Analyzer) startDetectVulnerabilities(langs []languages.Language) {
 	go func() {
 		defer close(done)
 		for _, language := range langs {
-			for _, projectSubPath := range wd.GetArrayByLanguage(language) {
+			for _, subPath := range wd.GetArrayByLanguage(language) {
+				projectSubPath := subPath
 				a.logProjectSubPath(language, projectSubPath)
 
 				if fn, exist := funcs[language]; exist {


### PR DESCRIPTION
**- What I did**

Initiated `projectSubPath` into new variable separate from the loop, avoiding variable sharing between threads. Fix for ZupIT/horusec#497

**- How to verify it**

Running horusec CLI with multiple workdirs for a language will process all defined directories

**- Description for the changelog**

Fixed workdir config only working on 1 directory 