### PR TITLE
Adds support to Jakarta package instead of javax

### DIFF
--- a/internal/services/engines/java/and/and.go
+++ b/internal/services/engines/java/and/and.go
@@ -287,6 +287,23 @@ func NewJavaAndServerHostnamesShouldBeVerifiedDuringSSLTLSConnectionsWithJakarta
 	}
 }
 
+func NewJavaAndServerHostnamesShouldBeVerifiedDuringSSLTLSConnectionsWithJakartaMail() text.TextRule {
+	return text.TextRule{
+		Metadata: engine.Metadata{
+			ID:          "90ee28f2-d622-4a5e-9d9d-13fb53ea5ca7",
+			Name:        "Server hostnames should be verified during SSL/TLS connections With JavaMail's",
+			Description: "To establish a SSL/TLS connection not vulnerable to man-in-the-middle attacks, it's essential to make sure the server presents the right certificate. The certificate's hostname-specific data should match the server hostname. It's not recommended to re-invent the wheel by implementing custom hostname verification. TLS/SSL libraries provide built-in hostname verification functions that should be used. For more information checkout the CWE-295 (https://cwe.mitre.org/data/definitions/295.html) advisory.",
+			Severity:    severities.High.ToString(),
+			Confidence:  confidence.Low.ToString(),
+		},
+		Type: text.AndMatch,
+		Expressions: []*regexp.Regexp{
+			regexp.MustCompile(`(new Properties\()(([^c]|c[^h]|ch[^e]|che[^c]|chec[^k]|check[^s]|checks[^e]|checkse[^r]|checkser[^v]|checkserv[^e]|checkserve[^r]|checkserver[^i]|checkserveri[^d]|checkserverid[^e]|checkserveride[^n]|checkserveriden[^t]|checkserverident[^i]|checkserveridenti[^t]|checkserveridentit[^y])*?)(new\sjakarta\.mail\.Authenticator\()`),
+			regexp.MustCompile(`put\(.*mail.smtp`),
+		},
+	}
+}
+
 func NewJavaAndTrustManagerThatAcceptAnyCertificatesServer() text.TextRule {
 	return text.TextRule{
 		Metadata: engine.Metadata{

--- a/internal/services/engines/java/and/and.go
+++ b/internal/services/engines/java/and/and.go
@@ -1734,6 +1734,23 @@ func NewJakartaAndWebApplicationsShouldHotHaveAMainMethod() text.TextRule {
 	}
 }
 
+func NewJakartaAndWebApplicationsShouldHotHaveAMainMethod() text.TextRule {
+	return text.TextRule{
+		Metadata: engine.Metadata{
+			ID:          "3b02a174-58a8-47da-b732-444899361a24",
+			Name:        "Web applications should not have a main method",
+			Description: "Having a main method in a web application opens a door to the application logic that an attacker may never be able to reach (but watch out if one does!), but it is a sloppy practice and indicates that other problems may be present. For more information checkout the CWE-489 (https://cwe.mitre.org/data/definitions/489.html) advisory.",
+			Severity:    severities.High.ToString(),
+			Confidence:  confidence.Low.ToString(),
+		},
+		Type: text.AndMatch,
+		Expressions: []*regexp.Regexp{
+			regexp.MustCompile(`import jakarta.servlet.*`),
+			regexp.MustCompile(`public static void main\(String\[\] args\)`),
+		},
+	}
+}
+
 func NewJavaAndSecureRandomSeedsShouldNotBePredictable() text.TextRule {
 	return text.TextRule{
 		Metadata: engine.Metadata{

--- a/internal/services/engines/java/and/and.go
+++ b/internal/services/engines/java/and/and.go
@@ -287,23 +287,6 @@ func NewJavaAndServerHostnamesShouldBeVerifiedDuringSSLTLSConnectionsWithJakarta
 	}
 }
 
-func NewJavaAndServerHostnamesShouldBeVerifiedDuringSSLTLSConnectionsWithJakartaMail() text.TextRule {
-	return text.TextRule{
-		Metadata: engine.Metadata{
-			ID:          "90ee28f2-d622-4a5e-9d9d-13fb53ea5ca7",
-			Name:        "Server hostnames should be verified during SSL/TLS connections With JavaMail's",
-			Description: "To establish a SSL/TLS connection not vulnerable to man-in-the-middle attacks, it's essential to make sure the server presents the right certificate. The certificate's hostname-specific data should match the server hostname. It's not recommended to re-invent the wheel by implementing custom hostname verification. TLS/SSL libraries provide built-in hostname verification functions that should be used. For more information checkout the CWE-295 (https://cwe.mitre.org/data/definitions/295.html) advisory.",
-			Severity:    severities.High.ToString(),
-			Confidence:  confidence.Low.ToString(),
-		},
-		Type: text.AndMatch,
-		Expressions: []*regexp.Regexp{
-			regexp.MustCompile(`(new Properties\()(([^c]|c[^h]|ch[^e]|che[^c]|chec[^k]|check[^s]|checks[^e]|checkse[^r]|checkser[^v]|checkserv[^e]|checkserve[^r]|checkserver[^i]|checkserveri[^d]|checkserverid[^e]|checkserveride[^n]|checkserveriden[^t]|checkserverident[^i]|checkserveridenti[^t]|checkserveridentit[^y])*?)(new\sjakarta\.mail\.Authenticator\()`),
-			regexp.MustCompile(`put\(.*mail.smtp`),
-		},
-	}
-}
-
 func NewJavaAndTrustManagerThatAcceptAnyCertificatesServer() text.TextRule {
 	return text.TextRule{
 		Metadata: engine.Metadata{
@@ -987,22 +970,6 @@ func NewJakartaAndPotentialPathTraversal() text.TextRule {
 	}
 }
 
-func NewJakartaAndPotentialPathTraversal() text.TextRule {
-	return text.TextRule{
-		Metadata: engine.Metadata{
-			ID:          "8b8acafb-b4e5-45d2-aa8a-2a297c2c7856",
-			Name:        "Potential Path Traversal (file read)",
-			Description: "A file is opened to read its content. The filename comes from an input parameter. If an unfiltered parameter is passed to this file API, files from an arbitrary filesystem location could be read. This rule identifies potential path traversal vulnerabilities. Please consider use this example: \"new File(\"resources/images/\", FilenameUtils.getName(value_received_in_params))\". For more information checkout the CWE-22 (https://cwe.mitre.org/data/definitions/22.html) advisory.",
-			Severity:    severities.High.ToString(),
-			Confidence:  confidence.High.ToString(),
-		},
-		Type: text.AndMatch,
-		Expressions: []*regexp.Regexp{
-			regexp.MustCompile(`(.*\@jakarta\.ws\.rs\.PathParam\(['|"]?\w+[[:print:]]['|"]?\).*)`),
-			regexp.MustCompile(`(.*new File\(['|"]?.*,\s?\w+\).*)`),
-		},
-	}
-}
 
 func NewJavaAndPotentialPathTraversalUsingScalaAPI() text.TextRule {
 	return text.TextRule{
@@ -1712,23 +1679,6 @@ func NewJavaAndWebApplicationsShouldHotHaveAMainMethod() text.TextRule {
 		Type: text.AndMatch,
 		Expressions: []*regexp.Regexp{
 			regexp.MustCompile(`import javax.servlet.*`),
-			regexp.MustCompile(`public static void main\(String\[\] args\)`),
-		},
-	}
-}
-
-func NewJakartaAndWebApplicationsShouldHotHaveAMainMethod() text.TextRule {
-	return text.TextRule{
-		Metadata: engine.Metadata{
-			ID:          "3b02a174-58a8-47da-b732-444899361a24",
-			Name:        "Web applications should not have a main method",
-			Description: "Having a main method in a web application opens a door to the application logic that an attacker may never be able to reach (but watch out if one does!), but it is a sloppy practice and indicates that other problems may be present. For more information checkout the CWE-489 (https://cwe.mitre.org/data/definitions/489.html) advisory.",
-			Severity:    severities.High.ToString(),
-			Confidence:  confidence.Low.ToString(),
-		},
-		Type: text.AndMatch,
-		Expressions: []*regexp.Regexp{
-			regexp.MustCompile(`import jakarta.servlet.*`),
 			regexp.MustCompile(`public static void main\(String\[\] args\)`),
 		},
 	}

--- a/internal/services/engines/java/and/and.go
+++ b/internal/services/engines/java/and/and.go
@@ -1682,6 +1682,23 @@ func NewJavaAndWebApplicationsShouldHotHaveAMainMethod() text.TextRule {
 	}
 }
 
+func NewJakartaAndWebApplicationsShouldHotHaveAMainMethod() text.TextRule {
+	return text.TextRule{
+		Metadata: engine.Metadata{
+			ID:          "3b02a174-58a8-47da-b732-444899361a24",
+			Name:        "Web applications should not have a main method",
+			Description: "Having a main method in a web application opens a door to the application logic that an attacker may never be able to reach (but watch out if one does!), but it is a sloppy practice and indicates that other problems may be present. For more information checkout the CWE-489 (https://cwe.mitre.org/data/definitions/489.html) advisory.",
+			Severity:    severities.High.ToString(),
+			Confidence:  confidence.Low.ToString(),
+		},
+		Type: text.AndMatch,
+		Expressions: []*regexp.Regexp{
+			regexp.MustCompile(`import jakarta.servlet.*`),
+			regexp.MustCompile(`public static void main\(String\[\] args\)`),
+		},
+	}
+}
+
 func NewJavaAndSecureRandomSeedsShouldNotBePredictable() text.TextRule {
 	return text.TextRule{
 		Metadata: engine.Metadata{

--- a/internal/services/engines/java/and/and.go
+++ b/internal/services/engines/java/and/and.go
@@ -935,6 +935,7 @@ func NewJavaAndQueryDatabaseOfSMSContacts() text.TextRule {
 	}
 }
 
+//Deprecated the javax package is deprecated in the Jakarta EE newest version. We'll use jakarta package.
 func NewJavaAndPotentialPathTraversal() text.TextRule {
 	return text.TextRule{
 		Metadata: engine.Metadata{

--- a/internal/services/engines/java/and/and.go
+++ b/internal/services/engines/java/and/and.go
@@ -94,7 +94,7 @@ func NewJavaAndXMLParsingVulnerableToXXEWithSAXParserFactory() text.TextRule {
 		},
 	}
 }
-//Deprecated The javax package is deprecated. We'll keep "jakarta" package instead
+
 func NewJavaAndXMLParsingVulnerableToXXEWithTransformerFactory() text.TextRule {
 	return text.TextRule{
 		Metadata: engine.Metadata{

--- a/internal/services/engines/java/and/and.go
+++ b/internal/services/engines/java/and/and.go
@@ -252,7 +252,7 @@ func NewJavaAndServerHostnamesShouldBeVerifiedDuringSSLTLSConnectionsWithSimpleE
 	}
 }
 
-//Deprecated the javax package is deprecated in the Jakarta EE newest version. We'll use jakarta package.
+//Deprecated: the javax package is deprecated in the Jakarta EE newest version. We'll use jakarta package.
 func NewJavaAndServerHostnamesShouldBeVerifiedDuringSSLTLSConnectionsWithJavaMail() text.TextRule {
 	return text.TextRule{
 		Metadata: engine.Metadata{
@@ -935,7 +935,7 @@ func NewJavaAndQueryDatabaseOfSMSContacts() text.TextRule {
 	}
 }
 
-//Deprecated the javax package is deprecated in the Jakarta EE newest version. We'll use jakarta package.
+//Deprecated: the javax package is deprecated in the Jakarta EE newest version. We'll use jakarta package.
 func NewJavaAndPotentialPathTraversal() text.TextRule {
 	return text.TextRule{
 		Metadata: engine.Metadata{
@@ -1613,7 +1613,7 @@ func NewJavaAndOpenSAML2ShouldBeConfiguredToPreventAuthenticationBypass() text.T
 		},
 	}
 }
-//Deprecated the javax package is deprecated in the Jakarta EE newest version. We'll use jakarta package.
+//Deprecated: the javax package is deprecated in the Jakarta EE newest version. We'll use jakarta package.
 func NewJavaAndHttpServletRequestGetRequestedSessionIdShouldNotBeUsed() text.TextRule {
 	return text.TextRule{
 		Metadata: engine.Metadata{
@@ -1664,7 +1664,7 @@ func NewJavaAndLDAPAuthenticatedAnalyzeYourCode() text.TextRule {
 	}
 }
 
-//Deprecated the javax package is deprecated in the Jakarta EE newest version. We'll use jakarta package.
+//Deprecated: the javax package is deprecated in the Jakarta EE newest version. We'll use jakarta package.
 func NewJavaAndWebApplicationsShouldHotHaveAMainMethod() text.TextRule {
 	return text.TextRule{
 		Metadata: engine.Metadata{

--- a/internal/services/engines/java/and/and.go
+++ b/internal/services/engines/java/and/and.go
@@ -270,6 +270,23 @@ func NewJavaAndServerHostnamesShouldBeVerifiedDuringSSLTLSConnectionsWithJavaMai
 	}
 }
 
+func NewJavaAndServerHostnamesShouldBeVerifiedDuringSSLTLSConnectionsWithJakartaMail() text.TextRule {
+	return text.TextRule{
+		Metadata: engine.Metadata{
+			ID:          "90ee28f2-d622-4a5e-9d9d-13fb53ea5ca7",
+			Name:        "Server hostnames should be verified during SSL/TLS connections With JavaMail's",
+			Description: "To establish a SSL/TLS connection not vulnerable to man-in-the-middle attacks, it's essential to make sure the server presents the right certificate. The certificate's hostname-specific data should match the server hostname. It's not recommended to re-invent the wheel by implementing custom hostname verification. TLS/SSL libraries provide built-in hostname verification functions that should be used. For more information checkout the CWE-295 (https://cwe.mitre.org/data/definitions/295.html) advisory.",
+			Severity:    severities.High.ToString(),
+			Confidence:  confidence.Low.ToString(),
+		},
+		Type: text.AndMatch,
+		Expressions: []*regexp.Regexp{
+			regexp.MustCompile(`(new Properties\()(([^c]|c[^h]|ch[^e]|che[^c]|chec[^k]|check[^s]|checks[^e]|checkse[^r]|checkser[^v]|checkserv[^e]|checkserve[^r]|checkserver[^i]|checkserveri[^d]|checkserverid[^e]|checkserveride[^n]|checkserveriden[^t]|checkserverident[^i]|checkserveridenti[^t]|checkserveridentit[^y])*?)(new\sjakarta\.mail\.Authenticator\()`),
+			regexp.MustCompile(`put\(.*mail.smtp`),
+		},
+	}
+}
+
 func NewJavaAndTrustManagerThatAcceptAnyCertificatesServer() text.TextRule {
 	return text.TextRule{
 		Metadata: engine.Metadata{

--- a/internal/services/engines/java/and/and.go
+++ b/internal/services/engines/java/and/and.go
@@ -953,6 +953,23 @@ func NewJavaAndPotentialPathTraversal() text.TextRule {
 	}
 }
 
+func NewJakartaAndPotentialPathTraversal() text.TextRule {
+	return text.TextRule{
+		Metadata: engine.Metadata{
+			ID:          "8b8acafb-b4e5-45d2-aa8a-2a297c2c7856",
+			Name:        "Potential Path Traversal (file read)",
+			Description: "A file is opened to read its content. The filename comes from an input parameter. If an unfiltered parameter is passed to this file API, files from an arbitrary filesystem location could be read. This rule identifies potential path traversal vulnerabilities. Please consider use this example: \"new File(\"resources/images/\", FilenameUtils.getName(value_received_in_params))\". For more information checkout the CWE-22 (https://cwe.mitre.org/data/definitions/22.html) advisory.",
+			Severity:    severities.High.ToString(),
+			Confidence:  confidence.High.ToString(),
+		},
+		Type: text.AndMatch,
+		Expressions: []*regexp.Regexp{
+			regexp.MustCompile(`(.*\@jakarta\.ws\.rs\.PathParam\(['|"]?\w+[[:print:]]['|"]?\).*)`),
+			regexp.MustCompile(`(.*new File\(['|"]?.*,\s?\w+\).*)`),
+		},
+	}
+}
+
 func NewJavaAndPotentialPathTraversalUsingScalaAPI() text.TextRule {
 	return text.TextRule{
 		Metadata: engine.Metadata{

--- a/internal/services/engines/java/and/and.go
+++ b/internal/services/engines/java/and/and.go
@@ -273,7 +273,7 @@ func NewJavaAndServerHostnamesShouldBeVerifiedDuringSSLTLSConnectionsWithJavaMai
 func NewJavaAndServerHostnamesShouldBeVerifiedDuringSSLTLSConnectionsWithJakartaMail() text.TextRule {
 	return text.TextRule{
 		Metadata: engine.Metadata{
-			ID:          "90ee28f2-d622-4a5e-9d9d-13fb53ea5ca7",
+			ID:          "a6a2ae16-8ca5-46e1-bed4-822068a41a01",
 			Name:        "Server hostnames should be verified during SSL/TLS connections With JavaMail's",
 			Description: "To establish a SSL/TLS connection not vulnerable to man-in-the-middle attacks, it's essential to make sure the server presents the right certificate. The certificate's hostname-specific data should match the server hostname. It's not recommended to re-invent the wheel by implementing custom hostname verification. TLS/SSL libraries provide built-in hostname verification functions that should be used. For more information checkout the CWE-295 (https://cwe.mitre.org/data/definitions/295.html) advisory.",
 			Severity:    severities.High.ToString(),
@@ -956,7 +956,7 @@ func NewJavaAndPotentialPathTraversal() text.TextRule {
 func NewJakartaAndPotentialPathTraversal() text.TextRule {
 	return text.TextRule{
 		Metadata: engine.Metadata{
-			ID:          "8b8acafb-b4e5-45d2-aa8a-2a297c2c7856",
+			ID:          "2ed3def4-780f-4076-9cbc-d1943cd9adc2",
 			Name:        "Potential Path Traversal (file read)",
 			Description: "A file is opened to read its content. The filename comes from an input parameter. If an unfiltered parameter is passed to this file API, files from an arbitrary filesystem location could be read. This rule identifies potential path traversal vulnerabilities. Please consider use this example: \"new File(\"resources/images/\", FilenameUtils.getName(value_received_in_params))\". For more information checkout the CWE-22 (https://cwe.mitre.org/data/definitions/22.html) advisory.",
 			Severity:    severities.High.ToString(),
@@ -1636,7 +1636,7 @@ func NewJavaAndHttpServletRequestGetRequestedSessionIdShouldNotBeUsed() text.Tex
 func NewJakartaAndHttpServletRequestGetRequestedSessionIdShouldNotBeUsed() text.TextRule {
 	return text.TextRule{
 		Metadata: engine.Metadata{
-			ID:          "fa0ccc8d-f6bd-4be2-8764-f38194fd9185",
+			ID:          "2e301a1e-d2eb-4505-9dff-26341e159bdf",
 			Name:        "HttpServletRequest.getRequestedSessionId should not be used",
 			Description: "Due to the ability of the end-user to manually change the value, the session ID in the request should only be used by a servlet container (E.G. Tomcat or Jetty) to see if the value matches the ID of an an existing session. If it does not, the user should be considered unauthenticated. Moreover, this session ID should never be logged to prevent hijacking of active sessions. For more information checkout the CWE-807 (https://cwe.mitre.org/data/definitions/807) advisory.",
 			Severity:    severities.High.ToString(),
@@ -1687,7 +1687,7 @@ func NewJavaAndWebApplicationsShouldHotHaveAMainMethod() text.TextRule {
 func NewJakartaAndWebApplicationsShouldHotHaveAMainMethod() text.TextRule {
 	return text.TextRule{
 		Metadata: engine.Metadata{
-			ID:          "3b02a174-58a8-47da-b732-444899361a24",
+			ID:          "84f60119-53e7-4ca2-beca-504891712b80",
 			Name:        "Web applications should not have a main method",
 			Description: "Having a main method in a web application opens a door to the application logic that an attacker may never be able to reach (but watch out if one does!), but it is a sloppy practice and indicates that other problems may be present. For more information checkout the CWE-489 (https://cwe.mitre.org/data/definitions/489.html) advisory.",
 			Severity:    severities.High.ToString(),

--- a/internal/services/engines/java/and/and.go
+++ b/internal/services/engines/java/and/and.go
@@ -1647,6 +1647,7 @@ func NewJavaAndOpenSAML2ShouldBeConfiguredToPreventAuthenticationBypass() text.T
 		},
 	}
 }
+
 //Deprecated: the javax package is deprecated in the Jakarta EE newest version. We'll use jakarta package.
 func NewJavaAndHttpServletRequestGetRequestedSessionIdShouldNotBeUsed() text.TextRule {
 	return text.TextRule{

--- a/internal/services/engines/java/and/and.go
+++ b/internal/services/engines/java/and/and.go
@@ -252,6 +252,7 @@ func NewJavaAndServerHostnamesShouldBeVerifiedDuringSSLTLSConnectionsWithSimpleE
 	}
 }
 
+//Deprecated the javax package is deprecated in the Jakarta EE newest version. We'll use jakarta package.
 func NewJavaAndServerHostnamesShouldBeVerifiedDuringSSLTLSConnectionsWithJavaMail() text.TextRule {
 	return text.TextRule{
 		Metadata: engine.Metadata{

--- a/internal/services/engines/java/and/and.go
+++ b/internal/services/engines/java/and/and.go
@@ -987,6 +987,23 @@ func NewJakartaAndPotentialPathTraversal() text.TextRule {
 	}
 }
 
+func NewJakartaAndPotentialPathTraversal() text.TextRule {
+	return text.TextRule{
+		Metadata: engine.Metadata{
+			ID:          "8b8acafb-b4e5-45d2-aa8a-2a297c2c7856",
+			Name:        "Potential Path Traversal (file read)",
+			Description: "A file is opened to read its content. The filename comes from an input parameter. If an unfiltered parameter is passed to this file API, files from an arbitrary filesystem location could be read. This rule identifies potential path traversal vulnerabilities. Please consider use this example: \"new File(\"resources/images/\", FilenameUtils.getName(value_received_in_params))\". For more information checkout the CWE-22 (https://cwe.mitre.org/data/definitions/22.html) advisory.",
+			Severity:    severities.High.ToString(),
+			Confidence:  confidence.High.ToString(),
+		},
+		Type: text.AndMatch,
+		Expressions: []*regexp.Regexp{
+			regexp.MustCompile(`(.*\@jakarta\.ws\.rs\.PathParam\(['|"]?\w+[[:print:]]['|"]?\).*)`),
+			regexp.MustCompile(`(.*new File\(['|"]?.*,\s?\w+\).*)`),
+		},
+	}
+}
+
 func NewJavaAndPotentialPathTraversalUsingScalaAPI() text.TextRule {
 	return text.TextRule{
 		Metadata: engine.Metadata{

--- a/internal/services/engines/java/and/and.go
+++ b/internal/services/engines/java/and/and.go
@@ -94,7 +94,7 @@ func NewJavaAndXMLParsingVulnerableToXXEWithSAXParserFactory() text.TextRule {
 		},
 	}
 }
-
+//Deprecated The javax package is deprecated. We'll keep "jakarta" package instead
 func NewJavaAndXMLParsingVulnerableToXXEWithTransformerFactory() text.TextRule {
 	return text.TextRule{
 		Metadata: engine.Metadata{

--- a/internal/services/engines/java/and/and.go
+++ b/internal/services/engines/java/and/and.go
@@ -1613,6 +1613,7 @@ func NewJavaAndOpenSAML2ShouldBeConfiguredToPreventAuthenticationBypass() text.T
 		},
 	}
 }
+//Deprecated the javax package is deprecated in the Jakarta EE newest version. We'll use jakarta package.
 func NewJavaAndHttpServletRequestGetRequestedSessionIdShouldNotBeUsed() text.TextRule {
 	return text.TextRule{
 		Metadata: engine.Metadata{
@@ -1625,6 +1626,23 @@ func NewJavaAndHttpServletRequestGetRequestedSessionIdShouldNotBeUsed() text.Tex
 		Type: text.AndMatch,
 		Expressions: []*regexp.Regexp{
 			regexp.MustCompile(`import javax.servlet.http.HttpServletRequest`),
+			regexp.MustCompile(`getRequestedSessionId\(\)`),
+		},
+	}
+}
+
+func NewJakartaAndHttpServletRequestGetRequestedSessionIdShouldNotBeUsed() text.TextRule {
+	return text.TextRule{
+		Metadata: engine.Metadata{
+			ID:          "fa0ccc8d-f6bd-4be2-8764-f38194fd9185",
+			Name:        "HttpServletRequest.getRequestedSessionId should not be used",
+			Description: "Due to the ability of the end-user to manually change the value, the session ID in the request should only be used by a servlet container (E.G. Tomcat or Jetty) to see if the value matches the ID of an an existing session. If it does not, the user should be considered unauthenticated. Moreover, this session ID should never be logged to prevent hijacking of active sessions. For more information checkout the CWE-807 (https://cwe.mitre.org/data/definitions/807) advisory.",
+			Severity:    severities.High.ToString(),
+			Confidence:  confidence.Low.ToString(),
+		},
+		Type: text.AndMatch,
+		Expressions: []*regexp.Regexp{
+			regexp.MustCompile(`import jakarta.servlet.http.HttpServletRequest`),
 			regexp.MustCompile(`getRequestedSessionId\(\)`),
 		},
 	}

--- a/internal/services/engines/java/and/and.go
+++ b/internal/services/engines/java/and/and.go
@@ -1664,6 +1664,7 @@ func NewJavaAndLDAPAuthenticatedAnalyzeYourCode() text.TextRule {
 	}
 }
 
+//Deprecated the javax package is deprecated in the Jakarta EE newest version. We'll use jakarta package.
 func NewJavaAndWebApplicationsShouldHotHaveAMainMethod() text.TextRule {
 	return text.TextRule{
 		Metadata: engine.Metadata{

--- a/internal/services/engines/java/rules.go
+++ b/internal/services/engines/java/rules.go
@@ -120,6 +120,7 @@ func rules() []engine.Rule {
 		and.NewJavaAndServerHostnamesShouldBeVerifiedDuringSSLTLSConnectionsWithSimpleEmail(),
 		and.NewJavaAndFunctionCallsShouldNotBeVulnerableToPathInjectionAttacks(),
 		and.NewJavaAndServerHostnamesShouldBeVerifiedDuringSSLTLSConnectionsWithJavaMail(),
+		and.NewJavaAndServerHostnamesShouldBeVerifiedDuringSSLTLSConnectionsWithJakartaMail(),
 		and.NewJavaAndHTTPResponseHeadersShouldNotBeVulnerableToInjectionAttacks(),
 		and.NewJavaAndLDAPAuthenticatedAnalyzeYourCode(),
 		and.NewJavaAndSecureRandomSeedsShouldNotBePredictable(),

--- a/internal/services/engines/java/rules.go
+++ b/internal/services/engines/java/rules.go
@@ -131,6 +131,7 @@ func rules() []engine.Rule {
 		and.NewJavaAndHttpServletRequestGetRequestedSessionIdShouldNotBeUsed(),
 		and.NewJakartaAndHttpServletRequestGetRequestedSessionIdShouldNotBeUsed(),
 		and.NewJavaAndWebApplicationsShouldHotHaveAMainMethod(),
+		and.NewJakartaAndWebApplicationsShouldHotHaveAMainMethod(),
 
 		// Or Rules
 		or.NewJavaOrFileIsWorldReadable(),

--- a/internal/services/engines/java/rules.go
+++ b/internal/services/engines/java/rules.go
@@ -129,6 +129,7 @@ func rules() []engine.Rule {
 		and.NewJavaAndActiveMQConnectionFactoryVulnerableToMaliciousCodeDeserialization(),
 		and.NewJavaAndOpenSAML2ShouldBeConfiguredToPreventAuthenticationBypass(),
 		and.NewJavaAndHttpServletRequestGetRequestedSessionIdShouldNotBeUsed(),
+		and.NewJakartaAndHttpServletRequestGetRequestedSessionIdShouldNotBeUsed(),
 		and.NewJavaAndWebApplicationsShouldHotHaveAMainMethod(),
 
 		// Or Rules

--- a/internal/services/engines/java/rules.go
+++ b/internal/services/engines/java/rules.go
@@ -73,6 +73,7 @@ func rules() []engine.Rule {
 		and.NewJavaAndGetSIMOperatorName(),
 		and.NewJavaAndQueryDatabaseOfSMSContacts(),
 		and.NewJavaAndPotentialPathTraversal(),
+		and.NewJakartaAndPotentialPathTraversal(),
 		and.NewJavaAndPotentialPathTraversalUsingScalaAPI(),
 		and.NewJavaAndSMTPHeaderInjection(),
 		and.NewJavaAndInsecureSMTPSSLConnection(),

--- a/internal/services/engines/rules_test.go
+++ b/internal/services/engines/rules_test.go
@@ -67,7 +67,7 @@ func TestGetRules(t *testing.T) {
 		{
 			engine:             "Java",
 			manager:            java.NewRules(),
-			expectedTotalRules: 185,
+			expectedTotalRules: 189,
 		},
 		{
 			engine:             "Dart",


### PR DESCRIPTION
In the transition through Eclipse Foundation, the package has changed to `jakarta` instead of `javax`


I need help to create unit tests for each new method. Could you help me with that?

Ref: https://eclipse-foundation.blog/2020/12/08/jakarta-ee-9-delivers-the-big-bang/
