### PR TITLE
workflows: updating workflows to contains amr64

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -40,6 +40,12 @@ jobs:
         with:
           go-version: 1.17
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Docker Login
         uses: docker/login-action@v1
         with:
@@ -64,6 +70,7 @@ jobs:
           context: .
           file: ./deployments/Dockerfile
           tags: horuszup/horusec-cli:alpha
+          platforms: linux/amd64,linux/arm64
 
       - name: Sign image
         run: |
@@ -104,40 +111,70 @@ jobs:
           -X 'github.com/ZupIT/horusec/cmd/app/version.Version=alpha' \
           -X 'github.com/ZupIT/horusec/cmd/app/version.Commit=${{ github.sha }}' \
           -X 'github.com/ZupIT/horusec/cmd/app/version.Date=${{ steps.date.outputs.date }}'" \
-          -o ./tmp/horusec_linux_x64_stand_alone  ./cmd/app/main.go
+          -o ./tmp/horusec_linux_amd64_stand_alone  ./cmd/app/main.go
 
           cosign sign-blob -key=$COSIGN_KEY_LOCATION \
-          -output=./tmp/horusec_linux_x64_stand_alone.sig ./tmp/horusec_linux_x64_stand_alone
+          -output=./tmp/horusec_linux_amd64_stand_alone.sig ./tmp/horusec_linux_amd64_stand_alone
+
+          CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags \
+          "-X 'github.com/ZupIT/horusec/config/dist.standAlone=true' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Version=alpha' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Commit=${{ github.sha }}' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Date=${{ steps.date.outputs.date }}'" \
+          -o ./tmp/horusec_linux_arm64_stand_alone  ./cmd/app/main.go
+
+          cosign sign-blob -key=$COSIGN_KEY_LOCATION \
+          -output=./tmp/horusec_linux_arm64_stand_alone.sig ./tmp/horusec_linux_arm64_stand_alone
 
           CGO_ENABLED=0 GOOS=windows GOARCH=386 go build -ldflags \
           "-X 'github.com/ZupIT/horusec/config/dist.standAlone=true' \
           -X 'github.com/ZupIT/horusec/cmd/app/version.Version=alpha' \
           -X 'github.com/ZupIT/horusec/cmd/app/version.Commit=${{ github.sha }}' \
           -X 'github.com/ZupIT/horusec/cmd/app/version.Date=${{ steps.date.outputs.date }}'" \
-          -o ./tmp/horusec_windows_x86_stand_alone.exe  ./cmd/app/main.go
+          -o ./tmp/horusec_win_x86_stand_alone.exe  ./cmd/app/main.go
 
           cosign sign-blob -key=$COSIGN_KEY_LOCATION \
-          -output=./tmp/horusec_windows_x86_stand_alone.exe.sig ./tmp/horusec_windows_x86_stand_alone.exe
+          -output=./tmp/horusec_win_x86_stand_alone.exe.sig ./tmp/horusec_win_x86_stand_alone.exe
 
           CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags \
           "-X 'github.com/ZupIT/horusec/config/dist.standAlone=true' \
           -X 'github.com/ZupIT/horusec/cmd/app/version.Version=alpha' \
           -X 'github.com/ZupIT/horusec/cmd/app/version.Commit=${{ github.sha }}' \
           -X 'github.com/ZupIT/horusec/cmd/app/version.Date=${{ steps.date.outputs.date }}'" \
-          -o ./tmp/horusec_windows_x64_stand_alone.exe  ./cmd/app/main.go
+          -o ./tmp/horusec_win_amd64_stand_alone.exe  ./cmd/app/main.go
 
           cosign sign-blob -key=$COSIGN_KEY_LOCATION \
