### PR TITLE
all: remove usage of io/ioutil package

### DIFF
--- a/cmd/app/generate/generate_test.go
+++ b/cmd/app/generate/generate_test.go
@@ -17,7 +17,7 @@ package generate
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -55,7 +55,7 @@ func TestGenerate_CreateCobraCmd(t *testing.T) {
 		defer func() {
 			_ = file.Close()
 		}()
-		fileBytes, _ := ioutil.ReadAll(file)
+		fileBytes, _ := io.ReadAll(file)
 		assert.Contains(t, string(fileBytes), fmt.Sprintf("\"%s\": 600", strcase.ToLowerCamel(strcase.ToSnake(config.EnvTimeoutInSecondsAnalysis))))
 	})
 	t.Run("Should update file already exists with default configuration", func(t *testing.T) {
@@ -74,7 +74,7 @@ func TestGenerate_CreateCobraCmd(t *testing.T) {
 		_ = fileExisting.Close()
 		fileExisting, err = os.Open(configs.ConfigFilePath)
 		assert.NoError(t, err)
-		fileExistingBytes, err := ioutil.ReadAll(fileExisting)
+		fileExistingBytes, err := io.ReadAll(fileExisting)
 		assert.NoError(t, err)
 		assert.Equal(t, "{}", string(fileExistingBytes))
 
@@ -93,7 +93,7 @@ func TestGenerate_CreateCobraCmd(t *testing.T) {
 
 		// Check content on file created
 		file, _ := os.Open(configs.ConfigFilePath)
-		fileBytes, _ := ioutil.ReadAll(file)
+		fileBytes, _ := io.ReadAll(file)
 		assert.NotEmpty(t, string(fileBytes))
 		assert.NotEqual(t, "{}", string(fileBytes))
 		assert.Contains(t, string(fileBytes), fmt.Sprintf("\"%s\": 600", strcase.ToLowerCamel(strcase.ToSnake(config.EnvTimeoutInSecondsAnalysis))))

--- a/cmd/app/start/start_test.go
+++ b/cmd/app/start/start_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -376,7 +375,7 @@ func TestStartCommand_Execute(t *testing.T) {
 		assert.Contains(t, output, "YOUR ANALYSIS HAD FINISHED WITHOUT ANY VULNERABILITY!")
 		assert.Contains(t, output, "{HORUSEC_CLI} Horusec not show info vulnerabilities in this analysis")
 
-		bytesFile, err := ioutil.ReadFile("./tmp-json.json")
+		bytesFile, err := os.ReadFile("./tmp-json.json")
 		assert.NoError(t, err)
 		bytesFileString := string(bytesFile)
 		assert.Contains(t, bytesFileString, "\"analysisVulnerabilities\": null")
@@ -536,7 +535,7 @@ func TestStartCommand_Execute(t *testing.T) {
 		assert.Contains(t, output, "YOUR ANALYSIS HAD FINISHED WITHOUT ANY VULNERABILITY!")
 		assert.Contains(t, output, "{HORUSEC_CLI} Horusec not show info vulnerabilities in this analysis")
 
-		bytesFile, err := ioutil.ReadFile("./tmp-sonarqube.json")
+		bytesFile, err := os.ReadFile("./tmp-sonarqube.json")
 		assert.NoError(t, err)
 		bytesFileString := string(bytesFile)
 		assert.Contains(t, bytesFileString, "\"issues\": []")

--- a/internal/controllers/analyzer/analyzer_test.go
+++ b/internal/controllers/analyzer/analyzer_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -108,11 +107,11 @@ func TestAnalyzer_AnalysisDirectory(t *testing.T) {
 		dockerMocker := &dockerClient.Mock{}
 		dockerMocker.On("CreateLanguageAnalysisContainer").Return("", nil)
 		dockerMocker.On("ImageList").Return([]types.ImageSummary{{}}, nil)
-		dockerMocker.On("ImagePull").Return(ioutil.NopCloser(bytes.NewReader([]byte(""))), nil)
+		dockerMocker.On("ImagePull").Return(io.NopCloser(bytes.NewReader([]byte(""))), nil)
 		dockerMocker.On("ContainerCreate").Return(container.ContainerCreateCreatedBody{}, nil)
 		dockerMocker.On("ContainerStart").Return(nil)
 		dockerMocker.On("ContainerWait").Return(container.ContainerWaitOKBody{}, nil)
-		dockerMocker.On("ContainerLogs").Return(ioutil.NopCloser(bytes.NewReader([]byte(""))), nil)
+		dockerMocker.On("ContainerLogs").Return(io.NopCloser(bytes.NewReader([]byte(""))), nil)
 		dockerMocker.On("ContainerRemove").Return(nil)
 		dockerMocker.On("ContainerList").Return([]types.Container{{ID: "test"}}, nil)
 
@@ -166,11 +165,11 @@ func TestAnalyzer_AnalysisDirectory(t *testing.T) {
 		dockerMocker := &dockerClient.Mock{}
 		dockerMocker.On("CreateLanguageAnalysisContainer").Return("", nil)
 		dockerMocker.On("ImageList").Return([]types.ImageSummary{{}}, nil)
-		dockerMocker.On("ImagePull").Return(ioutil.NopCloser(bytes.NewReader([]byte(""))), nil)
+		dockerMocker.On("ImagePull").Return(io.NopCloser(bytes.NewReader([]byte(""))), nil)
 		dockerMocker.On("ContainerCreate").Return(container.ContainerCreateCreatedBody{}, nil)
 		dockerMocker.On("ContainerStart").Return(nil)
 		dockerMocker.On("ContainerWait").Return(container.ContainerWaitOKBody{}, nil)
-		dockerMocker.On("ContainerLogs").Return(ioutil.NopCloser(bytes.NewReader([]byte(""))), nil)
+		dockerMocker.On("ContainerLogs").Return(io.NopCloser(bytes.NewReader([]byte(""))), nil)
 		dockerMocker.On("ContainerRemove").Return(nil)
 		dockerMocker.On("ContainerList").Return([]types.Container{{ID: "test"}}, nil)
 
@@ -209,11 +208,11 @@ func TestAnalyzer_AnalysisDirectory(t *testing.T) {
 		dockerMocker := &dockerClient.Mock{}
 		dockerMocker.On("CreateLanguageAnalysisContainer").Return("", nil)
 		dockerMocker.On("ImageList").Return([]types.ImageSummary{{}}, nil)
-		dockerMocker.On("ImagePull").Return(ioutil.NopCloser(bytes.NewReader([]byte(""))), nil)
+		dockerMocker.On("ImagePull").Return(io.NopCloser(bytes.NewReader([]byte(""))), nil)
 		dockerMocker.On("ContainerCreate").Return(container.ContainerCreateCreatedBody{}, nil)
 		dockerMocker.On("ContainerStart").Return(nil)
 		dockerMocker.On("ContainerWait").Return(container.ContainerWaitOKBody{}, nil)
-		dockerMocker.On("ContainerLogs").Return(ioutil.NopCloser(bytes.NewReader([]byte(""))), nil)
+		dockerMocker.On("ContainerLogs").Return(io.NopCloser(bytes.NewReader([]byte(""))), nil)
 		dockerMocker.On("ContainerRemove").Return(nil)
 		dockerMocker.On("ContainerList").Return([]types.Container{{ID: "test"}}, nil)
 

--- a/internal/services/custom_rules/service.go
+++ b/internal/services/custom_rules/service.go
@@ -17,7 +17,7 @@ package customrules
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
@@ -82,7 +82,7 @@ func (s *Service) openCustomRulesJSONFile() (customRules []customRulesEntities.C
 		return nil, err
 	}
 
-	byteValue, _ := ioutil.ReadAll(file)
+	byteValue, _ := io.ReadAll(file)
 	return customRules, json.Unmarshal(byteValue, &customRules)
 }
 

--- a/internal/services/docker/client/docker_config_test.go
+++ b/internal/services/docker/client/docker_config_test.go
@@ -15,7 +15,7 @@
 package client
 
 import (
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -54,7 +54,7 @@ func TestMock(t *testing.T) {
 	t.Run("Should return expected data to ContainerLogs", func(t *testing.T) {
 		m := &Mock{}
 
-		m.On("ContainerLogs").Return(ioutil.NopCloser(strings.NewReader("some text")), nil)
+		m.On("ContainerLogs").Return(io.NopCloser(strings.NewReader("some text")), nil)
 		_, err := m.ContainerLogs(nil, "", dockerTypes.ContainerLogsOptions{})
 		assert.NoError(t, err)
 	})
@@ -72,7 +72,7 @@ func TestMock(t *testing.T) {
 	})
 	t.Run("Should return expected data to ImagePull", func(t *testing.T) {
 		m := &Mock{}
-		m.On("ImagePull").Return(ioutil.NopCloser(strings.NewReader("some text")), nil)
+		m.On("ImagePull").Return(io.NopCloser(strings.NewReader("some text")), nil)
 		_, err := m.ImagePull(nil, "", dockerTypes.ImagePullOptions{})
 		assert.NoError(t, err)
 	})

--- a/internal/services/docker/docker_api.go
+++ b/internal/services/docker/docker_api.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strconv"
 	"strings"
 
@@ -144,7 +143,7 @@ func (d *API) setPullOptions() types.ImagePullOptions {
 }
 
 func (d *API) readPullReader(imageWithTagAndRegistry string, reader io.ReadCloser) error {
-	readResult, err := ioutil.ReadAll(reader)
+	readResult, err := io.ReadAll(reader)
 	if err != nil {
 		logger.LogErrorWithLevel(messages.MsgErrorDockerPullImage, err)
 		logger.LogDebugWithLevel(string(readResult))
@@ -245,7 +244,7 @@ func (d *API) readContainer(containerID string) (string, error) {
 }
 
 func (d *API) getOutputString(containerOutPut io.Reader) (string, error) {
-	containerOutPutBytes, err := ioutil.ReadAll(containerOutPut)
+	containerOutPutBytes, err := io.ReadAll(containerOutPut)
 	if err != nil {
 		return "", err
 	}

--- a/internal/services/docker/docker_api_test.go
+++ b/internal/services/docker/docker_api_test.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -116,7 +116,7 @@ func TestDockerAPI_CreateLanguageAnalysisContainer(t *testing.T) {
 	t.Run("Should return error when pull new image", func(t *testing.T) {
 		dockerAPIClient := &client.Mock{}
 		dockerAPIClient.On("ImageList").Return([]types.ImageSummary{}, nil)
-		dockerAPIClient.On("ImagePull").Return(ioutil.NopCloser(bytes.NewReader([]byte("Some data"))), ErrGeneric)
+		dockerAPIClient.On("ImagePull").Return(io.NopCloser(bytes.NewReader([]byte("Some data"))), ErrGeneric)
 
 		api := New(dockerAPIClient, &cliConfig.Config{}, uuid.New())
 
@@ -132,7 +132,7 @@ func TestDockerAPI_CreateLanguageAnalysisContainer(t *testing.T) {
 
 		dockerAPIClient := &client.Mock{}
 		dockerAPIClient.On("ImageList").Return([]types.ImageSummary{{ID: uuid.New().String()}}, nil)
-		dockerAPIClient.On("ImagePull").Return(ioutil.NopCloser(bytes.NewReader([]byte("Some data"))), nil)
+		dockerAPIClient.On("ImagePull").Return(io.NopCloser(bytes.NewReader([]byte("Some data"))), nil)
 		dockerAPIClient.On("ContainerCreate").Return(container.ContainerCreateCreatedBody{ID: uuid.New().String()}, ErrGeneric)
 
 		api := New(dockerAPIClient, &cliConfig.Config{}, uuid.New())
@@ -152,7 +152,7 @@ func TestDockerAPI_CreateLanguageAnalysisContainer(t *testing.T) {
 
 		dockerAPIClient := &client.Mock{}
 		dockerAPIClient.On("ImageList").Return([]types.ImageSummary{{ID: uuid.New().String()}}, nil)
-		dockerAPIClient.On("ImagePull").Return(ioutil.NopCloser(bytes.NewReader([]byte("Some data"))), nil)
+		dockerAPIClient.On("ImagePull").Return(io.NopCloser(bytes.NewReader([]byte("Some data"))), nil)
 		dockerAPIClient.On("ContainerCreate").Return(container.ContainerCreateCreatedBody{ID: uuid.New().String()}, nil)
 		dockerAPIClient.On("ContainerStart").Return(ErrGeneric)
 
@@ -173,7 +173,7 @@ func TestDockerAPI_CreateLanguageAnalysisContainer(t *testing.T) {
 
 		dockerAPIClient := &client.Mock{}
 		dockerAPIClient.On("ImageList").Return([]types.ImageSummary{{ID: uuid.New().String()}}, nil)
-		dockerAPIClient.On("ImagePull").Return(ioutil.NopCloser(bytes.NewReader([]byte("Some data"))), nil)
+		dockerAPIClient.On("ImagePull").Return(io.NopCloser(bytes.NewReader([]byte("Some data"))), nil)
 		dockerAPIClient.On("ContainerCreate").Return(container.ContainerCreateCreatedBody{ID: uuid.New().String()}, nil)
 		dockerAPIClient.On("ContainerStart").Return(nil)
 		dockerAPIClient.On("ContainerWait").Return(container.ContainerWaitOKBody{
@@ -201,11 +201,11 @@ func TestDockerAPI_CreateLanguageAnalysisContainer(t *testing.T) {
 
 		dockerAPIClient := &client.Mock{}
 		dockerAPIClient.On("ImageList").Return([]types.ImageSummary{{ID: uuid.New().String()}}, nil)
-		dockerAPIClient.On("ImagePull").Return(ioutil.NopCloser(bytes.NewReader([]byte("Some data"))), nil)
+		dockerAPIClient.On("ImagePull").Return(io.NopCloser(bytes.NewReader([]byte("Some data"))), nil)
 		dockerAPIClient.On("ContainerCreate").Return(container.ContainerCreateCreatedBody{ID: uuid.New().String()}, nil)
 		dockerAPIClient.On("ContainerStart").Return(nil)
 		dockerAPIClient.On("ContainerWait").Return(container.ContainerWaitOKBody{}, nil)
-		dockerAPIClient.On("ContainerLogs").Return(ioutil.NopCloser(bytes.NewReader(nil)), ErrGeneric)
+		dockerAPIClient.On("ContainerLogs").Return(io.NopCloser(bytes.NewReader(nil)), ErrGeneric)
 		dockerAPIClient.On("ContainerRemove").Return(nil)
 
 		api := New(dockerAPIClient, &cliConfig.Config{}, uuid.New())
@@ -226,11 +226,11 @@ func TestDockerAPI_CreateLanguageAnalysisContainer(t *testing.T) {
 
 		dockerAPIClient := &client.Mock{}
 		dockerAPIClient.On("ImageList").Return([]types.ImageSummary{{ID: uuid.New().String()}}, nil)
-		dockerAPIClient.On("ImagePull").Return(ioutil.NopCloser(bytes.NewReader([]byte("Some data"))), nil)
+		dockerAPIClient.On("ImagePull").Return(io.NopCloser(bytes.NewReader([]byte("Some data"))), nil)
 		dockerAPIClient.On("ContainerCreate").Return(container.ContainerCreateCreatedBody{ID: uuid.New().String()}, nil)
 		dockerAPIClient.On("ContainerStart").Return(nil)
 		dockerAPIClient.On("ContainerWait").Return(container.ContainerWaitOKBody{}, nil)
-		dockerAPIClient.On("ContainerLogs").Return(ioutil.NopCloser(bytes.NewReader([]byte("{}"))), nil)
+		dockerAPIClient.On("ContainerLogs").Return(io.NopCloser(bytes.NewReader([]byte("{}"))), nil)
 		dockerAPIClient.On("ContainerRemove").Return(nil)
 
 		api := New(dockerAPIClient, &cliConfig.Config{}, uuid.New())

--- a/internal/services/horusec_api/horus_api.go
+++ b/internal/services/horusec_api/horus_api.go
@@ -19,8 +19,8 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 
 	"github.com/google/uuid"
 
@@ -165,7 +165,7 @@ func (s *Service) setTLSConfig() (*tls.Config, error) {
 		InsecureSkipVerify: s.config.CertInsecureSkipVerify, // nolint:gosec // skip dynamic
 	}
 	if s.config.CertPath != "" {
-		caCert, err := ioutil.ReadFile(s.config.CertPath)
+		caCert, err := os.ReadFile(s.config.CertPath)
 		if err != nil {
 			return tlsConfig, err
 		}

--- a/internal/services/horusec_api/horus_api_test.go
+++ b/internal/services/horusec_api/horus_api_test.go
@@ -17,7 +17,7 @@ package horusecapi
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -69,7 +69,7 @@ func TestSendAnalysis(t *testing.T) {
 			Status:    enumHorusec.Running,
 		}
 
-		readCloser := ioutil.NopCloser(strings.NewReader("test"))
+		readCloser := io.NopCloser(strings.NewReader("test"))
 
 		response := &http.Response{
 			StatusCode: 401,
@@ -183,7 +183,7 @@ func TestService_GetAnalysis(t *testing.T) {
 			Status:  http.StatusText(http.StatusOK),
 			Content: analysisContent,
 		}
-		body := ioutil.NopCloser(bytes.NewReader(entity.ToBytes()))
+		body := io.NopCloser(bytes.NewReader(entity.ToBytes()))
 
 		httpMock := &request.Mock{}
 		httpMock.On("NewHTTPRequest").Return(&http.Request{}, nil)
@@ -203,7 +203,7 @@ func TestService_GetAnalysis(t *testing.T) {
 	})
 	t.Run("should get analysis with error because response is 400", func(t *testing.T) {
 		entity := mock.CreateAnalysisMock()
-		body := ioutil.NopCloser(bytes.NewReader([]byte("uuid not valid in path")))
+		body := io.NopCloser(bytes.NewReader([]byte("uuid not valid in path")))
 
 		httpMock := &request.Mock{}
 		httpMock.On("NewHTTPRequest").Return(&http.Request{}, nil)


### PR DESCRIPTION
Since Go 1.16 the io/ioutil package was deprecated, so this commit
change the usage of io/ioutil functions to io and os packages.
https://golang.org/doc/go1.16#ioutil

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
