### PR TITLE
hotfix/ignore semver validation goreleaser

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -75,7 +75,7 @@ jobs:
           args: release --snapshot --skip-publish
         env:
           COSIGN_PWD: ${{ secrets.COSIGN_PWD }}
-          GORELEASER_CURRENT_TAG: alpha
+          GORELEASER_CURRENT_TAG: v0.0.0-alpha
 
       - name: Update alpha release
         uses: meeDamian/github-release@2.0


### PR DESCRIPTION
Goreleaser no longer ignores semver validation on snapshot mode, added generic alpha version to fix the issue.

https://goreleaser.com/deprecations/#skipping-semver-validations

Signed-off-by: nathanmartinszup <nathan.martins@zup.com.br>