-          -output=./tmp/horusec_windows_x64_stand_alone.exe.sig ./tmp/horusec_windows_x64_stand_alone.exe
+          -output=./tmp/horusec_win_amd64_stand_alone.exe.sig ./tmp/horusec_win_amd64_stand_alone.exe
+
+          CGO_ENABLED=0 GOOS=windows GOARCH=arm64 go build -ldflags \
+          "-X 'github.com/ZupIT/horusec/config/dist.standAlone=true' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Version=alpha' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Commit=${{ github.sha }}' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Date=${{ steps.date.outputs.date }}'" \
+          -o ./tmp/horusec_win_arm64_stand_alone.exe  ./cmd/app/main.go
+
+          cosign sign-blob -key=$COSIGN_KEY_LOCATION \
+          -output=./tmp/horusec_win_arm64_stand_alone.exe.sig ./tmp/horusec_win_arm64_stand_alone.exe
 
           CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags \
           "-X 'github.com/ZupIT/horusec/config/dist.standAlone=true' \
           -X 'github.com/ZupIT/horusec/cmd/app/version.Version=alpha' \
           -X 'github.com/ZupIT/horusec/cmd/app/version.Commit=${{ github.sha }}' \
           -X 'github.com/ZupIT/horusec/cmd/app/version.Date=${{ steps.date.outputs.date }}'" \
-          -o ./tmp/horusec_mac_x64_stand_alone  ./cmd/app/main.go
+          -o ./tmp/horusec_mac_amd64_stand_alone  ./cmd/app/main.go
 
           cosign sign-blob -key=$COSIGN_KEY_LOCATION \
-          -output=./tmp/horusec_mac_x64_stand_alone.sig ./tmp/horusec_mac_x64_stand_alone
+          -output=./tmp/horusec_mac_amd64_stand_alone.sig ./tmp/horusec_mac_amd64_stand_alone
+
+          CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags \
+          "-X 'github.com/ZupIT/horusec/config/dist.standAlone=true' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Version=alpha' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Commit=${{ github.sha }}' \
+          -X 'github.com/ZupIT/horusec/cmd/app/version.Date=${{ steps.date.outputs.date }}'" \
+          -o ./tmp/horusec_mac_arm64_stand_alone  ./cmd/app/main.go
+
+          cosign sign-blob -key=$COSIGN_KEY_LOCATION \
+          -output=./tmp/horusec_mac_arm64_stand_alone.sig ./tmp/horusec_mac_arm64_stand_alone
         env:
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PWD }}
 
@@ -164,26 +201,38 @@ jobs:
             checksums.txt:./dist/checksums.txt
             checksums.txt.sig:./dist/checksums.txt.sig
             cosign.pub:./deployments/cosign.pub
-            horusec_linux_x64:./dist/horusec_linux_amd64/horusec
-            horusec_linux_x64.sig:./dist/horusec_linux_amd64/horusec.sig
+            horusec_linux_amd64:./dist/horusec_linux_amd64/horusec
+            horusec_linux_amd64.sig:./dist/horusec_linux_amd64/horusec.sig
             horusec_linux_x86:./dist/horusec_linux_386/horusec
             horusec_linux_x86.sig:./dist/horusec_linux_386/horusec.sig
-            horusec_mac_x64:./dist/horusec_darwin_amd64/horusec
-            horusec_mac_x64.sig:./dist/horusec_darwin_amd64/horusec.sig
-            horusec_win_x64.exe:./dist/horusec_windows_amd64/horusec.exe
-            horusec_win_x64.exe.sig:./dist/horusec_windows_amd64/horusec.exe.sig
+            horusec_mac_amd64:./dist/horusec_darwin_amd64/horusec
+            horusec_mac_amd64.sig:./dist/horusec_darwin_amd64/horusec.sig
+            horusec_win_amd64.exe:./dist/horusec_windows_amd64/horusec.exe
+            horusec_win_amd64.exe.sig:./dist/horusec_windows_amd64/horusec.exe.sig
             horusec_win_x86.exe:./dist/horusec_windows_386/horusec.exe
             horusec_win_x86.exe.sig:./dist/horusec_windows_386/horusec.exe.sig
