### PR TITLE
cli: not stop analysis when get error to create log file

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -388,7 +388,7 @@ func (c *Config) LoadFromEnvironmentVariables() *Config {
 // After each read values step we normalize the paths from relative to absolute and
 // finally configure and create the log file.
 func (c *Config) PersistentPreRun(cmd *cobra.Command, _ []string) error {
-	return c.
+	err := c.
 		LoadGlobalFlags(cmd).
 		Normalize().
 		LoadFromConfigFile().
@@ -398,6 +398,11 @@ func (c *Config) PersistentPreRun(cmd *cobra.Command, _ []string) error {
 		LoadStartFlags(cmd).
 		Normalize().
 		ConfigureLogger()
+	if err != nil {
+		logger.LogErrorWithLevel(messages.MsgErrorSettingLogFile, err)
+	}
+
+	return nil
 }
 
 // ConfigureLogger create the log file and configure the log output.


### PR DESCRIPTION
This commit change the pre run step of cobra command to not crash when
get an error when setting the log file. This can be related to #656.

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
