### PR TITLE
formatters: add documentation on IService interface

### DIFF
--- a/internal/services/formatters/interface.go
+++ b/internal/services/formatters/interface.go
@@ -29,27 +29,82 @@ type IFormatter interface {
 	StartAnalysis(projectSubPath string)
 }
 
+// IService is the service used by tools to start analysis on docker,
+// transform file paths and manipulate analysis information such as
+// vulnerabilities.
 type IService interface {
 	LogDebugWithReplace(msg string, tool tools.Tool, lang languages.Language)
+
+	// GetAnalysisID return the ID of current analysis.
 	GetAnalysisID() string
+
+	// ExecuteContainer execute a container using info from data input
+	// and return the data.CMD output or error if exists.
 	ExecuteContainer(data *docker.AnalysisData) (output string, err error)
+
+	// GetAnalysisIDErrorMessage returns a string message containing
+	// error information with the current analysis id, the tool that
+	// generate the error and the error itself.
 	GetAnalysisIDErrorMessage(tool tools.Tool, output string) string
-	GetCommitAuthor(line, filePath string) (commitAuthor commitauthor.CommitAuthor)
+
+	// GetCommitAuthor return commit author info to a given line and filepath.
+	GetCommitAuthor(line, filePath string) commitauthor.CommitAuthor
+
+	// AddWorkDirInCmd replace {{WORK_DIR}} from cmd with a `cd` into projectSubPath.
 	AddWorkDirInCmd(cmd string, projectSubPath string, tool tools.Tool) string
+
+	// GetConfigProjectPath return the project path of analysis. Note that the project
+	// path returned is the .horusec/ANALYSIS-ID directory created to execute analysis
+	// (It's not the project path informed by user).
 	GetConfigProjectPath() string
+
+	// SetAnalysisError add an error from a tool to current analysis.
 	SetAnalysisError(err error, tool tools.Tool, projectSubPath string)
+
+	// RemoveSrcFolderFromPath remove src prefix from filepath.
 	RemoveSrcFolderFromPath(filepath string) string
+
+	// GetCodeWithMaxCharacters returns the code limited to the MaxCharacters.
 	GetCodeWithMaxCharacters(code string, column int) string
+
+	// ToolIsToIgnore check if a tool should be ignored.
 	ToolIsToIgnore(tool tools.Tool) bool
+
+	// GetFilepathFromFilename return the relative file path inside projectSubpath
+	// to a given filename
 	GetFilepathFromFilename(filename, projectSubPath string) string
+
+	// GetProjectPathWithWorkdir return the project path inside working directory.
 	GetProjectPathWithWorkdir(projectSubPath string) string
+
+	// SetCommitAuthor set commit author info on vulnerability.
 	SetCommitAuthor(vulnerability *vulnerability.Vulnerability) *vulnerability.Vulnerability
+
+	// ParseFindingsToVulnerabilities convert findings to vulnerabilities and add these
+	// vulnerabilities on current analysis.
 	ParseFindingsToVulnerabilities(findings []engine.Finding, tool tools.Tool, language languages.Language) error
+
+	// AddNewVulnerabilityIntoAnalysis add vulnerability on current analysis.
 	AddNewVulnerabilityIntoAnalysis(vulnerability *vulnerability.Vulnerability)
-	IsDockerDisabled() bool
+
+	// GetCustomRulesByLanguage return user custom rules to a given language.
 	GetCustomRulesByLanguage(lang languages.Language) []engine.Rule
-	GetConfigCMDByFileExtension(projectSubPath, imageCmd, ext string, tool tools.Tool) string
+
+	// GetCustomImageByLanguage return a custom docker image to a given language.
 	GetCustomImageByLanguage(language languages.Language) string
+
+	// GetConfigCMDByFileExtension works like AddWorkDirInCmd but use a sub path
+	// that contains files that match ext extension. If this sub path was not found
+	// the project sub path returned from GetConfigProjectPath is used.
+	GetConfigCMDByFileExtension(projectSubPath, imageCmd, ext string, tool tools.Tool) string
+
+	// IsDockerDisabled return true if docker is disable, otherwise false.
+	IsDockerDisabled() bool
+
+	// IsOwaspDependencyCheckDisable return true if dependency check is disable
+	// otherwise false.
 	IsOwaspDependencyCheckDisable() bool
+
+	// IsShellcheckDisable return true if shell check is disable, otherwise false.
 	IsShellcheckDisable() bool
 }

--- a/internal/services/formatters/service.go
+++ b/internal/services/formatters/service.go
@@ -42,6 +42,9 @@ import (
 	"github.com/ZupIT/horusec/internal/services/git"
 )
 
+// MaxCharacters is the maximum length of code that a vulnerability can have.
+const MaxCharacters = 100
+
 // CustomRules is the interface that load custom rules to a given language
 type CustomRules interface {
 	Load(languages.Language) []engine.Rule
@@ -152,13 +155,12 @@ func (s *Service) RemoveSrcFolderFromPath(filepath string) string {
 }
 
 func (s *Service) GetCodeWithMaxCharacters(code string, column int) string {
-	const MaxCharacters = 100
 	if column < 0 {
 		column = 0
 	}
 
 	if len(code) > MaxCharacters {
-		return s.getAHundredCharacters(code, column)
+		return s.truncatedCode(code, column)
 	}
 
 	return code
@@ -171,8 +173,7 @@ func (s *Service) ToolIsToIgnore(tool tools.Tool) bool {
 	return false
 }
 
-func (s *Service) getAHundredCharacters(code string, column int) string {
-	const MaxCharacters = 100
+func (s *Service) truncatedCode(code string, column int) string {
 	if len(code) < column {
 		return code[:MaxCharacters]
 	}


### PR DESCRIPTION
formatters.IService interface has to many methods and sometimes is
confusing to understand. This commit add some documentation to make more
easily to understand these methods.

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
