### PR TITLE
renovate: change commit message template

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,7 @@
   "schedule": [
     "every weekend"
   ],
-  "commitBody": "Signed-off-by: Renovate Bot <bot@renovateapp.com>"
+  "commitBody": "Signed-off-by: Renovate Bot <bot@renovateapp.com>",
+  "commitMessagePrefix": "deps:",
+  "commitMessageAction": "update"
 }


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
Change commit message template of renovate bot to:
deps: update \<old\> to \<new\>

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>


**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
