### PR TITLE
git: improvement on success commit author tests 

### DIFF
--- a/internal/services/git/git_test.go
+++ b/internal/services/git/git_test.go
@@ -15,6 +15,7 @@
 package git
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,7 +25,7 @@ import (
 
 func TestGetCommitAuthor(t *testing.T) {
 	c := &config.Config{}
-	c.ProjectPath = "../../../../"
+	c.ProjectPath = filepath.Join("..", "..", "..")
 	c.EnableCommitAuthor = true
 	service := Git{
 		config: c,
@@ -33,33 +34,38 @@ func TestGetCommitAuthor(t *testing.T) {
 	t.Run("Should success get commit author", func(t *testing.T) {
 		author := service.CommitAuthor("1-2", "README.md")
 		assert.NotEmpty(t, author.Email)
+		assert.NotEqual(t, "-", author.Email)
 		assert.NotEmpty(t, author.Message)
+		assert.NotEqual(t, "-", author.Message)
 		assert.NotEmpty(t, author.Author)
+		assert.NotEqual(t, "-", author.Author)
 		assert.NotEmpty(t, author.CommitHash)
+		assert.NotEqual(t, "-", author.CommitHash)
 		assert.NotEmpty(t, author.Date)
+		assert.NotEqual(t, "-", author.Date)
 	})
 
-	t.Run("Should return error when something went wrong while executing cmd", func(t *testing.T) {
+	t.Run("Should return commit author not found when something went wrong while executing cmd", func(t *testing.T) {
 		author := service.CommitAuthor("999999", "")
 		assert.Equal(t, author, service.getCommitAuthorNotFound())
 	})
 
-	t.Run("Should return error when line or path not found", func(t *testing.T) {
+	t.Run("Should return commit author not found when line or path not found", func(t *testing.T) {
 		author := service.CommitAuthor("1", "-")
 		assert.Equal(t, author, service.getCommitAuthorNotFound())
 	})
 
-	t.Run("Should return error when parameters is empty", func(t *testing.T) {
+	t.Run("Should return commit author not found when parameters is empty", func(t *testing.T) {
 		author := service.CommitAuthor("", "./")
 		assert.Equal(t, author, service.getCommitAuthorNotFound())
 	})
 
-	t.Run("Should return error when not exists path", func(t *testing.T) {
+	t.Run("Should return commit author not found when not exists path", func(t *testing.T) {
 		author := service.CommitAuthor("1", "./some_path")
 		assert.Equal(t, author, service.getCommitAuthorNotFound())
 	})
 
-	t.Run("Should return empty commit author when invalid output", func(t *testing.T) {
+	t.Run("Should return commit author not found invalid output", func(t *testing.T) {
 		author := service.parseOutputToStruct([]byte("test"))
 		assert.Equal(t, author, service.getCommitAuthorNotFound())
 	})


### PR DESCRIPTION
Previously on tests of success getting commit author we was just
asserting that the result is not empty, but actually the tests was not
getting the correct commit author and was returning commit author not
found. This commit add asserts to make sure that we are successful
getting the commit author info from a file and line.

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
