### PR TITLE
analyzer: improve performance to execute tools on Docker

### DIFF
--- a/internal/entities/workdir/workdir.go
+++ b/internal/entities/workdir/workdir.go
@@ -89,8 +89,10 @@ func (w *WorkDir) Type() string {
 	return ""
 }
 
+// LanguagePaths returns a map of language and paths that should be analysed.
+//
 //nolint
-func (w *WorkDir) Map() map[languages.Language][]string {
+func (w *WorkDir) LanguagePaths() map[languages.Language][]string {
 	return map[languages.Language][]string{
 		languages.Go:         w.Go,
 		languages.CSharp:     w.CSharp,
@@ -112,8 +114,12 @@ func (w *WorkDir) Map() map[languages.Language][]string {
 	}
 }
 
-func (w *WorkDir) GetArrayByLanguage(language languages.Language) []string {
-	allPaths := w.Map()[language]
+// PathsOfLanguage return the paths of language that should be analyzed.
+//
+// Return the paths configured if has at least one, otherwise return an
+// slice with an empty path string.
+func (w *WorkDir) PathsOfLanguage(language languages.Language) []string {
+	allPaths := w.LanguagePaths()[language]
 	if len(allPaths) > 0 {
 		return allPaths
 	}

--- a/internal/entities/workdir/workdir_test.go
+++ b/internal/entities/workdir/workdir_test.go
@@ -57,7 +57,7 @@ func TestType(t *testing.T) {
 func TestMap(t *testing.T) {
 	t.Run("should success return a new map of workdir", func(t *testing.T) {
 		workDir := &WorkDir{}
-		assert.NotEmpty(t, workDir.Map())
+		assert.NotEmpty(t, workDir.LanguagePaths())
 	})
 }
 
@@ -66,6 +66,6 @@ func TestGetArrayByLanguage(t *testing.T) {
 		workDir := &WorkDir{
 			JavaScript: []string{"frontend"},
 		}
-		assert.NotEmpty(t, workDir.GetArrayByLanguage(languages.Javascript))
+		assert.NotEmpty(t, workDir.PathsOfLanguage(languages.Javascript))
 	})
 }

--- a/internal/services/docker/docker_api.go
+++ b/internal/services/docker/docker_api.go
@@ -24,7 +24,6 @@ import (
 	"io/ioutil"
 	"strconv"
 	"strings"
-	"time"
 
 	enumErrors "github.com/ZupIT/horusec/internal/enums/errors"
 
@@ -192,11 +191,12 @@ func (d *API) executeCRDContainer(imageNameWithTag, cmd string) (containerOutput
 	}
 
 	containerOutput, err = d.readContainer(containerID)
+	if err != nil {
+		return "", err
+	}
 	d.loggerAPIStatus(messages.MsgDebugDockerAPIContainerRead, imageNameWithTag)
-	const maxTimeWaitToRemoveContainer = 5
-	time.Sleep(maxTimeWaitToRemoveContainer * time.Second)
 	d.removeContainer(containerID)
-	return containerOutput, err
+	return containerOutput, nil
 }
 
 func (d *API) removeContainer(containerID string) {

--- a/internal/usecases/cli/cli.go
+++ b/internal/usecases/cli/cli.go
@@ -226,7 +226,7 @@ func (au *UseCases) validateWorkDir(workDir *workdir.WorkDir, projectPath string
 		if workDir == nil {
 			return errors.New(messages.MsgErrorParseStringToWorkDir)
 		}
-		for _, pathsByLanguage := range workDir.Map() {
+		for _, pathsByLanguage := range workDir.LanguagePaths() {
 			for _, projectSubPath := range pathsByLanguage {
 				err := au.validateIfExistPathInProjectToWorkDir(projectPath, projectSubPath)
 				if err != nil {


### PR DESCRIPTION
Previously some tools that we execute on Docker were running
synchronously. This commit fix this issue to execute all tools and
analysis in parallel. A benchmark was made using the Go examples
directory.

Before change:
goos: linux
goarch: amd64
pkg: github.com/ZupIT/horusec/internal/controllers/analyzer
cpu: Intel(R) Core(TM) i5-7200U CPU @ 2.50GHz
BenchmarkAnalyzerAnalyze
BenchmarkAnalyzerAnalyze-4                 1        33251799589 ns/op        4095008 B/op      20445 allocs/op
ok      github.com/ZupIT/horusec/internal/controllers/analyzer  33.305s

After change:
goos: linux
goarch: amd64
pkg: github.com/ZupIT/horusec/internal/controllers/analyzer
cpu: Intel(R) Core(TM) i5-7200U CPU @ 2.50GHz
BenchmarkAnalyzerAnalyze
BenchmarkAnalyzerAnalyze-4                 1        17626114733 ns/op        4089352 B/op      19347 allocs/op
ok      github.com/ZupIT/horusec/internal/controllers/analyzer  17.677s

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
