### PR TITLE
config: fix flags not overriding config file and env variables

### DIFF
--- a/cmd/app/start/start.go
+++ b/cmd/app/start/start.go
@@ -77,8 +77,14 @@ func NewStartCommand(configs *config.Config) *Start {
 	}
 }
 
-// nolint:funlen,lll // method is not necessary funlen
+// CreateStartCommand load the config values from config file
+// and environment variable and create the cobra command to parse
+// command line flags.
+//
+// nolint:funlen,lll
 func (s *Start) CreateStartCommand() *cobra.Command {
+	s.configs.MergeFromConfigFile().MergeFromEnvironmentVariables()
+
 	startCmd := &cobra.Command{
 		Use:     "start",
 		Short:   "Start horusec-cli",

--- a/cmd/app/start/start_test.go
+++ b/cmd/app/start/start_test.go
@@ -356,7 +356,7 @@ func TestStartCommand_Execute(t *testing.T) {
 		cobraCmd.SetArgs([]string{"-p", "./", "-o", "json", "-O", "./tmp-json.json"})
 
 		cobra.OnInitialize(func() {
-			assert.NoError(t, configs.Normalize().Eval(), "Expected nil error to eval config")
+			assert.NoError(t, configs.PreRun(nil, nil), "Expected nil error to pre run config")
 		})
 
 		assert.NoError(t, cobraCmd.Execute())
@@ -414,7 +414,7 @@ func TestStartCommand_Execute(t *testing.T) {
 		cobraCmd.SetArgs([]string{"-p", "./", "--information-severity", "true"})
 
 		cobra.OnInitialize(func() {
-			require.Nil(t, configs.Normalize().Eval(), "Expected nil error to eval config")
+			require.Nil(t, configs.PreRun(nil, nil), "Expected nil error to pre run config")
 		})
 
 		assert.NoError(t, cobraCmd.Execute())
@@ -465,7 +465,7 @@ func TestStartCommand_Execute(t *testing.T) {
 		cobraCmd.SetArgs([]string{"-p", "./", "-u", "https://google.com", "-a", uuid.NewString()})
 
 		cobra.OnInitialize(func() {
-			require.Nil(t, configs.Normalize().Eval(), "Expected nil error to eval config")
+			require.Nil(t, configs.PreRun(nil, nil), "Expected nil error to pre run config")
 		})
 
 		assert.NoError(t, cobraCmd.Execute())
@@ -516,7 +516,7 @@ func TestStartCommand_Execute(t *testing.T) {
 		cobraCmd.SetArgs([]string{"-p", "./", "-o", "sonarqube", "-O", "./tmp-sonarqube.json"})
 
 		cobra.OnInitialize(func() {
-			require.Nil(t, configs.Normalize().Eval(), "Expected nil error to eval config")
+			require.Nil(t, configs.PreRun(nil, nil), "Expected nil error to pre run config")
 		})
 
 		assert.NoError(t, cobraCmd.Execute())
@@ -581,7 +581,7 @@ func TestStartCommand_Execute(t *testing.T) {
 		cobraCmd.SetArgs([]string{"-p", dstProject, "-s", "CRITICAL, LOW"})
 
 		cobra.OnInitialize(func() {
-			require.Nil(t, configs.Normalize().Eval(), "Expected nil error to eval config")
+			require.Nil(t, configs.PreRun(nil, nil), "Expected nil error to pre run config")
 		})
 
 		assert.NoError(t, cobraCmd.Execute())
@@ -639,7 +639,7 @@ func TestStartCommand_Execute(t *testing.T) {
 		cobraCmd.SetArgs([]string{"-p", dstProject})
 
 		cobra.OnInitialize(func() {
-			require.Nil(t, configs.Normalize().Eval(), "Expected nil error to eval config")
+			require.Nil(t, configs.PreRun(nil, nil), "Expected nil error to pre run config")
 		})
 
 		assert.NoError(t, cobraCmd.Execute())

--- a/config/config.go
+++ b/config/config.go
@@ -333,26 +333,20 @@ func (c *Config) MergeFromEnvironmentVariables() *Config {
 	return c
 }
 
-// PreRun is a hook that load config values from config
-// file/environment variables, merge them with default values and
-// command line args and create the log file.
-//
+// PreRun is a hook that normalize config values and create the log file.
 // This hook is used as a PreRun on cobra commands.
 func (c *Config) PreRun(_ *cobra.Command, _ []string) error {
-	return c.MergeFromConfigFile().
-		MergeFromEnvironmentVariables().
-		Normalize().
-		Eval()
+	return c.Normalize().configureLogger()
 }
 
-// Eval evaluate user config input
-func (c *Config) Eval() error {
+// configureLogger create the log file and configure the log output.
+func (c *Config) configureLogger() error {
 	log, err := os.OpenFile(c.LogFilePath, os.O_CREATE|os.O_RDWR, os.ModePerm)
 	if err != nil {
 		return err
 	}
 	logger.LogSetOutput(log, os.Stdout)
-	logger.LogInfo("Set log file to " + log.Name())
+	logger.LogDebugWithLevel("Set log file to " + log.Name())
 	return nil
 }
 
@@ -412,6 +406,7 @@ func (c *Config) ToMapLowerCase() map[string]interface{} {
 	}
 }
 
+// Normalize transforms relative paths of files to absolute.
 func (c *Config) Normalize() *Config {
 	if c.JSONOutputFilePath != "" {
 		c.JSONOutputFilePath, _ = filepath.Abs(c.JSONOutputFilePath)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -414,7 +414,7 @@ func TestConfig_ToBytes(t *testing.T) {
 func TestSetLogOutput(t *testing.T) {
 	t.Run("Should success when log path is empty", func(t *testing.T) {
 		config := config.New()
-		err := config.Eval()
+		err := config.PreRun(nil, nil)
 		assert.NoError(t, err)
 	})
 	t.Run("Should success when log path is valid", func(t *testing.T) {
@@ -423,7 +423,7 @@ func TestSetLogOutput(t *testing.T) {
 
 		config := config.New()
 		config.LogFilePath = file.Name()
-		err = config.Eval()
+		err = config.PreRun(nil, nil)
 		assert.NoError(t, err)
 	})
 

--- a/internal/controllers/language_detect/language_detect.go
+++ b/internal/controllers/language_detect/language_detect.go
@@ -64,7 +64,6 @@ func (ld *LanguageDetect) Detect(directory string) ([]languages.Language, error)
 func (ld *LanguageDetect) getLanguages(directory string) (languagesFound []string, err error) {
 	filesToSkip, languagesFound, err := ld.walkInPathAndReturnTotalToSkip(directory)
 	if filesToSkip > 0 {
-		print("\n")
 		msg := strings.ReplaceAll(messages.MsgWarnTotalFolderOrFileWasIgnored, "{{0}}", strconv.Itoa(filesToSkip))
 		logger.LogWarnWithLevel(msg)
 	}


### PR DESCRIPTION
Previously we are parsing the config values in follow order:
command line flags -> config file -> env variables.
This commit fix the order to parse in follow order:
config file -> env variables -> command line flags.
Since the func passed to PreRun field on cobra command is executed after
the command line parsing, a change was made on CreateStartCommand method
to call the config methods to load the values from config file and
environment variables before creating the cobra command, so when the
PreRun is execute the only thing that is needed to do is normalize the
values and setup the log configuration.

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
