### PR TITLE
utils/file: remove usage of find command to search for files

### DIFF
--- a/internal/controllers/analyzer/analyzer.go
+++ b/internal/controllers/analyzer/analyzer.go
@@ -16,6 +16,7 @@ package analyzer
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"log"
 	"os"
@@ -75,7 +76,6 @@ import (
 	"github.com/ZupIT/horusec/internal/services/formatters/swift/horusecswift"
 	"github.com/ZupIT/horusec/internal/services/formatters/yaml/horuseckubernetes"
 	horusecAPI "github.com/ZupIT/horusec/internal/services/horusec_api"
-	"github.com/ZupIT/horusec/internal/utils/file"
 )
 
 const LoadingDelay = 200 * time.Millisecond
@@ -157,7 +157,7 @@ func (a *Analyzer) removeTrashByInterruptProcess() {
 }
 
 func (a *Analyzer) removeHorusecFolder() {
-	err := os.RemoveAll(a.config.ProjectPath + file.ReplacePathSeparator("/.horusec"))
+	err := os.RemoveAll(filepath.Join(a.config.ProjectPath, ".horusec"))
 	logger.LogErrorWithLevel(messages.MsgErrorRemoveAnalysisFolder, err)
 	if !a.config.DisableDocker {
 		a.docker.DeleteContainersFromAPI()

--- a/internal/controllers/language_detect/language_detect.go
+++ b/internal/controllers/language_detect/language_detect.go
@@ -166,7 +166,7 @@ func (ld *LanguageDetect) checkFileExtensionInvalid(path string) bool {
 }
 
 func (ld *LanguageDetect) copyProjectToHorusecFolder(directory string) error {
-	folderDstName := file.ReplacePathSeparator(fmt.Sprintf("%s/.horusec/%s", directory, ld.analysisID.String()))
+	folderDstName := filepath.Join(directory, ".horusec", ld.analysisID.String())
 	err := copy.Copy(directory, folderDstName, ld.filesAndFoldersToIgnore)
 	if err != nil {
 		logger.LogErrorWithLevel(messages.MsgErrorCopyProjectToHorusecAnalysis, err)

--- a/internal/services/formatters/service.go
+++ b/internal/services/formatters/service.go
@@ -188,7 +188,7 @@ func (s *Service) truncatedCode(code string, column int) string {
 
 func (s *Service) GetFilepathFromFilename(filename, projectSubPath string) string {
 	basePath := file.ReplacePathSeparator(path.Join(s.GetConfigProjectPath(), projectSubPath))
-	filepath := file.GetPathIntoFilename(filename, basePath)
+	filepath := file.GetPathFromFilename(filename, basePath)
 	if filepath != "" {
 		return path.Join(projectSubPath, filepath[1:])
 	}

--- a/internal/utils/file/file_test.go
+++ b/internal/utils/file/file_test.go
@@ -18,55 +18,28 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/ZupIT/horusec/internal/utils/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetPath(t *testing.T) {
-	t.Run("Should return path correctly", func(t *testing.T) {
-		filePath := "file/file_test.go"
-		volume := "../../../.."
-		response := GetAbsFilePathIntoBasePath(filePath, volume)
-		assert.NotEqual(t, response, filePath)
-		assert.Contains(t, response, "/utils/file/file_test.go")
-	})
-	t.Run("Should return filePath because not found", func(t *testing.T) {
-		filePath := "some_other_not_existing_file.go"
-		volume := "../../../.."
-		response := GetAbsFilePathIntoBasePath(filePath, volume)
-		assert.Equal(t, response, filePath)
-	})
-	t.Run("Should return filePath because base path is wrong", func(t *testing.T) {
-		filePath := "some_other_not_existing_file.go"
-		volume := "S0M3 N0T E3X1$t"
-		response := GetAbsFilePathIntoBasePath(filePath, volume)
-		assert.Equal(t, response, filePath)
-	})
-	t.Run("Should return filePath because base path is not exists", func(t *testing.T) {
-		filePath := "some_other_not_existing_file.go"
-		volume := "./not_existing_path"
-		response := GetAbsFilePathIntoBasePath(filePath, volume)
-		assert.Equal(t, response, filePath)
-	})
-}
-
 func TestGetFilePathIntoBasePath(t *testing.T) {
 	t.Run("Should return path correctly", func(t *testing.T) {
-		filePath := "file/file_test.go"
-		volume := "../../../.."
-		response := GetPathIntoFilename(filePath, volume)
+		filePath := filepath.Join("file", "file_test.go")
+		volume := testutil.RootPath
+		response := GetPathFromFilename(filePath, volume)
 		assert.NotEqual(t, response, filePath)
-		assert.Contains(t, response, "/utils/file/file_test.go")
+		assert.Equal(t, filepath.Join("internal", "utils", "file", "file_test.go"), response)
 	})
 	t.Run("Should return filePath because not found", func(t *testing.T) {
 		filePath := "some_other_not_existing_file.go"
-		volume := "../../../.."
-		response := GetPathIntoFilename(filePath, volume)
+		volume := testutil.RootPath
+		response := GetPathFromFilename(filePath, volume)
 		assert.Equal(t, "", response)
 	})
 	t.Run("Should return filePath because base path is wrong", func(t *testing.T) {
 		filePath := "some_other_not_existing_file.go"
 		volume := "S0M3 N0T E3X1$t"
-		response := GetPathIntoFilename(filePath, volume)
+		response := GetPathFromFilename(filePath, volume)
 		assert.Equal(t, "", response)
 	})
 }


### PR DESCRIPTION
Previously some functions of utils/file package use the command find
to search for files, which make only Linux compatible and add an
unnecessary dependency. This commit change the implementation to use
filepath.Walk function and search using only the Go std.

This commit also make some improvements on function names, remove
dead code and add some documentation.

Also this commit change some usages of ReplacePathSeparator to use
filepath.Join instead which is a better approach since this package is
OS compatible. Note that not all usages of ReplacePathSeparator was
changed since in some cases we need to replace slashes on paths that
was returned from tools that run on Docker when we are running on
Windows.

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
