### PR TITLE
scripts:feature - updating install script to the new binary standard

### DIFF
--- a/deployments/scripts/install.sh
+++ b/deployments/scripts/install.sh
@@ -13,127 +13,151 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 URL_DOWNLOAD=""
 VERSION_DOWNLOAD=$1
 LATEST_RC=$(git ls-remote --exit-code --sort='v:refname' --tags https://github.com/ZupIT/horusec.git --ref 'v*.*.*-rc.*' | cut --delimiter='/' --fields=3 | tail --lines=1 | sed 's/.*\///; s/\^{}//')
 LATEST_BETA=$(git ls-remote --exit-code --sort='v:refname' --tags https://github.com/ZupIT/horusec.git --ref 'v*.*.*-beta.*' | cut --delimiter='/' --fields=3 | tail --lines=1 | sed 's/.*\///; s/\^{}//')
+IS_NEW_URL=false
 
 regex='^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
 
-horusecSetVersion () {
-    if [ -z "$VERSION_DOWNLOAD" ]; then
-        echo "invalid input, empty string"
-        exit 1
-    elif [ "$VERSION_DOWNLOAD" = "latest-rc" ] ; then
-        echo "Version set to $LATEST_RC"
-        VERSION_DOWNLOAD=$LATEST_RC
-    elif [ "$VERSION_DOWNLOAD" = "latest-beta" ] ; then
-        echo "Version set to $LATEST_BETA"
-        VERSION_DOWNLOAD=$LATEST_BETA
-    elif  [ "$VERSION_DOWNLOAD" = "latest" ] ; then
-        echo "Version set to $LATEST_BETA"
-        VERSION_DOWNLOAD='latest'
-    elif echo $VERSION_DOWNLOAD| grep -Eq  $regex; then
-        echo "Version set to $VERSION_DOWNLOAD"
+horusecSetVersion() {
+  if [ -z "$VERSION_DOWNLOAD" ]; then
+    echo "invalid input, empty string"
+    exit 1
+  elif [ "$VERSION_DOWNLOAD" = "latest-rc" ]; then
+    echo "Version set to $LATEST_RC"
+    VERSION_DOWNLOAD=$LATEST_RC
+  elif [ "$VERSION_DOWNLOAD" = "latest-beta" ]; then
+    echo "Version set to $LATEST_BETA"
+    VERSION_DOWNLOAD=$LATEST_BETA
+  elif [ "$VERSION_DOWNLOAD" = "latest" ]; then
+    echo "Version set to $LATEST_BETA"
+    VERSION_DOWNLOAD='latest'
+  elif echo $VERSION_DOWNLOAD | grep -Eq $regex; then
+    echo "Version set to $VERSION_DOWNLOAD"
+  else
+    echo "input not match required params: 'latest-rc' 'latest-beta' 'latest' or a semantic version compliant, check https://github.com/ZupIT/horusec/releases"
+    exit 1
+  fi
+  echo "Download version: $VERSION_DOWNLOAD"
+}
+
+horusecIdentifyOSLatest() {
+  if [ "$(uname)" = "Linux" ]; then
+    if [ "$(uname -m)" = "x86_64" ]; then
+      echo "Installing Horusec for Linux amd64"
+      URL_DOWNLOAD="https://github.com/ZupIT/horusec/releases/${VERSION_DOWNLOAD}/download/horusec_linux_amd64"
+    elif [ "$(uname -m)" = "aarch64" ]; then
+      echo "Installing Horusec for Linux arm64"
+      URL_DOWNLOAD="https://github.com/ZupIT/horusec/releases/${VERSION_DOWNLOAD}/download/horusec_linux_arm64"
     else
-      echo "input not match required params: 'latest-rc' 'latest-beta' 'latest' or a semantic version compliant, check https://github.com/ZupIT/horusec/releases"
+      echo "Installing Horusec for Linux x86"
+      URL_DOWNLOAD="https://github.com/ZupIT/horusec/releases/${VERSION_DOWNLOAD}/download/horusec_linux_x86"
+    fi
+  elif [ "$(uname)" = "Darwin" ]; then
+    if [ "$(uname -m)" = "x86_64" ]; then
+      echo "Installing Horusec for Mac amd64"
+      URL_DOWNLOAD="https://github.com/ZupIT/horusec/releases/${VERSION_DOWNLOAD}/download/horusec_mac_amd64"
+    elif [ "$(uname -m)" = "arm64" ]; then
+      echo "Installing Horusec for Mac arm64"
+      URL_DOWNLOAD="https://github.com/ZupIT/horusec/releases/${VERSION_DOWNLOAD}/download/horusec_mac_arm64"
+    else
+      echo "Not enable Horusec to Mac x86"
       exit 1
     fi
-    echo "Download version: $VERSION_DOWNLOAD"
-
+  else
+    echo "Unable to identify which OS you're using"
+    exit 1
+  fi
 }
 
-horusecIdentifyOSLatest () {
-    if [ "$(uname)" = "Linux" ]; then
-        if [ "$(uname -m)" = "x86_64" ]; then
-            echo "Installing Horusec for Linux x64"
-            URL_DOWNLOAD="https://github.com/ZupIT/horusec/releases/${VERSION_DOWNLOAD}/download/horusec_linux_x64"
-        elif [ "$(uname -m)" = "aarch64" ]; then
-            echo "Installing Horusec for Linux arm64"
-            URL_DOWNLOAD="https://github.com/ZupIT/horusec/releases/${VERSION_DOWNLOAD}/download/horusec_linux_arm64"
-        else
-            echo "Installing Horusec for Linux x86"
-            URL_DOWNLOAD="https://github.com/ZupIT/horusec/releases/${VERSION_DOWNLOAD}/download/horusec_linux_x86"
-        fi
-    elif [ "$(uname)" = "Darwin" ]; then
-        if [ "$(uname -m)" = "x86_64" ]; then
-            echo "Installing Horusec for Mac x64"
-            URL_DOWNLOAD="https://github.com/ZupIT/horusec/releases/${VERSION_DOWNLOAD}/download/horusec_mac_x64"
-        elif [ "$(uname -m)" = "arm64" ]; then
-            echo "Installing Horusec for Mac arm64"
-            URL_DOWNLOAD="https://github.com/ZupIT/horusec/releases/${VERSION_DOWNLOAD}/download/horusec_mac_arm64"
-        else
-            echo "Not enable Horusec to Mac x86"
-            exit 1
-        fi
+horusecIdentifyOSWithVersion() {
+  if [ "$(uname)" = "Linux" ]; then
+    if [ "$(uname -m)" = "x86_64" ]; then
+      echo "Installing Horusec for Linux amd64"
+      if [ $IS_NEW_URL = true ]; then
+        URL_DOWNLOAD="https://github.com/ZupIT/horusec/releases/download/${VERSION_DOWNLOAD}/horusec_linux_amd64"
+      else
+        URL_DOWNLOAD="https://github.com/ZupIT/horusec/releases/download/${VERSION_DOWNLOAD}/horusec_linux_x64"
+      fi
+    elif [ "$(uname -m)" = "aarch64" ]; then
+      echo "Installing Horusec for Linux arm64"
+      URL_DOWNLOAD="https://github.com/ZupIT/horusec/releases/download/${VERSION_DOWNLOAD}/horusec_linux_arm64"
     else
-        echo "Unable to identify which OS you're using"
-        exit 1
+      echo "Installing Horusec for Linux x86"
+      URL_DOWNLOAD="https://github.com/ZupIT/horusec/releases/download/${VERSION_DOWNLOAD}/horusec_linux_x86"
     fi
-}
-
-horusecIdentifyOSWithVersion () {
-    if [ "$(uname)" = "Linux" ]; then
-        if [ "$(uname -m)" = "x86_64" ]; then
-            echo "Installing Horusec for Linux x64"
-            URL_DOWNLOAD="https://github.com/ZupIT/horusec/releases/download/${VERSION_DOWNLOAD}/horusec_linux_x64"
-        elif [ "$(uname -m)" = "aarch64" ]; then
-            echo "Installing Horusec for Linux x64"
-            URL_DOWNLOAD="https://github.com/ZupIT/horusec/releases/download/${VERSION_DOWNLOAD}/horusec_linux_arm64"
-        else
-            echo "Installing Horusec for Linux x86"
-            URL_DOWNLOAD="https://github.com/ZupIT/horusec/releases/download/${VERSION_DOWNLOAD}/horusec_linux_x64"
-        fi
-    elif [ "$(uname)" = "Darwin" ]; then
-        if [ "$(uname -m)" = "x86_64" ]; then
-            echo "Installing Horusec for Mac x64"
-            URL_DOWNLOAD="https://github.com/ZupIT/horusec/releases/download/${VERSION_DOWNLOAD}/horusec_mac_x64"
-        elif [ "$(uname -m)" = "x86_64" ]; then
-            echo "Installing Horusec for Mac M1"
-            URL_DOWNLOAD="https://github.com/ZupIT/horusec/releases/download/${VERSION_DOWNLOAD}/horusec_mac_arm64"
-        else
-            echo "Not enable Horusec to Mac x86"
-            exit 1
-        fi
+  elif [ "$(uname)" = "Darwin" ]; then
+    if [ "$(uname -m)" = "x86_64" ]; then
+      echo "Installing Horusec for Mac amd64"
+      if [ $IS_NEW_URL = true ]; then
+        URL_DOWNLOAD="https://github.com/ZupIT/horusec/releases/download/${VERSION_DOWNLOAD}/horusec_mac_amd64"
+      else
+        URL_DOWNLOAD="https://github.com/ZupIT/horusec/releases/download/${VERSION_DOWNLOAD}/horusec_mac_x64"
+      fi
+    elif [ "$(uname -m)" = "x86_64" ]; then
+      echo "Installing Horusec for amr64"
+      URL_DOWNLOAD="https://github.com/ZupIT/horusec/releases/download/${VERSION_DOWNLOAD}/horusec_mac_arm64"
     else
-        echo "Unable to identify which OS you're using"
-        exit 1
+      echo "Not enable Horusec to Mac x86"
+      exit 1
     fi
+  else
+    echo "Unable to identify which OS you're using"
+    exit 1
+  fi
 }
 
-horusecDownloadAndInstall () {
-    INSTALL_PATH="/usr/local/bin"
+horusecDownloadAndInstall() {
+  INSTALL_PATH="/usr/local/bin"
 
-    if [ ! -d "$INSTALL_PATH" ]; then
-        mkdir -p $INSTALL_PATH
-    fi
+  if [ ! -d "$INSTALL_PATH" ]; then
+    mkdir -p $INSTALL_PATH
+  fi
 
-    rm -r $INSTALL_PATH/horusec >/dev/null 2>&1
+  rm -r $INSTALL_PATH/horusec >/dev/null 2>&1
 
-    echo "Downloading horusec..."
-    echo $URL_DOWNLOAD
+  echo "Downloading horusec..."
+  echo $URL_DOWNLOAD
 
-    curl -fsSL "$URL_DOWNLOAD" -o ./horusec
+  curl -fsSL "$URL_DOWNLOAD" -o ./horusec
 
-    chmod +x ./horusec
+  chmod +x ./horusec
 
-    sudo mv ./horusec "$INSTALL_PATH"
+  sudo mv ./horusec "$INSTALL_PATH"
 
-    echo "Horusec was downloaded and moved to $INSTALL_PATH/horusec"
+  echo "Horusec was downloaded and moved to $INSTALL_PATH/horusec"
 
-    $INSTALL_PATH/horusec version
+  $INSTALL_PATH/horusec version
 }
 
-horusecIdentifyOS () {
-    if [ "$VERSION_DOWNLOAD" = "latest" ]; then
-      horusecIdentifyOSLatest
-    else
-      horusecIdentifyOSWithVersion
+horusecIdentifyOS() {
+  if [ "$VERSION_DOWNLOAD" = "latest" ]; then
+    horusecIdentifyOSLatest
+  else
+    horusecIdentifyOSWithVersion
+  fi
+}
+
+# After version 2.6.4 binaries have name changes, which cause a change in the download link.
+# This function checks if it is earlier or later than version 2.6.4 and through this we can decide which is the
+# correct download link for the version informed by the user.
+isOldURLVersion() {
+  if [ $VERSION_DOWNLOAD != "latest" ]; then
+    VERSION_WITHOUT_PREFIX=$(echo "$VERSION_DOWNLOAD" | sed -e "s/v//g")
+
+    VERSION_WITHOUT_DOTS=$(echo "$VERSION_WITHOUT_PREFIX" | sed -e "s/\.//g")
+
+    if [ "$VERSION_WITHOUT_DOTS" -gt 264 ]; then
+      IS_NEW_URL=true
     fi
+  fi
 }
 
 horusecSetVersion
+
+isOldURLVersion
 
 horusecIdentifyOS
 


### PR DESCRIPTION
> :warning: SHOULD BE MERGE ONLY WHEN THE NEXT RELEASE WITH THE BINARIES NAME CHANGES WAS RELEASED.

Signed-off-by: Nathan Martins <nathan.martins@zup.com.br>

This pull request contains changes to the new standard binaries names, that were changed in the pr #702.
Now binaries are sepated by archicteture, and this made needed a change to the install script, on the next release the binaries names will change and this pull request contains a validation to the old and the new standard.

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