+            horusec_linux_arm64:./dist/horusec_linux_arm64/horusec
+            horusec_linux_arm64.sig:./dist/horusec_linux_arm64/horusec.sig
+            horusec_win_arm64.exe:./dist/horusec_windows_arm64/horusec.exe
+            horusec_win_arm64.exe.sig:./dist/horusec_windows_arm64/horusec.exe.sig
+            horusec_mac_arm64:./dist/horusec_darwin_arm64/horusec
+            horusec_mac_arm64.sig:./dist/horusec_darwin_arm64/horusec.sig
             horusec_linux_x86_stand_alone:./tmp/horusec_linux_x86_stand_alone
             horusec_linux_x86_stand_alone.sig:./tmp/horusec_linux_x86_stand_alone.sig
-            horusec_linux_x64_stand_alone:./tmp/horusec_linux_x64_stand_alone
-            horusec_linux_x64_stand_alone.sig:./tmp/horusec_linux_x64_stand_alone.sig
-            horusec_windows_x86_stand_alone.exe:./tmp/horusec_windows_x86_stand_alone.exe
-            horusec_windows_x86_stand_alone.exe.sig:./tmp/horusec_windows_x86_stand_alone.exe.sig
-            horusec_windows_x64_stand_alone.exe:./tmp/horusec_windows_x64_stand_alone.exe
-            horusec_windows_x64_stand_alone.exe.sig:./tmp/horusec_windows_x64_stand_alone.exe.sig
-            horusec_mac_x64_stand_alone:./tmp/horusec_mac_x64_stand_alone
-            horusec_mac_x64_stand_alone.sig:./tmp/horusec_mac_x64_stand_alone.sig
+            horusec_linux_amd64_stand_alone:./tmp/horusec_linux_amd64_stand_alone
+            horusec_linux_amd64_stand_alone.sig:./tmp/horusec_linux_amd64_stand_alone.sig
+            horusec_win_x86_stand_alone.exe:./tmp/horusec_win_x86_stand_alone.exe
+            horusec_win_x86_stand_alone.exe.sig:./tmp/horusec_win_x86_stand_alone.exe.sig
+            horusec_win_amd64_stand_alone.exe:./tmp/horusec_win_amd64_stand_alone.exe
+            horusec_win_amd64_stand_alone.exe.sig:./tmp/horusec_win_amd64_stand_alone.exe.sig
+            horusec_mac_amd64_stand_alone:./tmp/horusec_mac_amd64_stand_alone
+            horusec_mac_amd64_stand_alone.sig:./tmp/horusec_mac_amd64_stand_alone.sig
+            horusec_linux_arm64_stand_alone:./tmp/horusec_linux_arm64_stand_alone
+            horusec_linux_arm64_stand_alone.sig:./tmp/horusec_linux_arm64_stand_alone.sig
+            horusec_win_arm64_stand_alone.exe:./tmp/horusec_win_arm64_stand_alone.exe
+            horusec_win_arm64_stand_alone.exe.sig:./tmp/horusec_win_arm64_stand_alone.exe.sig
+            horusec_mac_arm64_stand_alone:./tmp/horusec_mac_arm64_stand_alone
+            horusec_mac_arm64_stand_alone.sig:./tmp/horusec_mac_arm64_stand_alone.sig
           body: |
             ## Docker images
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,10 +86,10 @@ jobs:
           -X 'github.com/ZupIT/horusec/cmd/app/version.Version=${{ steps.updated-version.outputs.version }}' \
           -X 'github.com/ZupIT/horusec/cmd/app/version.Commit=${{ github.sha }}' \
           -X 'github.com/ZupIT/horusec/cmd/app/version.Date=${{ steps.date.outputs.date }}'" \
-          -o ./tmp/horusec_linux_x64_stand_alone  ./cmd/app/main.go
+          -o ./tmp/horusec_linux_amd64_stand_alone  ./cmd/app/main.go
 
           cosign sign-blob -key=$COSIGN_KEY_LOCATION \
