### PR TITLE
language_detect: improve tests, file matching checks and to_ignore paths

### DIFF
--- a/internal/controllers/language_detect/language_detect.go
+++ b/internal/controllers/language_detect/language_detect.go
@@ -21,8 +21,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ZupIT/horusec/internal/utils/file"
-
 	doubleStar "github.com/bmatcuk/doublestar/v4"
 	"github.com/go-enry/go-enry/v2"
 	"github.com/google/uuid"
@@ -90,7 +88,7 @@ func (ld *LanguageDetect) execWalkToGetLanguagesAndReturnIfSkip(
 	path string, info os.FileInfo) (languagesFound []string, skip bool) {
 	skip = ld.filesAndFoldersToIgnore(path)
 	if skip {
-		logger.LogDebugWithLevel(messages.MsgDebugFolderOrFileIgnored, path)
+		logger.LogDebugWithLevel(messages.MsgDebugFolderOrFileIgnored, filepath.Clean(path))
 	}
 	if !info.IsDir() && !skip {
 		newLanguages := enry.GetLanguages(path, nil)
@@ -135,12 +133,12 @@ func (ld *LanguageDetect) filesAndFoldersToIgnore(path string) bool {
 
 func (ld *LanguageDetect) checkDefaultPathsToIgnore(path string) bool {
 	for _, value := range toignore.GetDefaultFoldersToIgnore() {
-		if strings.Contains(path, file.ReplacePathSeparator(value)) {
+		if strings.Contains(path, value) {
 			return true
 		}
 	}
 	if !ld.configs.EnableGitHistoryAnalysis {
-		return strings.Contains(path, file.ReplacePathSeparator("/.git/"))
+		return strings.Contains(path, ".git")
 	}
 	return false
 }

--- a/internal/enums/toignore/to_ignore.go
+++ b/internal/enums/toignore/to_ignore.go
@@ -15,7 +15,7 @@
 package toignore
 
 func GetDefaultFoldersToIgnore() []string {
-	return []string{"/.horusec/", "/.idea/", "/.vscode/", "/node_modules/", "/vendor/"}
+	return []string{".horusec", ".idea", ".vscode", "node_modules", "vendor"}
 }
 
 func GetDefaultExtensionsToIgnore() []string {

--- a/internal/usecases/cli/cli_test.go
+++ b/internal/usecases/cli/cli_test.go
@@ -19,8 +19,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/ZupIT/horusec/internal/enums/outputtype"
 	validation "github.com/go-ozzo/ozzo-validation/v4"
+
+	"github.com/ZupIT/horusec/internal/enums/outputtype"
 
 	"github.com/stretchr/testify/assert"
 


### PR DESCRIPTION
this commits updates language detect tests and some file matching checks now using filepath.Join(), removing ReplacePathSeparator usages on this package as discussed in #719 and fix to_ignore paths to run as it should

Signed-off-by: Ian Cardoso <ian.cardoso@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
