### PR TITLE
Javascript rules improve

### DIFF
--- a/examples/javascript/example2/app.js
+++ b/examples/javascript/example2/app.js
@@ -25,6 +25,13 @@ app.get('/', (req, res) => {
     })
   });
 
+app.get('/any/path', (req, res) => {
+    let url = req.param('url');
+    if (url) {
+        res.redirect(url);
+    }
+});
+
 app.get('/healthcheck', (req, res) => {
     res.status(200).send('WORKING')
   });

--- a/internal/services/engines/nodejs/regular/regular.go
+++ b/internal/services/engines/nodejs/regular/regular.go
@@ -429,3 +429,20 @@ func NewNodeJSRegularNoExposeStackTrace() text.TextRule {
 		},
 	}
 }
+
+func NewNodeJSRegularInsecureDownload() text.TextRule {
+	return text.TextRule{
+		Metadata: engine.Metadata{
+			ID:          "6c7e9f6c-f6eb-4a69-a398-d03cb23c044d",
+			Name:        "Insecure download of executable file",
+			Description: "Downloading executeables or other sensitive files over an unencrypted connection can leave a server open to man-in-the-middle attacks (MITM). Such an attack can allow an attacker to insert arbitrary content into the downloaded file, and in the worst case, allow the attacker to execute arbitrary code on the vulnerable system.. For more information checkout the CWE-829 (https://cwe.mitre.org/data/definitions/829.html) advisory.",
+			Severity:    severities.Medium.ToString(),
+			Confidence:  confidence.Medium.ToString(),
+		},
+		Type: text.Regular,
+		Expressions: []*regexp.Regexp{
+			regexp.MustCompile(`(fetch|get|download)*\(.*(?:http:).*.(\.sh|\.exe|\.cmd|\.bat|\.dll|\.txt)`),
+		},
+	}
+}
+

--- a/internal/services/engines/nodejs/regular/regular.go
+++ b/internal/services/engines/nodejs/regular/regular.go
@@ -387,12 +387,28 @@ func NewNodeJSRegularNoRenderContentFromRequest() text.TextRule {
 			ID:          "11fe3d80-f8f7-4372-b631-4247aecb26bb",
 			Name:        "No render content from request",
 			Description: "Directly using user-controlled objects as arguments to template engines might allow an attacker to do local file reads or even remote code execution. For more information checkout the CWE-73 (https://cwe.mitre.org/data/definitions/73.html) advisory.",
-			Severity:    severities.Medium.ToString(),
-			Confidence:  confidence.Medium.ToString(),
+			Severity:    severities.High.ToString(),
+			Confidence:  confidence.Low.ToString(),
 		},
 		Type: text.Regular,
 		Expressions: []*regexp.Regexp{
 			regexp.MustCompile(`\.render\(.*(?:req\.|req\.query|req\.body|req\.param)`),
+		},
+	}
+}
+
+func NewNodeJSRegularNoWriteOnDocumentContentFromRequest() text.TextRule {
+	return text.TextRule{
+		Metadata: engine.Metadata{
+			ID:          "1398f039-b97f-4e72-8946-5179cd62afc4",
+			Name:        "No write content from request on HTML",
+			Description: "Directly writing  messages to a webpage without sanitization allows for a cross-site scripting vulnerability if parts of the message can be influenced by a user. For more information checkout the CWE-79 (https://cwe.mitre.org/data/definitions/79.html) advisory.",
+			Severity:    severities.High.ToString(),
+			Confidence:  confidence.Low.ToString(),
+		},
+		Type: text.Regular,
+		Expressions: []*regexp.Regexp{
+			regexp.MustCompile(`(document\.write|element\.write|body\.write)\(.*(?:req\.|req\.query|req\.body|req\.param)`),
 		},
 	}
 }

--- a/internal/services/engines/nodejs/regular/regular.go
+++ b/internal/services/engines/nodejs/regular/regular.go
@@ -388,11 +388,12 @@ func NewNodeJSRegularNoRenderContentFromRequest() text.TextRule {
 			Name:        "No render content from request",
 			Description: "Directly using user-controlled objects as arguments to template engines might allow an attacker to do local file reads or even remote code execution. For more information checkout the CWE-73 (https://cwe.mitre.org/data/definitions/73.html) advisory.",
 			Severity:    severities.High.ToString(),
-			Confidence:  confidence.Low.ToString(),
+			Confidence:  confidence.Medium.ToString(),
 		},
 		Type: text.Regular,
 		Expressions: []*regexp.Regexp{
 			regexp.MustCompile(`\.render\(.*(?:req\.|req\.query|req\.body|req\.param)`),
+			regexp.MustCompile(`\.send\(.*(?:req\.|req\.query|req\.body|req\.param)`),
 		},
 	}
 }
