### PR TITLE
cli: fix breaking change on vulnerability hashes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ZupIT/horusec
 go 1.17
 
 require (
-	github.com/ZupIT/horusec-devkit v1.0.18
+	github.com/ZupIT/horusec-devkit v1.0.19
 	github.com/ZupIT/horusec-engine v0.3.6
 	github.com/bmatcuk/doublestar/v4 v4.0.2
 	github.com/briandowns/spinner v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWX
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/ZupIT/horusec-devkit v1.0.17/go.mod h1:wTsXrXTD1YrChTQEng8EvVg+zL9nMUIQkhUG85sQwuQ=
-github.com/ZupIT/horusec-devkit v1.0.18 h1:Nbl7YQTBnwPFRmIEn0LKINN5u2SwvCu6Jt8wmlhHTO8=
-github.com/ZupIT/horusec-devkit v1.0.18/go.mod h1:8rEUFNoFOGeAIG1unUfaF5qP6agHPnf9WsMtGfQR/iU=
+github.com/ZupIT/horusec-devkit v1.0.19 h1:eQNzst0a91YkAzSWy+1A/brBR9Lon2dMmzs0vZ3dUzQ=
+github.com/ZupIT/horusec-devkit v1.0.19/go.mod h1:8rEUFNoFOGeAIG1unUfaF5qP6agHPnf9WsMtGfQR/iU=
 github.com/ZupIT/horusec-engine v0.3.6 h1:m/kL9K8+OVAaYjagoDmNFFDEA3BnyJbcx0DfNYGyaDM=
 github.com/ZupIT/horusec-engine v0.3.6/go.mod h1:s3SZQ9gXXlEcIagEuopZJga+Dw6RBFWMD7Rh5A+tIys=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=

--- a/internal/controllers/printresults/print_results.go
+++ b/internal/controllers/printresults/print_results.go
@@ -277,6 +277,9 @@ func (pr *PrintResults) printTextOutputVulnerabilityData(vulnerability *vulnerab
 	pr.printLNF("Confidence: %s", vulnerability.Confidence)
 	pr.printLNF("File: %s", pr.getProjectPath(vulnerability.File))
 	pr.printLNF("Code: %s", vulnerability.Code)
+	if vulnerability.RuleID != "" {
+		pr.printLNF("RuleID: %s", vulnerability.RuleID)
+	}
 	pr.printLNF("Details: %s", vulnerability.Details)
 	pr.printLNF("Type: %s", vulnerability.Type)
 

--- a/internal/services/formatters/service.go
+++ b/internal/services/formatters/service.go
@@ -237,12 +237,13 @@ func (s *Service) AddNewVulnerabilityIntoAnalysis(vuln *vulnerability.Vulnerabil
 func (s *Service) newVulnerabilityFromFinding(finding *engine.Finding, tool tools.Tool,
 	language languages.Language) *vulnerability.Vulnerability {
 	return &vulnerability.Vulnerability{
+		RuleID:       finding.ID,
 		Line:         strconv.Itoa(finding.SourceLocation.Line),
 		Column:       strconv.Itoa(finding.SourceLocation.Column),
 		Confidence:   confidence.Confidence(finding.Confidence),
 		File:         s.removeHorusecFolder(finding.SourceLocation.Filename),
 		Code:         s.GetCodeWithMaxCharacters(finding.CodeSample, finding.SourceLocation.Column),
-		Details:      fmt.Sprintf("%s: %s\n%s", finding.ID, finding.Name, finding.Description),
+		Details:      fmt.Sprintf("%s\n%s", finding.Name, finding.Description),
 		SecurityTool: tool,
 		Language:     language,
 		Severity:     severities.GetSeverityByString(finding.Severity),

--- a/internal/utils/vuln_hash/vuln_hash.go
+++ b/internal/utils/vuln_hash/vuln_hash.go
@@ -15,6 +15,7 @@
 package vulnhash
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -22,11 +23,24 @@ import (
 	"github.com/ZupIT/horusec-devkit/pkg/utils/crypto"
 )
 
+// Bind generate and set the vulnerability hash on vuln. Note that Bind
+// generate the valid and invalid vulnerability hashes.
+//
+// nolint:funlen
 func Bind(vuln *vulnerability.Vulnerability) *vulnerability.Vulnerability {
 	vuln.VulnHash = crypto.GenerateSHA256(
 		toOneLine(vuln.Code),
 		vuln.Line,
 		vuln.Details,
+		vuln.File,
+		vuln.CommitEmail,
+	)
+
+	// See vulnerability.Vulnerability.VulnHashInvalid docs for more info.
+	vuln.VulnHashInvalid = crypto.GenerateSHA256(
+		toOneLine(vuln.Code),
+		vuln.Line,
+		fmt.Sprintf("%s: %s", vuln.RuleID, vuln.Details),
 		vuln.File,
 		vuln.CommitEmail,
 	)


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
On pr #636 we add the rule id on description of vulnerability, but the
Details of vulnerability is used to generate the vulnerability hash, so
adding the rule id on details generate a different hash which cause a
breaking change. So this commit remove the rule id prefix from Details
field of Vulnerability and also add a workaround to users that is
already using the new hash as a false positive and risk accept.
To support the two ways of hashing the vulnerability a new field was
added on Vulnerability struct that represents the breaking way, so we
generate the two hashes of vulnerability and when we set the
vulnerability to false positive/risk accept according to config file we
use the two hashes to match.

Fixes #680

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>


**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
