### PR TITLE
git: validate if repository is fully cloned

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+          fetch-depth: 0
       - uses: actions/setup-go@v2
         with:
           go-version: 1.17

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+          fetch-depth: 0
       - uses: actions/setup-go@v2
         with:
           go-version: 1.17

--- a/internal/helpers/messages/warn.go
+++ b/internal/helpers/messages/warn.go
@@ -34,4 +34,7 @@ const (
 	MsgWarnInfoVulnerabilitiesDisabled = "{HORUSEC_CLI} Horusec not show info vulnerabilities in this analysis, " +
 		"to see info vulnerabilities add option \"--information-severity=true\". " +
 		"For more details use (horusec start --help) command."
+	MsgWarnGitRepositoryIsNotFullCloned = "{HORUSEC_CLI} Repository is not fully cloned." +
+		"Commit author can result wrong authors. Check the documentation for more info." +
+		"https://horusec.io/docs/cli/installation/#2-installation-via-pipeline"
 )

--- a/internal/services/git/git.go
+++ b/internal/services/git/git.go
@@ -162,3 +162,15 @@ func (g *Git) existsGitFolderInPath() bool {
 
 	return true
 }
+
+// RepositoryIsShallow check if the ProjectPath is a shallow repository.
+// A shallow repository is when a repository was cloned using the --depth=N
+// where N is the number of commits that should be cloned.
+//
+// This git functionality is commonly used by CIs to clone the repository.
+//
+// For more read https://www.git-scm.com/docs/shallow
+func RepositoryIsShallow(cfg *config.Config) bool {
+	_, err := os.Stat(filepath.Join(cfg.ProjectPath, ".git", "shallow"))
+	return !os.IsNotExist(err)
+}


### PR DESCRIPTION
Previously if commit author was enable and the repository was cloned
using --depth flag the results of commit author was wrong since not
all commits are present in the repository. When a repository is cloned
using --depth flag a file named `shallow` is created inside .git
directory, so this commit add a validation to check if this file exists
when starting analysis, if this file exists a warning is printed
informing the user that the commit authors results could be wrong.

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