@@ -404,7 +405,7 @@ func NewNodeJSRegularNoWriteOnDocumentContentFromRequest() text.TextRule {
 			Name:        "No write content from request on HTML",
 			Description: "Directly writing  messages to a webpage without sanitization allows for a cross-site scripting vulnerability if parts of the message can be influenced by a user. For more information checkout the CWE-79 (https://cwe.mitre.org/data/definitions/79.html) advisory.",
 			Severity:    severities.High.ToString(),
-			Confidence:  confidence.Low.ToString(),
+			Confidence:  confidence.Medium.ToString(),
 		},
 		Type: text.Regular,
 		Expressions: []*regexp.Regexp{

--- a/internal/services/engines/nodejs/regular/regular.go
+++ b/internal/services/engines/nodejs/regular/regular.go
@@ -130,7 +130,7 @@ func NewNodeJSRegularNoReadFileUsingDataFromRequest() text.TextRule {
 		},
 		Type: text.Regular,
 		Expressions: []*regexp.Regexp{
-			regexp.MustCompile(`\.readFile\(.*(?:req\.|req\.query|req\.body|req\.param)`),
+			regexp.MustCompile(`\.(readFile|readFileSync)\(.*(?:req\.|req\.query|req\.body|req\.param)`),
 		},
 	}
 }
@@ -361,6 +361,22 @@ func NewNodeJSRegularUsingCommandLineArguments() text.TextRule {
 		Type: text.Regular,
 		Expressions: []*regexp.Regexp{
 			regexp.MustCompile(`(console|(?i)log|exec|spawn).(.|\n)*process.argv`),
+		},
+	}
+}
+
+func NewNodeJSRegularRedirectToUnknownPath() text.TextRule {
+	return text.TextRule{
+		Metadata: engine.Metadata{
+			ID:          "71c4c404-c796-4ce7-98f6-936b24248776",
+			Name:        "Redirect to unknown path",
+			Description: "Sanitizing untrusted URLs is an important technique for preventing attacks such as request forgeries and malicious redirections. Often, this is done by checking that the host of a URL is in a set of allowed hosts. For more information checkout the CWE-20 (https://cwe.mitre.org/data/definitions/20.html) advisory.",
+			Severity:    severities.High.ToString(),
+			Confidence:  confidence.Low.ToString(),
+		},
+		Type: text.Regular,
+		Expressions: []*regexp.Regexp{
+			regexp.MustCompile(`redirect\((?:\w)`),
 		},
 	}
 }

--- a/internal/services/engines/nodejs/regular/regular.go
+++ b/internal/services/engines/nodejs/regular/regular.go
@@ -380,3 +380,19 @@ func NewNodeJSRegularRedirectToUnknownPath() text.TextRule {
 		},
 	}
 }
+
+func NewNodeJSRegularNoRenderContentFromRequest() text.TextRule {
+	return text.TextRule{
+		Metadata: engine.Metadata{
+			ID:          "11fe3d80-f8f7-4372-b631-4247aecb26bb",
+			Name:        "No render content from request",
+			Description: "User data passed untreated to the 'createReadStream' function can cause a Directory Traversal attack. This attack exploits the lack of security, with the attacker gaining unauthorized access to the file system. For more information checkout the CWE-35 (https://cwe.mitre.org/data/definitions/35.html) advisory.",
+			Severity:    severities.Medium.ToString(),
+			Confidence:  confidence.Medium.ToString(),
+		},
+		Type: text.Regular,
+		Expressions: []*regexp.Regexp{
+			regexp.MustCompile(`\.render\(.*(?:req\.|req\.query|req\.body|req\.param)`),
+		},
+	}
+}

--- a/internal/services/engines/nodejs/regular/regular.go
+++ b/internal/services/engines/nodejs/regular/regular.go
@@ -413,3 +413,19 @@ func NewNodeJSRegularNoWriteOnDocumentContentFromRequest() text.TextRule {
 		},
 	}
 }
+
+func NewNodeJSRegularNoExposeStackTrace() text.TextRule {
+	return text.TextRule{
+		Metadata: engine.Metadata{
+			ID:          "dac52410-4a31-44ed-a713-5c5da9c2b284",
+			Name:        "Stack trace exposure",
+			Description: "Software developers often add stack traces to error messages, as a debugging aid. Whenever that error message occurs for an end user, the developer can use the stack trace to help identify how to fix the problem. For more information checkout the CWE-209 (https://cwe.mitre.org/data/definitions/209.html) advisory.",
+			Severity:    severities.Medium.ToString(),
+			Confidence:  confidence.High.ToString(),
+		},
+		Type: text.Regular,
+		Expressions: []*regexp.Regexp{
+			regexp.MustCompile(`(res\.end|res\.send)\(.*(?:req\.|e\.stack|error\.stack|err\.stack)`),
+		},
+	}
+}

