### PR TITLE
cli: fix parse of custom-rule-path flag

### DIFF
--- a/cmd/app/start/start.go
+++ b/cmd/app/start/start.go
@@ -248,12 +248,11 @@ func (s *Start) CreateStartCommand() *cobra.Command {
 			"Used to pass project path in host when running horusec cli inside a container.",
 		)
 
-	// TODO: This flag may have a bug
 	startCmd.PersistentFlags().
 		StringVarP(
-			&s.configs.ContainerBindProjectPath,
+			&s.configs.CustomRulesPath,
 			"custom-rules-path", "c",
-			s.configs.ContainerBindProjectPath,
+			s.configs.CustomRulesPath,
 			"Used to pass the path to the horusec custom rules file. Example: -c=\"./horusec/horusec-custom-rules.json\".",
 		)
 


### PR DESCRIPTION
Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