-          -output=./tmp/horusec_linux_x64_stand_alone.sig ./tmp/horusec_linux_x64_stand_alone
+          -output=./tmp/horusec_linux_amd64_stand_alone.sig ./tmp/horusec_linux_amd64_stand_alone
 
           CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags \
           "-X 'github.com/ZupIT/horusec/config/dist.standAlone=true' \
@@ -106,40 +106,40 @@ jobs:
           -X 'github.com/ZupIT/horusec/cmd/app/version.Version=${{ steps.updated-version.outputs.version }}' \
           -X 'github.com/ZupIT/horusec/cmd/app/version.Commit=${{ github.sha }}' \
           -X 'github.com/ZupIT/horusec/cmd/app/version.Date=${{ steps.date.outputs.date }}'" \
-          -o ./tmp/horusec_windows_x86_stand_alone.exe  ./cmd/app/main.go
+          -o ./tmp/horusec_win_x86_stand_alone.exe  ./cmd/app/main.go
 
           cosign sign-blob -key=$COSIGN_KEY_LOCATION \
-          -output=./tmp/horusec_windows_x86_stand_alone.exe.sig ./tmp/horusec_windows_x86_stand_alone.exe
+          -output=./tmp/horusec_win_x86_stand_alone.exe.sig ./tmp/horusec_win_x86_stand_alone.exe
 
           CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags \
           "-X 'github.com/ZupIT/horusec/config/dist.standAlone=true' \
           -X 'github.com/ZupIT/horusec/cmd/app/version.Version=${{ steps.updated-version.outputs.version }}' \
           -X 'github.com/ZupIT/horusec/cmd/app/version.Commit=${{ github.sha }}' \
           -X 'github.com/ZupIT/horusec/cmd/app/version.Date=${{ steps.date.outputs.date }}'" \
-          -o ./tmp/horusec_windows_x64_stand_alone.exe  ./cmd/app/main.go
+          -o ./tmp/horusec_win_amd64_stand_alone.exe  ./cmd/app/main.go
 
           cosign sign-blob -key=$COSIGN_KEY_LOCATION \
-          -output=./tmp/horusec_windows_x64_stand_alone.exe.sig ./tmp/horusec_windows_x64_stand_alone.exe
+          -output=./tmp/horusec_win_amd64_stand_alone.exe.sig ./tmp/horusec_win_amd64_stand_alone.exe
 
           CGO_ENABLED=0 GOOS=windows GOARCH=arm64 go build -ldflags \
           "-X 'github.com/ZupIT/horusec/config/dist.standAlone=true' \
           -X 'github.com/ZupIT/horusec/cmd/app/version.Version=${{ steps.updated-version.outputs.version }}' \
           -X 'github.com/ZupIT/horusec/cmd/app/version.Commit=${{ github.sha }}' \
           -X 'github.com/ZupIT/horusec/cmd/app/version.Date=${{ steps.date.outputs.date }}'" \
-          -o ./tmp/horusec_windows_arm64_stand_alone.exe  ./cmd/app/main.go
+          -o ./tmp/horusec_win_arm64_stand_alone.exe  ./cmd/app/main.go
 
           cosign sign-blob -key=$COSIGN_KEY_LOCATION \
-          -output=./tmp/horusec_windows_arm64_stand_alone.exe.sig ./tmp/horusec_windows_x64_stand_alone.exe
+          -output=./tmp/horusec_win_arm64_stand_alone.exe.sig ./tmp/horusec_win_arm64_stand_alone.exe
 
           CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags \
           "-X 'github.com/ZupIT/horusec/config/dist.standAlone=true' \
           -X 'github.com/ZupIT/horusec/cmd/app/version.Version=${{ steps.updated-version.outputs.version }}' \
           -X 'github.com/ZupIT/horusec/cmd/app/version.Commit=${{ github.sha }}' \
           -X 'github.com/ZupIT/horusec/cmd/app/version.Date=${{ steps.date.outputs.date }}'" \