--- a/internal/services/engines/nodejs/regular/regular.go
+++ b/internal/services/engines/nodejs/regular/regular.go
@@ -386,7 +386,7 @@ func NewNodeJSRegularNoRenderContentFromRequest() text.TextRule {
 		Metadata: engine.Metadata{
 			ID:          "11fe3d80-f8f7-4372-b631-4247aecb26bb",
 			Name:        "No render content from request",
-			Description: "User data passed untreated to the 'createReadStream' function can cause a Directory Traversal attack. This attack exploits the lack of security, with the attacker gaining unauthorized access to the file system. For more information checkout the CWE-35 (https://cwe.mitre.org/data/definitions/35.html) advisory.",
+			Description: "Directly using user-controlled objects as arguments to template engines might allow an attacker to do local file reads or even remote code execution. For more information checkout the CWE-73 (https://cwe.mitre.org/data/definitions/73.html) advisory.",
 			Severity:    severities.Medium.ToString(),
 			Confidence:  confidence.Medium.ToString(),
 		},

--- a/internal/services/engines/nodejs/rules.go
+++ b/internal/services/engines/nodejs/rules.go
@@ -56,6 +56,7 @@ func rules() []engine.Rule {
 		regular.NewNodeJSRegularNoLogSensitiveInformationInConsole(),
 		regular.NewNodeJSRegularRedirectToUnknownPath(),
 		regular.NewNodeJSRegularNoRenderContentFromRequest(),
+		regular.NewNodeJSRegularNoWriteOnDocumentContentFromRequest(),
 
 		// And rules
 		and.NewNodeJSAndNoUseGetMethodUsingDataFromRequestOfUserInput(),

--- a/internal/services/engines/nodejs/rules.go
+++ b/internal/services/engines/nodejs/rules.go
@@ -55,6 +55,7 @@ func rules() []engine.Rule {
 		regular.NewNodeJSRegularUsingCommandLineArguments(),
 		regular.NewNodeJSRegularNoLogSensitiveInformationInConsole(),
 		regular.NewNodeJSRegularRedirectToUnknownPath(),
+		regular.NewNodeJSRegularNoRenderContentFromRequest(),
 
 		// And rules
 		and.NewNodeJSAndNoUseGetMethodUsingDataFromRequestOfUserInput(),

--- a/internal/services/engines/nodejs/rules.go
+++ b/internal/services/engines/nodejs/rules.go
@@ -54,6 +54,7 @@ func rules() []engine.Rule {
 		regular.NewNodeJSRegularReadingTheStandardInput(),
 		regular.NewNodeJSRegularUsingCommandLineArguments(),
 		regular.NewNodeJSRegularNoLogSensitiveInformationInConsole(),
+		regular.NewNodeJSRegularRedirectToUnknownPath(),
 
 		// And rules
 		and.NewNodeJSAndNoUseGetMethodUsingDataFromRequestOfUserInput(),

--- a/internal/services/engines/nodejs/rules.go
+++ b/internal/services/engines/nodejs/rules.go
@@ -58,6 +58,7 @@ func rules() []engine.Rule {
 		regular.NewNodeJSRegularNoRenderContentFromRequest(),
 		regular.NewNodeJSRegularNoWriteOnDocumentContentFromRequest(),
 		regular.NewNodeJSRegularNoExposeStackTrace(),
+		regular.NewNodeJSRegularInsecureDownload(),
 
 		// And rules
 		and.NewNodeJSAndNoUseGetMethodUsingDataFromRequestOfUserInput(),

--- a/internal/services/engines/nodejs/rules.go
+++ b/internal/services/engines/nodejs/rules.go
@@ -57,6 +57,7 @@ func rules() []engine.Rule {
 		regular.NewNodeJSRegularRedirectToUnknownPath(),
 		regular.NewNodeJSRegularNoRenderContentFromRequest(),
 		regular.NewNodeJSRegularNoWriteOnDocumentContentFromRequest(),
+		regular.NewNodeJSRegularNoExposeStackTrace(),
 
 		// And rules
 		and.NewNodeJSAndNoUseGetMethodUsingDataFromRequestOfUserInput(),

--- a/internal/services/engines/rules_test.go
+++ b/internal/services/engines/rules_test.go
@@ -42,7 +42,7 @@ func TestGetRules(t *testing.T) {
 		{
 			engine:             "Nodejs",
 			manager:            nodejs.NewRules(),
-			expectedTotalRules: 48,
+			expectedTotalRules: 53,
 		},
 		{
 			engine:             "Nginx",


### PR DESCRIPTION
### New Rules:
- Redirect unsafe
- No render content from request
- No write content from request on HTML
- Expose stack trace
- Insecure download of executable file

### Improve:
- Add readFileSync in regex of NoReadFileUsingDataFromRequest() rule