### PR TITLE
trivy: fix trivy parsing error

### DIFF
--- a/internal/services/formatters/generic/trivy/config.go
+++ b/internal/services/formatters/generic/trivy/config.go
@@ -22,12 +22,12 @@ func (c Cmd) ToString() string {
 
 const CmdFs Cmd = `
 		{{WORK_DIR}}
-		TRIVY_NEW_JSON_SCHEMA=true trivy fs  -f json -o result.json ./ &> /dev/null
-		cat result.json
+		TRIVY_NEW_JSON_SCHEMA=true trivy fs  -f json -o resultFs.json ./ &> /dev/null
+		cat resultFs.json
   `
 
 const CmdConfig Cmd = `
 		{{WORK_DIR}}
-		TRIVY_NEW_JSON_SCHEMA=true trivy config -f json -o result.json ./ &> /dev/null 
-		cat result.json
+		TRIVY_NEW_JSON_SCHEMA=true trivy config -f json -o resultConfig.json ./ &> /dev/null 
+		cat resultConfig.json
   `


### PR DESCRIPTION
Trivy docker container was shared for both checks and both commands were writing to same file amending 2 jsons incorrectly, this commit change it to different files to solve this problem

Signed-off-by: Ian Cardoso <ian.cardoso@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
