### PR TITLE
workflows: adding stand alone binaries

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -71,6 +71,10 @@ jobs:
         env:
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PWD }}
 
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date "+%a %b %d %H:%M:%S %Y")"
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
@@ -80,6 +84,62 @@ jobs:
         env:
           COSIGN_PWD: ${{ secrets.COSIGN_PWD }}
           GORELEASER_CURRENT_TAG: v0.0.0-alpha
+          CURRENT_DATE: ${{ steps.date.outputs.date }}
+          CLI_VERSION: alpha
+
+      - name: Build stand alone cli
+        run: |
+          CGO_ENABLED=0 GOOS=linux GOARCH=386 go build -ldflags \
+          "-X 'github.com/ZupIT/horusec/config/dist.standAlone=true' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Version=alpha' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Commit=${{ github.sha }}' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Date=${{ steps.date.outputs.date }}'" \
+          -o ./tmp/horusec_linux_x86_stand_alone  ./cmd/app/main.go
+
+          cosign sign-blob -key=$COSIGN_KEY_LOCATION \
+          -output=./tmp/horusec_linux_x86_stand_alone.sig ./tmp/horusec_linux_x86_stand_alone
+
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags \
+          "-X 'github.com/ZupIT/horusec/config/dist.standAlone=true' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Version=alpha' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Commit=${{ github.sha }}' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Date=${{ steps.date.outputs.date }}'" \
+          -o ./tmp/horusec_linux_x64_stand_alone  ./cmd/app/main.go
+
+          cosign sign-blob -key=$COSIGN_KEY_LOCATION \
+          -output=./tmp/horusec_linux_x64_stand_alone.sig ./tmp/horusec_linux_x64_stand_alone
+
+          CGO_ENABLED=0 GOOS=windows GOARCH=386 go build -ldflags \
+          "-X 'github.com/ZupIT/horusec/config/dist.standAlone=true' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Version=alpha' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Commit=${{ github.sha }}' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Date=${{ steps.date.outputs.date }}'" \
+          -o ./tmp/horusec_windows_x86_stand_alone.exe  ./cmd/app/main.go
+
+          cosign sign-blob -key=$COSIGN_KEY_LOCATION \
+          -output=./tmp/horusec_windows_x86_stand_alone.exe.sig ./tmp/horusec_windows_x86_stand_alone.exe
+
+          CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags \
+          "-X 'github.com/ZupIT/horusec/config/dist.standAlone=true' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Version=alpha' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Commit=${{ github.sha }}' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Date=${{ steps.date.outputs.date }}'" \
+          -o ./tmp/horusec_windows_x64_stand_alone.exe  ./cmd/app/main.go
+
+          cosign sign-blob -key=$COSIGN_KEY_LOCATION \
+          -output=./tmp/horusec_windows_x64_stand_alone.exe.sig ./tmp/horusec_windows_x64_stand_alone.exe
+
+          CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags \
+          "-X 'github.com/ZupIT/horusec/config/dist.standAlone=true' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Version=alpha' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Commit=${{ github.sha }}' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Date=${{ steps.date.outputs.date }}'" \
+          -o ./tmp/horusec_mac_x64_stand_alone  ./cmd/app/main.go
+
+          cosign sign-blob -key=$COSIGN_KEY_LOCATION \
+          -output=./tmp/horusec_mac_x64_stand_alone.sig ./tmp/horusec_mac_x64_stand_alone
+        env:
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PWD }}
 
       - name: Delete outdate release
         uses: dev-drprasad/delete-tag-and-release@v0.2.0
@@ -114,6 +174,16 @@ jobs:
             horusec_win_x64.exe.sig:./dist/horusec_windows_amd64/horusec.exe.sig
             horusec_win_x86.exe:./dist/horusec_windows_386/horusec.exe
             horusec_win_x86.exe.sig:./dist/horusec_windows_386/horusec.exe.sig
