### PR TITLE
cli: fix unnecessary log file creation

### DIFF
--- a/cmd/app/generate/generate.go
+++ b/cmd/app/generate/generate.go
@@ -41,6 +41,7 @@ func (g *Generate) CreateCobraCmd() *cobra.Command {
 		Short:   "Generate horusec configuration",
 		Long:    "Generate the Horusec configuration",
 		Example: "horusec generate",
+		PreRunE: g.configs.PreRun,
 		RunE:    g.runE,
 	}
 }

--- a/cmd/app/generate/generate_test.go
+++ b/cmd/app/generate/generate_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/iancoleman/strcase"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/ZupIT/horusec/config"
@@ -39,9 +38,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestGenerate_CreateCobraCmd(t *testing.T) {
-	globalCmd := &cobra.Command{}
-	_ = globalCmd.PersistentFlags().String("log-level", "", "Set verbose level of the CLI. Log Level enable is: \"panic\",\"fatal\",\"error\",\"warn\",\"info\",\"debug\",\"trace\"")
-	_ = globalCmd.PersistentFlags().String("config-file-path", "./tmp/horusec-config.json", "Path of the file horusec-config.json to setup content of horusec")
 	t.Run("Should create file with default configuration", func(t *testing.T) {
 		configs := config.New()
 		configs.SetConfigFilePath("./tmp/horusec-config1.json")
@@ -49,13 +45,12 @@ func TestGenerate_CreateCobraCmd(t *testing.T) {
 		stdoutMock := bytes.NewBufferString("")
 		logrus.SetOutput(stdoutMock)
 		cobraCmd := cmd.CreateCobraCmd()
+		// Remove the pre run hook to override the output
+		cobraCmd.PreRunE = nil
 		cobraCmd.SetOut(stdoutMock)
 
 		assert.NoError(t, cobraCmd.Execute())
-		outputBytes, err := ioutil.ReadAll(stdoutMock)
-		output := string(outputBytes)
-		assert.NoError(t, err)
-		assert.Contains(t, output, messages.MsgInfoConfigFileCreatedSuccess)
+		assert.Contains(t, stdoutMock.String(), messages.MsgInfoConfigFileCreatedSuccess)
 		file, _ := os.Open(configs.GetConfigFilePath())
 		defer func() {
 			_ = file.Close()
@@ -87,14 +82,14 @@ func TestGenerate_CreateCobraCmd(t *testing.T) {
 		stdoutMock := bytes.NewBufferString("")
 		logrus.SetOutput(stdoutMock)
 		cobraCmd := cmd.CreateCobraCmd()
+		// Remove the pre run hook to override the output
+		cobraCmd.PreRunE = nil
 		cobraCmd.SetOut(stdoutMock)
 		assert.NoError(t, cobraCmd.Execute())
 
 		// Validate ouput from cobra
-		outputBytes, err := ioutil.ReadAll(stdoutMock)
-		output := string(outputBytes)
 		assert.NoError(t, err)
-		assert.Contains(t, output, messages.MsgInfoConfigAlreadyExist)
+		assert.Contains(t, stdoutMock.String(), messages.MsgInfoConfigAlreadyExist)
 
 		// Check content on file created
 		file, _ := os.Open(configs.GetConfigFilePath())

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -26,7 +25,6 @@ import (
 	"github.com/ZupIT/horusec/cmd/app/start"
 	"github.com/ZupIT/horusec/cmd/app/version"
 	"github.com/ZupIT/horusec/config"
-	"github.com/ZupIT/horusec/internal/helpers/messages"
 )
 
 // nolint:funlen,lll
@@ -79,15 +77,6 @@ horusec start -p="/home/user/projects/my-project"
 	rootCmd.AddCommand(generateCmd.CreateCobraCmd())
 
 	cobra.OnInitialize(func() {
-		err := cfg.MergeFromConfigFile().
-			MergeFromEnvironmentVariables().
-			Normalize().
-			Eval()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s: %v\n", messages.MsgErrorSettingLogFile, err)
-			os.Exit(1)
-		}
-
 		engine.SetLogLevel(cfg.LogLevel)
 	})
 

--- a/cmd/app/start/start.go
+++ b/cmd/app/start/start.go
@@ -84,6 +84,7 @@ func (s *Start) CreateStartCommand() *cobra.Command {
 		Short:   "Start horusec-cli",
 		Long:    "Start the Horusec' analysis in the current path",
 		Example: "horusec start",
+		PreRunE: s.configs.PreRun,
 		RunE:    s.runE,
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
 	"github.com/ZupIT/horusec-devkit/pkg/enums/vulnerability"
@@ -330,6 +331,18 @@ func (c *Config) MergeFromEnvironmentVariables() *Config {
 	c.EnableOwaspDependencyCheck = env.GetEnvOrDefaultBool(EnvEnableOwaspDependencyCheck, c.EnableOwaspDependencyCheck)
 	c.EnableShellCheck = env.GetEnvOrDefaultBool(EnvEnableShellCheck, c.EnableShellCheck)
 	return c
+}
+
+// PreRun is a hook that load config values from config
+// file/environment variables, merge them with default values and
+// command line args and create the log file.
+//
+// This hook is used as a PreRun on cobra commands.
+func (c *Config) PreRun(_ *cobra.Command, _ []string) error {
+	return c.MergeFromConfigFile().
+		MergeFromEnvironmentVariables().
+		Normalize().
+		Eval()
 }
 
 // Eval evaluate user config input

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -359,6 +359,8 @@ func TestNewHorusecConfig(t *testing.T) {
 		startCmd := start.NewStartCommand(configs)
 
 		cobraCmd := startCmd.CreateStartCommand()
+		// Remove the pre run hook to override the output
+		cobraCmd.PreRunE = nil
 
 		target, err := os.MkdirTemp(os.TempDir(), "testing-target")
 		assert.NoError(t, err)


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
Previously we are reading and evaluating the config values on every
command of CLI, even if we don't needed. For example, when we ran the
version command we create the log files. So this commit change to read
and merge config values and create the log file only when needed.

Co-authored-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