-          -o ./tmp/horusec_mac_x64_stand_alone  ./cmd/app/main.go
+          -o ./tmp/horusec_mac_amd64_stand_alone  ./cmd/app/main.go
 
           cosign sign-blob -key=$COSIGN_KEY_LOCATION \
-          -output=./tmp/horusec_mac_x64_stand_alone.sig ./tmp/horusec_mac_x64_stand_alone
+          -output=./tmp/horusec_mac_amd64_stand_alone.sig ./tmp/horusec_mac_amd64_stand_alone
 
           CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags \
           "-X 'github.com/ZupIT/horusec/config/dist.standAlone=true' \

--- a/deployments/Dockerfile
+++ b/deployments/Dockerfile
@@ -21,11 +21,9 @@ WORKDIR /horusec
 
 RUN go get -t -v -d ./...
 
-RUN env GOOS=linux GOARCH=amd64 go build -o /bin/horusec ./cmd/app/main.go
+RUN env GOOS=linux go build -o /bin/horusec ./cmd/app/main.go
 
-FROM docker:20.10.9
-
-RUN apk add git
+FROM docker:20.10-git
 
 COPY --from=builder /bin/horusec /usr/local/bin
 RUN chmod +x /usr/local/bin/horusec

--- a/deployments/Dockerfile-gorelease
+++ b/deployments/Dockerfile-gorelease
@@ -12,11 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker:20.10.8
-
-RUN apk add git
+FROM docker:20.10-git
 
 COPY /horusec /usr/local/bin/horusec
-RUN chmod +x /usr/local/bin/horusec
 
 CMD [ "sh" ]

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -38,9 +38,9 @@ archives:
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
     format: binary
     replacements:
-      amd64: x64
+      amd64: amd64
       386: x86
-      aarch64: arm64
+      arm64: arm64
       darwin: mac
       windows: win
 checksum:
@@ -51,18 +51,18 @@ release:
     - glob: deployments/cosign.pub
     - glob: ./tmp/horusec_linux_x86_stand_alone
     - glob: ./tmp/horusec_linux_x86_stand_alone.sig
-    - glob: ./tmp/horusec_linux_x64_stand_alone
-    - glob: ./tmp/horusec_linux_x64_stand_alone.sig
+    - glob: ./tmp/horusec_linux_amd64_stand_alone
+    - glob: ./tmp/horusec_linux_amd64_stand_alone.sig
     - glob: ./tmp/horusec_linux_arm64_stand_alone
     - glob: ./tmp/horusec_linux_arm64_stand_alone.sig
-    - glob: ./tmp/horusec_windows_x86_stand_alone.exe
-    - glob: ./tmp/horusec_windows_x86_stand_alone.exe.sig
-    - glob: ./tmp/horusec_windows_x64_stand_alone.exe
-    - glob: ./tmp/horusec_windows_x64_stand_alone.exe.sig
-    - glob: ./tmp/horusec_windows_arm64_stand_alone.exe
-    - glob: ./tmp/horusec_windows_arm64_stand_alone.exe.sig
-    - glob: ./tmp/horusec_mac_x64_stand_alone
-    - glob: ./tmp/horusec_mac_x64_stand_alone.sig
+    - glob: ./tmp/horusec_win_x86_stand_alone.exe
+    - glob: ./tmp/horusec_win_x86_stand_alone.exe.sig
+    - glob: ./tmp/horusec_win_amd64_stand_alone.exe
+    - glob: ./tmp/horusec_win_amd64_stand_alone.exe.sig
+    - glob: ./tmp/horusec_win_arm64_stand_alone.exe
+    - glob: ./tmp/horusec_win_arm64_stand_alone.exe.sig
+    - glob: ./tmp/horusec_mac_amd64_stand_alone
+    - glob: ./tmp/horusec_mac_amd64_stand_alone.sig
     - glob: ./tmp/horusec_mac_arm64_stand_alone
     - glob: ./tmp/horusec_mac_arm64_stand_alone.sig
 nfpms:
@@ -70,8 +70,8 @@ nfpms:
     package_name: horusec
     file_name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
     replacements:
-      amd64: 64-bit
-      386: 32-bit
+      amd64: amd64
+      386: x86
       arm64: arm64
       darwin: mac
       windows: win
@@ -90,26 +90,19 @@ nfpms:
 signs:
   - cmd: cosign
     stdin: '{{ .Env.COSIGN_PWD }}'
-    args: ["sign-blob", "-key={{ .Env.COSIGN_KEY_LOCATION }}", "-output=${signature}", "${artifact}"]
+    args: [ "sign-blob", "-key={{ .Env.COSIGN_KEY_LOCATION }}", "-output=${signature}", "${artifact}" ]
     artifacts: all
 docker_signs:
   - cmd: cosign
-    args: ["sign", "-key={{ .Env.COSIGN_KEY_LOCATION }}", "${artifact}"]
+    args: [ "sign", "-key={{ .Env.COSIGN_KEY_LOCATION }}", "${artifact}" ]
     artifacts: all
     stdin: '{{ .Env.COSIGN_PWD }}'
 dockers:
-  - id: horusec
-    goos: linux
-    goarch: 
-      - amd64
-      - arm64
-    ids:
-      - horusec
-    image_templates:
-      - "horuszup/horusec-cli:latest"
-      - "horuszup/horusec-cli:{{ .Tag }}"
-      - "horuszup/horusec-cli:v{{ .Major }}"
+  - image_templates:
+      - 'horuszup/horusec-cli:{{ .Tag }}-amd64'
     skip_push: false
+    goos: linux
+    goarch: amd64
     dockerfile: ./deployments/Dockerfile-gorelease
     use: docker
     build_flag_templates:
@@ -118,5 +111,35 @@ dockers:
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--platform=linux/amd64"
     push_flags:
       - --tls-verify=false
+  - image_templates:
+      - 'horuszup/horusec-cli:{{ .Tag }}-arm64'
+    skip_push: false
+    goos: linux
+    goarch: arm64
+    dockerfile: ./deployments/Dockerfile-gorelease
+    use: docker
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--platform=linux/arm64"
+    push_flags:
+      - --tls-verify=false
+docker_manifests:
+  - name_template: 'horuszup/horusec-cli:{{ .Tag }}'
+    image_templates:
+      - 'horuszup/horusec-cli:{{ .Tag }}-amd64'
+      - 'horuszup/horusec-cli:{{ .Tag }}-arm64'
+  - name_template: 'horuszup/horusec-cli:latest'
+    image_templates:
+      - 'horuszup/horusec-cli:{{ .Tag }}-amd64'
+      - 'horuszup/horusec-cli:{{ .Tag }}-arm64'
+  - name_template: 'horuszup/horusec-cli:v{{ .Major }}'
+    image_templates:
+      - 'horuszup/horusec-cli:{{ .Tag }}-amd64'
+      - 'horuszup/horusec-cli:{{ .Tag }}-arm64'


### PR DESCRIPTION
Signed-off-by: Nathan Martins <nathan.martins@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
Added arm64 in alpha workflow and multiple architecture to the docker images. Standardization of names to separate binaries according to the architecture amd64 or arm64, before it was not possible to identify it cause only contained x64 in the binary name.

The first release after this pull request will change the binaries names, the pull request #703 update it to the new name standard.

Images Example:
```
horuszup/horusec-cli:v2.6.4-amd64 (amd64)
horuszup/horusec-cli:v2.6.4-arm64 (arm64)
horuszup/horusec-cli:v2.6.4 (amd64 and arm64)
horuszup/horusec-cli:v2 (amd64 and arm64)
horuszup/horusec-cli:latest (amd64 and arm64)
```
![docker-example](https://user-images.githubusercontent.com/63246935/138321297-414fa31d-6a26-4cf7-b5ee-8882a9d39e82.png)

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
