### PR TITLE
ci: fix workflows not running on pull requests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: Build
-on: [ "push" ]
+on: [ "pull_request" ]
 jobs:
   build:
     permissions:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: Coverage
-on: [ "push" ]
+on: [ "pull_request" ]
 jobs:
   coverage:
     permissions:

--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: DCO Validator
-on: [ "push" ]
+on: [ "pull_request" ]
 
 jobs:
   dco-gpg-validator:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,7 +14,7 @@
 
 name: e2e
 
-on: ["push"]
+on: ["pull_request"]
 
 jobs:
   e2e-cli:

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: License
-on: [ "push" ]
+on: [ "pull_request" ]
 jobs:
   license:
     permissions:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: Lint
-on: [ "push" ]
+on: [ "pull_request" ]
 jobs:
   lint:
     permissions:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: Security
-on: [ "push" ]
+on: [ "pull_request" ]
 jobs:
   security:
     permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: Test
-on: [ "push" ]
+on: [ "pull_request" ]
 jobs:
   test:
     permissions:


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
This commit change the workflows to run only on pull requests instead on
push. With this change pull requests from contributors outside the ZupIT
organization will run.

Signed-off-by: Matheus Alcantara <matheusssilv97@gmail.com>


**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
