### PR TITLE
version: improving the view of version command

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -72,7 +72,7 @@ horusec start -p="/home/user/projects/my-project"
 			`set user defined log file path instead of default`,
 		)
 
-	rootCmd.AddCommand(version.NewVersionCommand(cfg).CreateCobraCmd())
+	rootCmd.AddCommand(version.CreateCobraCmd())
 	rootCmd.AddCommand(startCmd.CreateStartCommand())
 	rootCmd.AddCommand(generateCmd.CreateCobraCmd())
 

--- a/cmd/app/version/version.go
+++ b/cmd/app/version/version.go
@@ -18,29 +18,31 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
-	"github.com/ZupIT/horusec/config"
+
 	"github.com/ZupIT/horusec/config/dist"
 )
 
-type Version struct {
-	config *config.Config
-}
+var (
+	Version = "{{VERSION_NOT_FOUND}}"
+	Commit  = "{{COMMIT_NOT_FOUND}}"
+	Date    = "{{DATE_NOT_FOUND}}"
+)
 
-func NewVersionCommand(cfg *config.Config) *Version {
-	return &Version{
-		config: cfg,
-	}
-}
-
-func (v *Version) CreateCobraCmd() *cobra.Command {
+func CreateCobraCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:     "version",
-		Short:   "Actual version installed of the horusec",
+		Short:   "Shows the current version of installed Horusec",
 		Example: "horusec version",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			logger.LogPrint(cmd.Short + " is: " + v.config.Version)
-			logger.LogPrint("dist: " + dist.GetVersion())
+			printVersionInfo()
 			return nil
 		},
 	}
+}
+
+func printVersionInfo() {
+	logger.LogPrint("Version:          " + Version)
+	logger.LogPrint("Git commit:       " + Commit)
+	logger.LogPrint("Built:            " + Date)
+	logger.LogPrint("Distribution:     " + dist.GetVersion())
 }

--- a/cmd/app/version/version_test.go
+++ b/cmd/app/version/version_test.go
@@ -19,24 +19,16 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
-
-	"github.com/ZupIT/horusec/config"
 )
 
 func TestVersionCommand_Execute(t *testing.T) {
-	cfg := config.New()
-
-	t.Run("Should execute command exec without error", func(t *testing.T) {
+	t.Run("should not panic when creating the version command", func(t *testing.T) {
 		assert.NotPanics(t, func() {
-			cobraCmd := NewVersionCommand(cfg)
-			cobraCmd.CreateCobraCmd()
+			CreateCobraCmd()
 		})
 	})
-	t.Run("Should execute command exec without error", func(t *testing.T) {
-		root := &cobra.Command{}
-		cobraCmd := NewVersionCommand(cfg)
-		cmd := cobraCmd.CreateCobraCmd()
-		err := cmd.RunE(root, []string{})
-		assert.NoError(t, err)
+
+	t.Run("should success execute the version command without errors", func(t *testing.T) {
+		assert.NoError(t, CreateCobraCmd().RunE(&cobra.Command{}, []string{}))
 	})
 }

--- a/config/config.go
+++ b/config/config.go
@@ -35,14 +35,13 @@ import (
 	"github.com/iancoleman/strcase"
 	"github.com/sirupsen/logrus"
 
+	"github.com/ZupIT/horusec/cmd/app/version"
 	"github.com/ZupIT/horusec/config/dist"
 	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
 	"github.com/ZupIT/horusec/internal/entities/workdir"
 	jsonutils "github.com/ZupIT/horusec/internal/utils/json"
 	"github.com/ZupIT/horusec/internal/utils/valueordefault"
 )
-
-var version = "{{VERSION_NOT_FOUND}}"
 
 const (
 	EnvHorusecAPIUri                   = "HORUSEC_CLI_HORUSEC_API_URI"
@@ -137,7 +136,7 @@ func New() *Config {
 	}
 
 	return &Config{
-		Version: version,
+		Version: version.Version,
 		GlobalOptions: GlobalOptions{
 			ConfigFilePath: filepath.Join(wd, "horusec-config.json"),
 			LogLevel:       logrus.InfoLevel.String(),


### PR DESCRIPTION
Signed-off-by: nathanmartinszup <nathan.martins@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

Changed the version command to show more info about that build.
This pull request depends on (#658), that includes some workflow changes during build to pass the necessary data. 
The command output will look like this by now:

```
Version:          alpha
Git commit:       8848fdb7c4ae3815afcc990a8a99d663dda1b590
Built:            qui out 07 13:35:45 2021
Distribution:     stand-alone
```

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
