### PR TITLE
tests: improve start tests 

### DIFF
--- a/cmd/app/start/start.go
+++ b/cmd/app/start/start.go
@@ -361,7 +361,7 @@ func (s *Start) askIfRunInDirectorySelected(shouldAsk bool) error {
 Please use the command below informing the directory you want to run the analysis: 
 horusec start -p ./
 `, err.Error())
-			return nil
+			return err
 		}
 		return s.validateReplyOfAsk(response)
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -342,7 +342,7 @@ func TestNewHorusecConfig(t *testing.T) {
 			"--enable-owasp-dependency-check", "true",
 			"--enable-shellcheck", "true",
 			"--headers", "X-Auth-Service=my-value",
-			"--horusec-url", "horusec-url-test",
+			"--horusec-url", "http://horusec-url-test.com",
 			"--ignore", "ignore-test-1,ignore-test-2",
 			"--insecure-skip-verify", "true",
 			"--json-output-file", "./tmp/json-output-file-test.json",
@@ -371,7 +371,7 @@ func TestNewHorusecConfig(t *testing.T) {
 		assert.Equal(t, true, configs.EnableOwaspDependencyCheck)
 		assert.Equal(t, true, configs.EnableShellCheck)
 		assert.Equal(t, map[string]string{"X-Auth-Service": "my-value"}, configs.Headers)
-		assert.Equal(t, "horusec-url-test", configs.HorusecAPIUri)
+		assert.Equal(t, "http://horusec-url-test.com", configs.HorusecAPIUri)
 		assert.Equal(t, []string{"ignore-test-1", "ignore-test-2"}, configs.FilesOrPathsToIgnore)
 		assert.Equal(t, true, configs.CertInsecureSkipVerify)
 		assert.Equal(t, filepath.Join(wd, "tmp", "json-output-file-test.json"), configs.JSONOutputFilePath)

--- a/go.mod
+++ b/go.mod
@@ -15,10 +15,13 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/iancoleman/strcase v0.2.0
 	github.com/manifoldco/promptui v0.8.0
+	github.com/onsi/ginkgo v1.16.5
+	github.com/onsi/gomega v1.16.0
 	github.com/opencontainers/image-spec v1.0.2-0.20190823105129-775207bd45b6
 	github.com/pborman/ansi v1.0.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.2.1
+	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.9.0
 	github.com/stretchr/testify v1.7.0
 )
@@ -49,8 +52,6 @@ require (
 	github.com/moby/term v0.0.0-20201216013528-df9cb8a40635 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
-	github.com/onsi/ginkgo v1.16.5
-	github.com/onsi/gomega v1.16.0
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
@@ -58,7 +59,6 @@ require (
 	github.com/spf13/afero v1.6.0 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect

--- a/internal/controllers/analyzer/analyzer_mock.go
+++ b/internal/controllers/analyzer/analyzer_mock.go
@@ -25,6 +25,6 @@ type Mock struct {
 }
 
 func (m *Mock) Analyze() (int, error) {
-	args := m.MethodCalled("AnalysisDirectory")
+	args := m.MethodCalled("Analyze")
 	return args.Get(0).(int), utilsMock.ReturnNilOrError(args, 0)
 }

--- a/internal/services/engines/java/rules.go
+++ b/internal/services/engines/java/rules.go
@@ -91,7 +91,6 @@ func NewXMLParsingVulnerableToXXEWithSAXParserFactory() text.TextRule {
 			regexp.MustCompile(`SAXParserFactory\.newInstance\(`),
 			regexp.MustCompile(`\.parse\(`),
 			regexp.MustCompile(`(SAXParserFactory\.newInstance\(\))(([^s]|s[^e]|se[^t]|set[^F]|setF[^e]|setFe[^a]|setFea[^t]|setFeat[^u]|setFeatu[^r]|setFeatur[^e])*)(\.parse\(.*\))`),
-
 		},
 	}
 }


### PR DESCRIPTION
This commit segregate unit test from integration tests and add some unit tests, more yet to come

Signed-off-by: Ian Cardoso <ian.cardoso@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
added a new struct for start table tests 
```
	type onFn func(*prompt.Mock, *requirements.Mock, *analyzer.Mock)
	type assertFn func(*testing.T, *prompt.Mock, *requirements.Mock, *analyzer.Mock, *config.Config)

	testcases := []struct {
		name     string
		args     []string
		err      bool
		onFn     onFn
		assertFn assertFn
	}
```

You can easily add another test by using this template at the bottom of the [list](https://github.com/ZupIT/horusec/pull/701/files#diff-f82dbcadf3edfb1b16b67f5d36f6399993e8e125e73af7c045fae79d71525b0eR586)
```
{
	name: "",
	args: []string{},
	err:  false,
	onFn: func(prompt *prompt.Mock, requirements *requirements.Mock, analyzer *analyzer.Mock) {
	},
	assertFn: func(t *testing.T, prompt *prompt.Mock, requirements *requirements.Mock, analyzer *analyzer.Mock, cfg *config.Config) {
	},
},
```
Also it fixes some validation on flags some flags:

- `--horusec-url`
- `--ignore-severity`

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
