### PR TITLE
Fix commit authors on windows 

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ horusec start -p .
 
 
 ## Usage with Docker
-It is also possible to be using the horusec through a docker image `horuszup/horusec-cli:latest.
+It is also possible to be using the horusec through a docker image `horuszup/horusec-cli:latest`.
 
 To do so, just run the following command:
 ```sh

--- a/e2e/scan_languages/scan_languages_test.go
+++ b/e2e/scan_languages/scan_languages_test.go
@@ -89,7 +89,7 @@ func TestHorusecCLI(t *testing.T) {
 		{
 			name:          "Ruby",
 			target:        filepath.Join("ruby", "example1"),
-			vulnerabilies: 54,
+			vulnerabilies: 53,
 		},
 		{
 			name:          "PythonBandit",

--- a/internal/services/git/git.go
+++ b/internal/services/git/git.go
@@ -81,10 +81,10 @@ func (g *Git) getCommitAuthorNotFound() commitAuthor.CommitAuthor {
 
 func (g *Git) executeCMD(line, filePath string) ([]byte, error) {
 	lineAndPath := g.setLineAndFilePath(g.getLine(line), filePath)
-	cmd := exec.Command("git", "log", "-1", "--format={ %n  ^^^^^author^^^^^: ^^^^^%an^^^^^,%n"+
+	cmd := exec.Command("git", "log", "-1", "--format=\"{ %n  ^^^^^author^^^^^: ^^^^^%an^^^^^,%n"+
 		"  ^^^^^email^^^^^:^^^^^%ae^^^^^,%n  ^^^^^message^^^^^: ^^^^^%s^^^^^,%n "+
 		" ^^^^^date^^^^^: ^^^^^%ci^^^^^,%n  ^^^^^commitHash^^^^^:"+
-		" ^^^^^%H^^^^^%n }", lineAndPath)
+		" ^^^^^%H^^^^^%n }\"", lineAndPath)
 
 	cmd.Dir = g.config.GetProjectPath()
 	response, err := cmd.Output()


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
Fixing issue #581
**- How to verify it**
Horusec failing when start compilation on windows because is necessary usage double cottle for accept commands
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
