### PR TITLE
engine: improving rule and adding tests for java 1, 3, 4

### DIFF
--- a/internal/services/engines/java/rules.go
+++ b/internal/services/engines/java/rules.go
@@ -38,6 +38,7 @@ func NewXMLParsingVulnerableToXXE() text.TextRule {
 		Expressions: []*regexp.Regexp{
 			regexp.MustCompile(`XMLReaderFactory\.createXMLReader\(`),
 			regexp.MustCompile(`\.parse\(`),
+			regexp.MustCompile(`(XMLReaderFactory\.createXMLReader\(\))(([^s]|s[^e]|se[^t]|set[^F]|setF[^e]|setFe[^a]|setFea[^t]|setFeat[^u]|setFeatu[^r]|setFeatur[^e])*)(\.parse\(.*\))`),
 		},
 	}
 }
@@ -71,6 +72,7 @@ func NewXMLParsingVulnerableToXXEWithDocumentBuilder() text.TextRule {
 		Expressions: []*regexp.Regexp{
 			regexp.MustCompile(`DocumentBuilderFactory\.newInstance\(`),
 			regexp.MustCompile(`\.parse\(`),
+			regexp.MustCompile(`(DocumentBuilderFactory\.newInstance\(\))(([^s]|s[^e]|se[^t]|set[^F]|setF[^e]|setFe[^a]|setFea[^t]|setFeat[^u]|setFeatu[^r]|setFeatur[^e])*)(\.parse\(.*\))`),
 		},
 	}
 }
@@ -88,6 +90,8 @@ func NewXMLParsingVulnerableToXXEWithSAXParserFactory() text.TextRule {
 		Expressions: []*regexp.Regexp{
 			regexp.MustCompile(`SAXParserFactory\.newInstance\(`),
 			regexp.MustCompile(`\.parse\(`),
+			regexp.MustCompile(`(SAXParserFactory\.newInstance\(\))(([^s]|s[^e]|se[^t]|set[^F]|setF[^e]|setFe[^a]|setFea[^t]|setFeat[^u]|setFeatu[^r]|setFeatur[^e])*)(\.parse\(.*\))`),
+
 		},
 	}
 }

--- a/internal/services/engines/java/rules_test.go
+++ b/internal/services/engines/java/rules_test.go
@@ -39,6 +39,34 @@ func TestRulesVulnerableCode(t *testing.T) {
 			},
 		},
 		{
+			Name: "HS-JAVA-3",
+			Rule: NewXMLParsingVulnerableToXXEWithDocumentBuilder(),
+			Src:  SampleVulnerableXMLParsingVulnerableToXXEWithDocumentBuilder,
+			Findings: []engine.Finding{
+				{
+					CodeSample: `DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();`,
+					SourceLocation: engine.Location{
+						Line:   4,
+						Column: 23,
+					},
+				},
+			},
+		},
+		{
+			Name: "HS-JAVA-4",
+			Rule: NewXMLParsingVulnerableToXXEWithSAXParserFactory(),
+			Src:  SampleVulnerableXMLParsingVulnerableToXXEWithSAXParserFactory,
+			Findings: []engine.Finding{
+				{
+					CodeSample: `SAXParser parser = SAXParserFactory.newInstance().newSAXParser();`,
+					SourceLocation: engine.Location{
+						Line:   4,
+						Column: 21,
+					},
+				},
+			},
+		},
+		{
 			Name: "HS-JAVA-134",
 			Rule: NewSQLInjection(),
 			Src:  SampleVulnerableJavaSQLInjection,
@@ -59,6 +87,21 @@ func TestRulesVulnerableCode(t *testing.T) {
 
 func TestRulesSafeCode(t *testing.T) {
 	testcases := []*testutil.RuleTestCase{
+		{
+			Name: "HS-JAVA-1",
+			Rule: NewXMLParsingVulnerableToXXE(),
+			Src:  SampleSafeJavaXMLParsingVulnerableToXXE,
+		},
+		{
+			Name: "HS-JAVA-3",
+			Rule: NewXMLParsingVulnerableToXXEWithDocumentBuilder(),
+			Src:  SampleSafeXMLParsingVulnerableToXXEWithDocumentBuilder,
+		},
+		{
+			Name: "HS-JAVA-4",
+			Rule: NewXMLParsingVulnerableToXXEWithSAXParserFactory(),
+			Src:  SampleSafeXMLParsingVulnerableToXXEWithSAXParserFactory,
+		},
 		{
 			Name: "HS-JAVA-134",
 			Rule: NewSQLInjection(),

--- a/internal/services/engines/java/sample_test.go
+++ b/internal/services/engines/java/sample_test.go
@@ -61,11 +61,70 @@ public class VulnerableCodeSQLInjection134 {
     }
 }
 `
+
 	SampleVulnerableJavaXMLParsingVulnerableToXXE = `
 class Foo {
 	void fn(String input) {
 		XMLReader reader = XMLReaderFactory.createXMLReader();
 		reader.parse(input)
+	}
+}
+	`
+
+	SampleSafeJavaXMLParsingVulnerableToXXE = `
+class Foo {
+	void bar() {
+		XMLReader reader = XMLReaderFactory.createXMLReader();
+		reader.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+		reader.setContentHandler(customHandler);
+		
+		reader.parse(new InputSource(inputStream));
+	}
+}
+	`
+
+	SampleVulnerableXMLParsingVulnerableToXXEWithDocumentBuilder = `
+class Foo {
+	void bar() {
+		DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+		
+		Document doc = db.parse(input);
+	}
+}
+	`
+
+	SampleSafeXMLParsingVulnerableToXXEWithDocumentBuilder = `
+class Foo {
+	void bar() {
+		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+		dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+		DocumentBuilder db = dbf.newDocumentBuilder();
+		
+		Document doc = db.parse(input);
+	}
+}
+	`
+
+	SampleVulnerableXMLParsingVulnerableToXXEWithSAXParserFactory = `
+class Foo {
+	void bar() {
+		SAXParser parser = SAXParserFactory.newInstance().newSAXParser();
+		
+		parser.parse(inputStream, customHandler);
+	}
+}
+	`
+
+	SampleSafeXMLParsingVulnerableToXXEWithSAXParserFactory = `
+class Foo {
+	void bar() {
+		SAXParserFactory spf = SAXParserFactory.newInstance();
+
+		spf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+
+		SAXParser parser = spf.newSAXParser();
+	
+		parser.parse(inputStream, customHandler);
 	}
 }
 	`


### PR DESCRIPTION
Signed-off-by: Nathan Martins <nathan.martins@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
HS-JAVA-1, HS-JAVA-3 and HS-JAVA-4 were taking both secure and vulnerable code, added new regex to avoid false positives. Also added vulnerable, safe samples and tests.

Samples:
 
HS-JAVA-1: https://find-sec-bugs.github.io/bugs.htm#XXE_XMLREADER
HS-JAVA-3: https://find-sec-bugs.github.io/bugs.htm#XXE_DOCUMENT
HS-JAVA-4: https://find-sec-bugs.github.io/bugs.htm#XXE_SAXPARSER

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