+            horusec_linux_x86_stand_alone:./tmp/horusec_linux_x86_stand_alone
+            horusec_linux_x86_stand_alone.sig:./tmp/horusec_linux_x86_stand_alone.sig
+            horusec_linux_x64_stand_alone:./tmp/horusec_linux_x64_stand_alone
+            horusec_linux_x64_stand_alone.sig:./tmp/horusec_linux_x64_stand_alone.sig
+            horusec_windows_x86_stand_alone.exe:./tmp/horusec_windows_x86_stand_alone.exe
+            horusec_windows_x86_stand_alone.exe.sig:./tmp/horusec_windows_x86_stand_alone.exe.sig
+            horusec_windows_x64_stand_alone.exe:./tmp/horusec_windows_x64_stand_alone.exe
+            horusec_windows_x64_stand_alone.exe.sig:./tmp/horusec_windows_x64_stand_alone.exe.sig
+            horusec_mac_x64_stand_alone:./tmp/horusec_mac_x64_stand_alone
+            horusec_mac_x64_stand_alone.sig:./tmp/horusec_mac_x64_stand_alone.sig
           body: |
             ## Docker images
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,64 @@ jobs:
           chmod +x /tmp/semver.sh
           /tmp/semver.sh -${{ github.event.inputs.releaseType }} ${{ github.event.repository.full_name }}
 
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date "+%a %b %d %H:%M:%S %Y")"
+
+      - name: Build stand alone cli
+        run: |
+          CGO_ENABLED=0 GOOS=linux GOARCH=386 go build -ldflags \
+          "-X 'github.com/ZupIT/horusec/config/dist.standAlone=true' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Version=${{ steps.updated-version.outputs.version }}' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Commit=${{ github.sha }}' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Date=${{ steps.date.outputs.date }}'" \
+          -o ./tmp/horusec_linux_x86_stand_alone  ./cmd/app/main.go
+
+          cosign sign-blob -key=$COSIGN_KEY_LOCATION \
+          -output=./tmp/horusec_linux_x86_stand_alone.sig ./tmp/horusec_linux_x86_stand_alone
+
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags \
+          "-X 'github.com/ZupIT/horusec/config/dist.standAlone=true' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Version=${{ steps.updated-version.outputs.version }}' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Commit=${{ github.sha }}' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Date=${{ steps.date.outputs.date }}'" \
+          -o ./tmp/horusec_linux_x64_stand_alone  ./cmd/app/main.go
+
+          cosign sign-blob -key=$COSIGN_KEY_LOCATION \
+          -output=./tmp/horusec_linux_x64_stand_alone.sig ./tmp/horusec_linux_x64_stand_alone
+
+          CGO_ENABLED=0 GOOS=windows GOARCH=386 go build -ldflags \
+          "-X 'github.com/ZupIT/horusec/config/dist.standAlone=true' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Version=${{ steps.updated-version.outputs.version }}' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Commit=${{ github.sha }}' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Date=${{ steps.date.outputs.date }}'" \
+          -o ./tmp/horusec_windows_x86_stand_alone.exe  ./cmd/app/main.go
+
+          cosign sign-blob -key=$COSIGN_KEY_LOCATION \
+          -output=./tmp/horusec_windows_x86_stand_alone.exe.sig ./tmp/horusec_windows_x86_stand_alone.exe
+
+          CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags \
+          "-X 'github.com/ZupIT/horusec/config/dist.standAlone=true' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Version=${{ steps.updated-version.outputs.version }}' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Commit=${{ github.sha }}' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Date=${{ steps.date.outputs.date }}'" \
+          -o ./tmp/horusec_windows_x64_stand_alone.exe  ./cmd/app/main.go
+
+          cosign sign-blob -key=$COSIGN_KEY_LOCATION \
+          -output=./tmp/horusec_windows_x64_stand_alone.exe.sig ./tmp/horusec_windows_x64_stand_alone.exe
+
+          CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags \
+          "-X 'github.com/ZupIT/horusec/config/dist.standAlone=true' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Version=${{ steps.updated-version.outputs.version }}' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Commit=${{ github.sha }}' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Date=${{ steps.date.outputs.date }}'" \
+          -o ./tmp/horusec_mac_x64_stand_alone  ./cmd/app/main.go
+
+          cosign sign-blob -key=$COSIGN_KEY_LOCATION \
+          -output=./tmp/horusec_mac_x64_stand_alone.sig ./tmp/horusec_mac_x64_stand_alone
+        env:
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PWD }}
+
       - name: Create tag
         run: |
           git tag ${{ steps.updated-version.outputs.version }}
@@ -80,6 +138,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COSIGN_PWD: ${{ secrets.COSIGN_PWD }}
           GORELEASER_CURRENT_TAG: ${{ steps.updated-version.outputs.version }}
+          CURRENT_DATE: ${{ steps.date.outputs.date }}
+          CLI_VERSION: ${{ steps.updated-version.outputs.version }}
 
       - name: Create release branch
         if: github.event.inputs.releaseType != 'p'

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -18,9 +18,9 @@ builds:
     env: [ CGO_ENABLED=0 ]
     main: ./cmd/app/main.go
     ldflags:
-      - -X github.com/ZupIT/horusec/config.version=v{{ .Version }}
-      - -X github.com/ZupIT/horusec/config.commit={{ .Commit }}
-      - -X github.com/ZupIT/horusec/config.date={{ .Date }}
+      - -X 'github.com/ZupIT/horusec/cmd/app/version.Version={{ .Env.CLI_VERSION }}'
+      - -X 'github.com/ZupIT/horusec/cmd/app/version.Commit={{ .Commit }}'
+      - -X 'github.com/ZupIT/horusec/cmd/app/version.Date={{ .Env.CURRENT_DATE }}'
     goos:
       - linux
       - windows
@@ -47,6 +47,16 @@ release:
   draft: true
   extra_files:
     - glob: deployments/cosign.pub
+    - glob: ./tmp/horusec_linux_x86_stand_alone
+    - glob: ./tmp/horusec_linux_x86_stand_alone.sig
+    - glob: ./tmp/horusec_linux_x64_stand_alone
+    - glob: ./tmp/horusec_linux_x64_stand_alone.sig
+    - glob: ./tmp/horusec_windows_x86_stand_alone.exe
+    - glob: ./tmp/horusec_windows_x86_stand_alone.exe.sig
+    - glob: ./tmp/horusec_windows_x64_stand_alone.exe
+    - glob: ./tmp/horusec_windows_x64_stand_alone.exe.sig
+    - glob: ./tmp/horusec_mac_x64_stand_alone
+    - glob: ./tmp/horusec_mac_x64_stand_alone.sig
 nfpms:
   - id: horusec
     package_name: horusec


### PR DESCRIPTION
Signed-off-by: nathanmartinszup <nathan.martins@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

Added stand alone binaries to the alpha and release workflows.
 I had to build manually the stand alone binaries cause they have a exclusive variable to set, that cant be on the gorelease file.
`-X 'github.com/ZupIT/horusec/config/dist.standAlone=true`. This pull request depends on (#659) that contains changes to show commit and date that the binarie was built.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
