### PR TITLE
Fix position and responsability of logs into horusec

### DIFF
--- a/cmd/app/start/start.go
+++ b/cmd/app/start/start.go
@@ -299,7 +299,6 @@ func (s *Start) runE(cmd *cobra.Command, _ []string) error {
 
 func (s *Start) startAnalysis(cmd *cobra.Command) (totalVulns int, err error) {
 	if err := s.askIfRunInDirectorySelected(s.isRunPromptQuestion(cmd)); err != nil {
-		logger.LogErrorWithLevel(messages.MsgErrorWhenAskDirToRun, err)
 		return 0, err
 	}
 	if err := s.configsValidations(cmd); err != nil {
@@ -357,10 +356,7 @@ func (s *Start) askIfRunInDirectorySelected(shouldAsk bool) error {
 			fmt.Sprintf("The folder selected is: [%s]. Proceed? [Y/n]", s.configs.ProjectPath),
 			"Y")
 		if err != nil {
-			logger.LogWarnWithLevel(messages.MsgErrorWhenAskDirToRun+`
-Please use the command below informing the directory you want to run the analysis: 
-horusec start -p ./
-`, err.Error())
+			logger.LogWarnWithLevel(messages.MsgWarnWhenAskDirToRun, err.Error())
 			return err
 		}
 		return s.validateReplyOfAsk(response)
@@ -374,7 +370,7 @@ func (s *Start) validateReplyOfAsk(response string) error {
 		return s.askIfRunInDirectorySelected(true)
 	}
 	if strings.EqualFold(response, "n") {
-		return errors.New("{HORUSEC_CLI} Operation was canceled by user")
+		return errors.New(messages.MsgErrorAskForUserCancelled)
 	}
 	return nil
 }

--- a/cmd/app/start/start_test.go
+++ b/cmd/app/start/start_test.go
@@ -559,21 +559,21 @@ func TestStartCommand_ExecuteIntegrationTest(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 	t.Run("Should execute command exec without error using json output", func(t *testing.T) {
-		prompt := &prompt.Mock{}
-		prompt.On("Ask").Return("Y", nil)
+		promptMock := &prompt.Mock{}
+		promptMock.On("Ask").Return("Y", nil)
 
 		cfg := config.New()
 		cfg.WorkDir = &workdir.WorkDir{}
 
-		requirements := &requirements.Mock{}
-		requirements.On("ValidateDocker")
+		requirementsMock := &requirements.Mock{}
+		requirementsMock.On("ValidateDocker")
 
 		cmd := &Start{
 			useCases:     cli.NewCLIUseCases(),
 			configs:      cfg,
-			prompt:       prompt,
+			prompt:       promptMock,
 			analyzer:     nil,
-			requirements: requirements,
+			requirements: requirementsMock,
 		}
 
 		oldStdout := os.Stdout
@@ -583,7 +583,7 @@ func TestStartCommand_ExecuteIntegrationTest(t *testing.T) {
 		outC := make(chan string)
 		go func() {
 			var buf bytes.Buffer
-			io.Copy(&buf, r)
+			_, _ = io.Copy(&buf, r)
 			outC <- buf.String()
 		}()
 		cobraCmd := cmd.CreateStartCommand()
@@ -610,25 +610,25 @@ func TestStartCommand_ExecuteIntegrationTest(t *testing.T) {
 		assert.NoError(t, err)
 		bytesFileString := string(bytesFile)
 		assert.Contains(t, bytesFileString, "\"analysisVulnerabilities\": null")
-		prompt.AssertNotCalled(t, "Ask")
+		promptMock.AssertNotCalled(t, "Ask")
 		assert.NoError(t, os.RemoveAll("./tmp-json.json"))
 	})
 	t.Run("Should execute command exec without error showing info vulnerabilities", func(t *testing.T) {
-		prompt := &prompt.Mock{}
-		prompt.On("Ask").Return("Y", nil)
+		promptMock := &prompt.Mock{}
+		promptMock.On("Ask").Return("Y", nil)
 
 		cfg := config.New()
 		cfg.WorkDir = &workdir.WorkDir{}
 
-		requirements := &requirements.Mock{}
-		requirements.On("ValidateDocker")
+		requirementsMock := &requirements.Mock{}
+		requirementsMock.On("ValidateDocker")
 
 		cmd := &Start{
 			useCases:     cli.NewCLIUseCases(),
 			configs:      cfg,
-			prompt:       prompt,
+			prompt:       promptMock,
 			analyzer:     nil,
-			requirements: requirements,
+			requirements: requirementsMock,
 		}
 		oldStdout := os.Stdout
 
@@ -637,7 +637,7 @@ func TestStartCommand_ExecuteIntegrationTest(t *testing.T) {
 		outC := make(chan string)
 		go func() {
 			var buf bytes.Buffer
-			io.Copy(&buf, r)
+			_, _ = io.Copy(&buf, r)
 			outC <- buf.String()
 		}()
 		cobraCmd := cmd.CreateStartCommand()
@@ -658,24 +658,24 @@ func TestStartCommand_ExecuteIntegrationTest(t *testing.T) {
 		assert.Contains(t, output, "YOUR ANALYSIS HAD FINISHED WITHOUT ANY VULNERABILITY!")
 		assert.NotContains(t, output, "{HORUSEC_CLI} Horusec not show info vulnerabilities in this analysis")
 
-		prompt.AssertNotCalled(t, "Ask")
+		promptMock.AssertNotCalled(t, "Ask")
 	})
 	t.Run("Should execute command exec without error sending to web application", func(t *testing.T) {
-		prompt := &prompt.Mock{}
-		prompt.On("Ask").Return("Y", nil)
+		promptMock := &prompt.Mock{}
+		promptMock.On("Ask").Return("Y", nil)
 
 		cfg := config.New()
 		cfg.WorkDir = &workdir.WorkDir{}
 
-		requirements := &requirements.Mock{}
-		requirements.On("ValidateDocker")
+		requirementsMock := &requirements.Mock{}
+		requirementsMock.On("ValidateDocker")
 
 		cmd := &Start{
 			useCases:     cli.NewCLIUseCases(),
 			configs:      cfg,
-			prompt:       prompt,
+			prompt:       promptMock,
 			analyzer:     nil,
-			requirements: requirements,
+			requirements: requirementsMock,
 		}
 		oldStdout := os.Stdout
 
@@ -684,7 +684,7 @@ func TestStartCommand_ExecuteIntegrationTest(t *testing.T) {
 		outC := make(chan string)
 		go func() {
 			var buf bytes.Buffer
-			io.Copy(&buf, r)
+			_, _ = io.Copy(&buf, r)
 			outC <- buf.String()
 		}()
 		cobraCmd := cmd.CreateStartCommand()
@@ -704,24 +704,24 @@ func TestStartCommand_ExecuteIntegrationTest(t *testing.T) {
 		assert.NotContains(t, output, "{HORUSEC_CLI} No authorization token was found, your code it is not going to be sent to horusec. Please enter a token with the -a flag to configure and save your analysis")
 		assert.Contains(t, output, "YOUR ANALYSIS HAD FINISHED WITHOUT ANY VULNERABILITY!")
 
-		prompt.AssertNotCalled(t, "Ask")
+		promptMock.AssertNotCalled(t, "Ask")
 	})
 	t.Run("Should execute command exec without error using sonarqube output", func(t *testing.T) {
-		prompt := &prompt.Mock{}
-		prompt.On("Ask").Return("Y", nil)
+		promptMock := &prompt.Mock{}
+		promptMock.On("Ask").Return("Y", nil)
 
 		cfg := config.New()
 		cfg.WorkDir = &workdir.WorkDir{}
 
-		requirements := &requirements.Mock{}
-		requirements.On("ValidateDocker")
+		requirementsMock := &requirements.Mock{}
+		requirementsMock.On("ValidateDocker")
 
 		cmd := &Start{
 			useCases:     cli.NewCLIUseCases(),
 			configs:      cfg,
-			prompt:       prompt,
+			prompt:       promptMock,
 			analyzer:     nil,
-			requirements: requirements,
+			requirements: requirementsMock,
 		}
 
 		oldStdout := os.Stdout
@@ -731,7 +731,7 @@ func TestStartCommand_ExecuteIntegrationTest(t *testing.T) {
 		outC := make(chan string)
 		go func() {
 			var buf bytes.Buffer
-			io.Copy(&buf, r)
+			_, _ = io.Copy(&buf, r)
 			outC <- buf.String()
 		}()
 		cobraCmd := cmd.CreateStartCommand()
@@ -758,7 +758,7 @@ func TestStartCommand_ExecuteIntegrationTest(t *testing.T) {
 		assert.NoError(t, err)
 		bytesFileString := string(bytesFile)
 		assert.Contains(t, bytesFileString, "\"issues\": []")
-		prompt.AssertNotCalled(t, "Ask")
+		promptMock.AssertNotCalled(t, "Ask")
 		assert.NoError(t, os.RemoveAll("./tmp-sonarqube.json"))
 	})
 	t.Run("Should execute command exec without error and return vulnerabilities of gitleaks but ignore vulnerabilities of the HIGH", func(t *testing.T) {
@@ -767,22 +767,22 @@ func TestStartCommand_ExecuteIntegrationTest(t *testing.T) {
 		assert.NoError(t, copy.Copy(srcProject, dstProject, func(src string) bool {
 			return false
 		}))
-		prompt := &prompt.Mock{}
-		prompt.On("Ask").Return("Y", nil)
+		promptMock := &prompt.Mock{}
+		promptMock.On("Ask").Return("Y", nil)
 
 		cfg := config.New()
 		cfg.ConfigFilePath = "./not-exists.json"
 		cfg.WorkDir = &workdir.WorkDir{}
 
-		requirements := &requirements.Mock{}
-		requirements.On("ValidateDocker")
+		requirementsMock := &requirements.Mock{}
+		requirementsMock.On("ValidateDocker")
 
 		cmd := &Start{
 			useCases:     cli.NewCLIUseCases(),
 			configs:      cfg,
-			prompt:       prompt,
+			prompt:       promptMock,
 			analyzer:     nil,
-			requirements: requirements,
+			requirements: requirementsMock,
 		}
 
 		oldStdout := os.Stdout
@@ -792,7 +792,7 @@ func TestStartCommand_ExecuteIntegrationTest(t *testing.T) {
 		outC := make(chan string)
 		go func() {
 			var buf bytes.Buffer
-			io.Copy(&buf, r)
+			_, _ = io.Copy(&buf, r)
 			outC <- buf.String()
 		}()
 		cobraCmd := cmd.CreateStartCommand()
@@ -812,9 +812,9 @@ func TestStartCommand_ExecuteIntegrationTest(t *testing.T) {
 		assert.Contains(t, output, "Total of Vulnerability MEDIUM is: 5")
 		assert.Contains(t, output, "Total of Vulnerability HIGH is: 11")
 		assert.Contains(t, output, "{HORUSEC_CLI} No authorization token was found, your code it is not going to be sent to horusec. Please enter a token with the -a flag to configure and save your analysis")
-		assert.Contains(t, output, "[HORUSEC] 16 VULNERABILITIES WERE FOUND IN YOUR CODE SENT TO HORUSEC, TO SEE MORE DETAILS USE THE LOG LEVEL AS DEBUG AND TRY AGAIN")
+		assert.Contains(t, output, "{HORUSEC_CLI} 16 VULNERABILITIES WERE FOUND IN YOUR CODE SENT TO HORUSEC, TO SEE MORE DETAILS USE THE LOG LEVEL AS DEBUG AND TRY AGAIN")
 		assert.Contains(t, output, "{HORUSEC_CLI} Horusec not show info vulnerabilities in this analysis")
-		prompt.AssertNotCalled(t, "Ask")
+		promptMock.AssertNotCalled(t, "Ask")
 		assert.NoError(t, os.RemoveAll(dstProject))
 	})
 	t.Run("Should execute command exec without error and return vulnerabilities of gitleaks and return error", func(t *testing.T) {
@@ -823,21 +823,21 @@ func TestStartCommand_ExecuteIntegrationTest(t *testing.T) {
 		assert.NoError(t, copy.Copy(srcProject, dstProject, func(src string) bool {
 			return false
 		}))
-		prompt := &prompt.Mock{}
-		prompt.On("Ask").Return("Y", nil)
+		promptMock := &prompt.Mock{}
+		promptMock.On("Ask").Return("Y", nil)
 
 		cfg := config.New()
 		cfg.WorkDir = &workdir.WorkDir{}
 
-		requirements := &requirements.Mock{}
-		requirements.On("ValidateDocker")
+		requirementMock := &requirements.Mock{}
+		requirementMock.On("ValidateDocker")
 
 		cmd := &Start{
 			useCases:     cli.NewCLIUseCases(),
 			configs:      cfg,
-			prompt:       prompt,
+			prompt:       promptMock,
 			analyzer:     nil,
-			requirements: requirements,
+			requirements: requirementMock,
 		}
 		oldStdout := os.Stdout
 
@@ -846,7 +846,7 @@ func TestStartCommand_ExecuteIntegrationTest(t *testing.T) {
 		outC := make(chan string)
 		go func() {
 			var buf bytes.Buffer
-			io.Copy(&buf, r)
+			_, _ = io.Copy(&buf, r)
 			outC <- buf.String()
 		}()
 		cobraCmd := cmd.CreateStartCommand()
@@ -864,10 +864,10 @@ func TestStartCommand_ExecuteIntegrationTest(t *testing.T) {
 		assert.Contains(t, output, "FOLDER BEFORE THE ANALYSIS FINISH! Don’t worry, we’ll remove it after the analysis ends automatically! Project sent to folder in location: ")
 		assert.Contains(t, output, "Horusec will return a timeout after 600 seconds. This time can be customized in the cli settings.")
 		assert.Contains(t, output, "{HORUSEC_CLI} No authorization token was found, your code it is not going to be sent to horusec. Please enter a token with the -a flag to configure and save your analysis")
-		assert.Contains(t, output, "[HORUSEC] 25 VULNERABILITIES WERE FOUND IN YOUR CODE SENT TO HORUSEC, TO SEE MORE DETAILS USE THE LOG LEVEL AS DEBUG AND TRY AGAIN")
+		assert.Contains(t, output, "{HORUSEC_CLI} 25 VULNERABILITIES WERE FOUND IN YOUR CODE SENT TO HORUSEC, TO SEE MORE DETAILS USE THE LOG LEVEL AS DEBUG AND TRY AGAIN")
 		assert.Contains(t, output, "{HORUSEC_CLI} Horusec not show info vulnerabilities in this analysis")
 		assert.Contains(t, output, "")
-		prompt.AssertNotCalled(t, "Ask")
+		promptMock.AssertNotCalled(t, "Ask")
 		assert.NoError(t, os.RemoveAll(dstProject))
 	})
 }

--- a/config/config.go
+++ b/config/config.go
@@ -423,7 +423,7 @@ func (c *Config) IsEmptyRepositoryAuthorization() bool {
 func (c *Config) setViperConfigsAndReturnIfExistFile() bool {
 	logger.LogDebugWithLevel(messages.MsgDebugConfigFileRunningOnPath + c.ConfigFilePath)
 	if _, err := os.Stat(c.ConfigFilePath); os.IsNotExist(err) {
-		logger.LogWarn(messages.MsgDebugConfigFileNotFoundOnPath)
+		logger.LogWarn(messages.MsgWarnConfigFileNotFoundOnPath)
 		return false
 	}
 	viper.SetConfigFile(c.ConfigFilePath)

--- a/internal/controllers/language_detect/language_detect.go
+++ b/internal/controllers/language_detect/language_detect.go
@@ -172,7 +172,7 @@ func (ld *LanguageDetect) copyProjectToHorusecFolder(directory string) error {
 		logger.LogErrorWithLevel(messages.MsgErrorCopyProjectToHorusecAnalysis, err)
 	} else {
 		fmt.Print("\n")
-		logger.LogWarnWithLevel(fmt.Sprintf(messages.MsgInfoMonitorTimeoutIn, ld.configs.TimeoutInSecondsAnalysis))
+		logger.LogWarnWithLevel(fmt.Sprintf(messages.MsgWarnMonitorTimeoutIn, ld.configs.TimeoutInSecondsAnalysis))
 		fmt.Print("\n")
 		logger.LogWarnWithLevel(messages.MsgWarnDontRemoveHorusecFolder, folderDstName)
 		fmt.Print("\n")

--- a/internal/controllers/printresults/print_results.go
+++ b/internal/controllers/printresults/print_results.go
@@ -79,7 +79,7 @@ func (pr *PrintResults) Print() (totalVulns int, err error) {
 	pr.printResponseAnalysis()
 	pr.checkIfExistsErrorsInAnalysis()
 	if pr.configs.IsTimeout {
-		logger.LogWarnWithLevel(messages.MsgErrorTimeoutOccurs)
+		logger.LogWarnWithLevel(messages.MsgWarnTimeoutOccurs)
 	}
 
 	return pr.totalVulns, nil
@@ -317,7 +317,7 @@ func (pr *PrintResults) checkIfExistsErrorsInAnalysis() {
 	}
 	if pr.analysis.HasErrors() {
 		pr.logSeparator(true)
-		logger.LogWarnWithLevel(messages.MsgErrorFoundErrorsInAnalysis)
+		logger.LogWarnWithLevel(messages.MsgWarnFoundErrorsInAnalysis)
 		fmt.Print("\n")
 
 		for _, errorMessage := range strings.SplitAfter(pr.analysis.Errors, ";") {
@@ -342,12 +342,12 @@ func (pr *PrintResults) printErrors(errorMessage string) {
 
 func (pr *PrintResults) printResponseAnalysis() {
 	if pr.totalVulns > 0 {
-		logger.LogWarnWithLevel(fmt.Sprintf(messages.MsgAnalysisFoundVulns, pr.totalVulns))
+		logger.LogWarnWithLevel(fmt.Sprintf(messages.MsgWarnAnalysisFoundVulns, pr.totalVulns))
 		fmt.Print("\n")
 		return
 	}
 
-	logger.LogWarnWithLevel(messages.MsgAnalysisFinishedWithoutVulns)
+	logger.LogWarnWithLevel(messages.MsgWarnAnalysisFinishedWithoutVulns)
 	fmt.Print("\n")
 }
 

--- a/internal/controllers/requirements/docker/docker.go
+++ b/internal/controllers/requirements/docker/docker.go
@@ -71,7 +71,7 @@ func (r *RequirementDocker) execDockerVersion() (string, error) {
 	responseBytes, err := exec.Command("docker", "-v").CombinedOutput()
 	if err != nil {
 		logger.LogErrorWithLevel(
-			messages.MsgErrorWhenCheckRequirements+"output: ", errors.New(string(responseBytes)))
+			messages.MsgErrorWhenCheckRequirementsDocker, errors.New(string(responseBytes)))
 		return "", err
 	}
 	return strings.ToLower(string(responseBytes)), nil
@@ -81,7 +81,7 @@ func (r *RequirementDocker) checkIfDockerIsRunning() error {
 	responseBytes, err := exec.Command("docker", "ps").CombinedOutput()
 	if err != nil {
 		logger.LogErrorWithLevel(
-			messages.MsgErrorWhenCheckDockerRunnnig+"output: ", errors.New(string(responseBytes)))
+			messages.MsgErrorWhenCheckDockerRunning, errors.New(string(responseBytes)))
 	}
 	return err
 }
@@ -95,7 +95,7 @@ func (r *RequirementDocker) validateIfDockerIsRunningInMinVersion(response strin
 
 	if version <= MinVersionDockerAccept && subversion < MinSubVersionDockerAccept {
 		fmt.Print("\n")
-		logger.LogWarn(messages.MsgDockerLowerVersion)
+		logger.LogInfo(messages.MsgInfoDockerLowerVersion)
 		fmt.Print("\n")
 	}
 

--- a/internal/controllers/requirements/git/git.go
+++ b/internal/controllers/requirements/git/git.go
@@ -69,7 +69,7 @@ func (r *RequirementGit) validateIfGitIsSupported(version string) error {
 func (r *RequirementGit) execGitVersion() (string, error) {
 	responseBytes, err := exec.Command("git", "--version").CombinedOutput()
 	if err != nil {
-		logger.LogErrorWithLevel(messages.MsgErrorWhenCheckRequirements, err)
+		logger.LogErrorWithLevel(messages.MsgErrorWhenCheckRequirementsGit, err)
 		return "", err
 	}
 	return strings.ToLower(string(responseBytes)), nil

--- a/internal/entities/docker/analysis_data_test.go
+++ b/internal/entities/docker/analysis_data_test.go
@@ -42,7 +42,9 @@ func TestSetData(t *testing.T) {
 			CMD: "test",
 		}
 
-		assert.NotEmpty(t, data.SetData("other-host.io/t/test:latest", "test:v1.0.0"))
+		newData := data.SetData("other-host.io/t/test:latest", "test:v1.0.0")
+		assert.Equal(t, "other-host.io/t/test:latest", newData.CustomImage)
+		assert.Equal(t, "docker.io/test:v1.0.0", newData.DefaultImage)
 	})
 
 }

--- a/internal/helpers/messages/debug.go
+++ b/internal/helpers/messages/debug.go
@@ -14,34 +14,22 @@
 
 package messages
 
+// Block of messages usage into log of the level debug
 const (
-	// Fired when start pull new image in docker
-	MsgDebugDockerAPIPullNewImage = "{HORUSEC_CLI} Docker pull new image: "
-	// Fired when image was finish download with success
+	MsgDebugDockerAPIPullNewImage        = "{HORUSEC_CLI} Docker pull new image: "
 	MsgDebugDockerAPIDownloadWithSuccess = "{HORUSEC_CLI} Docker download new image with success: "
-	// Fired when container will be created
-	MsgDebugDockerAPIContainerCreated = "{HORUSEC_CLI} Docker create new container: "
-	// Fired when wait container start analysis of the project
-	MsgDebugDockerAPIContainerWait = "{HORUSEC_CLI} Docker wait container up..."
-	// Fired when read container output of the analysis
-	MsgDebugDockerAPIContainerRead = "{HORUSEC_CLI} Docker read container output: "
-	// Fired when analysis is finished and return success
-	MsgDebugDockerAPIFinishedSuccess = "{HORUSEC_CLI} Docker Finished analysis with SUCCESS: "
-	// Fired when analysis is finished and return error
-	MsgDebugDockerAPIFinishedError = "{HORUSEC_CLI} Docker Finished analysis with ERROR: "
-	// Fired when tool start an analysis
-	MsgDebugToolStartAnalysis = "{HORUSEC_CLI} Running {{0}} - {{1}} in analysisID: "
-	// Fired when tool finish an analysis
-	MsgDebugToolFinishAnalysis = "{HORUSEC_CLI} {{0}} - {{1}} is finished in analysisID: "
-	// Fired when output of the analysis was run in docker is empty
-	MsgDebugOutputEmpty              = "{HORUSEC_CLI} When format Output it's Empty!"
-	MsgDebugConfigFileRunningOnPath  = "{HORUSEC_CLI} Config file running on path: "
-	MsgDebugConfigFileNotFoundOnPath = "{HORUSEC_CLI} Config file not found"
-	// Fired when occurs of ignore folder or file to send horusec analysis
-	MsgDebugFolderOrFileIgnored = "{HORUSEC_CLI} The file or folder was ignored to send analysis:"
-	// Fired when configs already validate and before start analysis
-	MsgDebugShowConfigs   = "{HORUSEC_CLI} The current configuration for this analysis are:"
-	MsgDebugShowWorkdir   = "{HORUSEC_CLI} The workdir setup for run in path:"
-	MsgDebugToolIgnored   = "{HORUSEC_CLI} The tool was ignored for run in this analysis: "
-	MsgDebugVulnHashToFix = "{HORUSEC_CLI} Vulnerability Hash expected to be FIXED: "
+	MsgDebugDockerAPIContainerCreated    = "{HORUSEC_CLI} Docker create new container: "
+	MsgDebugDockerAPIContainerWait       = "{HORUSEC_CLI} Docker wait container up..."
+	MsgDebugDockerAPIContainerRead       = "{HORUSEC_CLI} Docker read container output: "
+	MsgDebugDockerAPIFinishedSuccess     = "{HORUSEC_CLI} Docker Finished analysis with SUCCESS: "
+	MsgDebugDockerAPIFinishedError       = "{HORUSEC_CLI} Docker Finished analysis with ERROR: "
+	MsgDebugToolStartAnalysis            = "{HORUSEC_CLI} Running {{0}} - {{1}} in analysisID: "
+	MsgDebugToolFinishAnalysis           = "{HORUSEC_CLI} {{0}} - {{1}} is finished in analysisID: "
+	MsgDebugOutputEmpty                  = "{HORUSEC_CLI} When format Output it's Empty!"
+	MsgDebugConfigFileRunningOnPath      = "{HORUSEC_CLI} Config file running on path: "
+	MsgDebugFolderOrFileIgnored          = "{HORUSEC_CLI} The file or folder was ignored to send analysis:"
+	MsgDebugShowConfigs                  = "{HORUSEC_CLI} The current configuration for this analysis are:"
+	MsgDebugShowWorkdir                  = "{HORUSEC_CLI} The workdir setup for run in path:"
+	MsgDebugToolIgnored                  = "{HORUSEC_CLI} The tool was ignored for run in this analysis: "
+	MsgDebugVulnHashToFix                = "{HORUSEC_CLI} Vulnerability Hash expected to be FIXED: "
 )

--- a/internal/helpers/messages/error.go
+++ b/internal/helpers/messages/error.go
@@ -14,68 +14,19 @@
 
 package messages
 
+// Block of messages usage into error response
 const (
-	// Fired when occurs timeout on wait analysis Finish
-	MsgErrorTimeoutOccurs = "{HORUSEC_CLI} Some analysis was not completed due to the timeout, " +
-		"increase the time with -t flag and try again."
-	// USED IN USE CASES: Fired when the project path is invalid
-	MsgErrorPathNotValid = "invalid path: "
-	// USED IN USE CASES: Fired when an path of json is not valid in configs
-	MsgErrorJSONOutputFilePathNotValid = "Output File path is required or is invalid: "
-	// USED IN USE CASES: Fired when an severity is not allowed in configs
-	MsgErrorSeverityNotValid = "Type of severity not valid: "
-	// USED IN USE CASES: Fired when an false positive is not allowed in configs
-	MsgErrorFalsePositiveNotValid = "False positive is not valid because is duplicated in risk accept: "
-	// USED IN USE CASES: Fired when an risk accept is not allowed in configs
-	MsgErrorRiskAcceptNotValid = "Risk Accept is not valid because is duplicated in false positive: "
-	// Fired when an unexpected error occurs when check if the requirements it's ok
-	MsgErrorWhenCheckRequirements = "{HORUSEC_CLI} Error when check if requirements it's ok!"
-	// Fired when an unexpected error occurs when check if the docker is running
-	MsgErrorWhenCheckDockerRunnnig = "{HORUSEC_CLI} Error when check if docker is running in requirements, "
-	// Fired when docker is running in lower version
-	MsgErrorWhenDockerIsLowerVersion = "{HORUSEC_CLI} Your docker version is below of: "
-	// Fired when git is running in lower version
-	MsgErrorWhenGitIsLowerVersion = "{HORUSEC_CLI} Your git version is below of: "
-	// Fired when an unexpected error occurs when asking if the project directory is correct
-	MsgErrorWhenAskDirToRun = "{HORUSEC_CLI} Error when ask if can run prompt question."
-	// Fired when user-provided settings are invalid
-	MsgErrorInvalidConfigs = "{HORUSEC_CLI} Errors on validate configuration: "
-	// Fired when an unexpected error occurs when try remove analysis folder
-	MsgErrorRemoveAnalysisFolder = "{HORUSEC_CLI} Error when remove analysis project inside .horusec"
-	// Fired when an unexpected error occurs when try detect languages of the project
-	MsgErrorDetectLanguage = "{HORUSEC_CLI} Error when detect language"
-	// Fired when an unexpected error occurs when try copy project analysis to .horusec folder
-	MsgErrorCopyProjectToHorusecAnalysis = "{HORUSEC_CLI} Error when copy project to .horusec folder"
-	// Fired when an unexpected error occurs when try generate files json
-	MsgErrorGenerateJSONFile = "{HORUSEC_CLI} Error when try parse horusec analysis to output"
-	// Fired when an unexpected error occurs when try pull image in the docker
-	MsgErrorDockerPullImage = "{HORUSEC_CLI} Error when pull new image: "
-	// Fired when an unexpected error occurs when try pull list images in the docker
-	MsgErrorDockerListImages = "{HORUSEC_CLI} Error when list all images enable: "
-	// Fired when an unexpected error occurs when try create container of analysis in the docker
-	MsgErrorDockerCreateContainer = "{HORUSEC_CLI} Error when create container of analysis: "
-	// Fired when an unexpected error occurs when try start container of analysis in the docker
-	MsgErrorDockerStartContainer = "{HORUSEC_CLI} Error when start container of analysis: "
-	// Fired when an unexpected error occurs when try list all containers of analysis in the docker
-	MsgErrorDockerListAllContainers = "{HORUSEC_CLI} Error when list all containers of analysis: "
-	// Fired when an unexpected error occurs when try remove container of analysis in the docker
-	MsgErrorDockerRemoveContainer = "{HORUSEC_CLI} Error when remove container of analysis: "
-	// Fired when an unexpected error occurs when try execute command to extract commit authors of an vulnerability
-	MsgErrorGitCommitAuthorsExecute = "{HORUSEC_CLI} Error when execute commit author command: "
-	// Fired when an unexpected error occurs when try parse output commit authors to struct CommitAuthors
-	MsgErrorGitCommitAuthorsParseOutput = "{HORUSEC_CLI} Error when to parse output to commit author struct: "
-	// Fired when validate vulnerability types to show
-	MsgVulnerabilityTypeToShowInvalid = "{HORUSEC_CLI} Error on validate vulnerability type to show, wrong type: "
-	// Fired when an unexpected error occurs when run tool in docker
-	MsgErrorRunToolInDocker = "{HORUSEC_CLI} Something error went wrong in {{0}} tool " +
+	MsgErrorPathNotValid                        = "invalid path: "
+	MsgErrorJSONOutputFilePathNotValidExtension = "Output File path not valid file of type:"
+	MsgErrorJSONOutputFilePathNotValidUnknown   = "Output File path is required or is invalid:"
+	MsgErrorSeverityNotValid                    = "Type of severity not valid. See severities enable:"
+	MsgErrorAskForUserCancelled                 = "{HORUSEC_CLI} Operation was canceled by user"
+	MsgVulnerabilityTypeToShowInvalid           = "{HORUSEC_CLI} Error on validate vulnerability type is wrong type: "
+	MsgErrorRunToolInDocker                     = "{HORUSEC_CLI} Something error went wrong in {{0}} tool " +
 		"| analysisID -> {{1}} | output -> {{2}}"
-	// Fired when to be parse string of the WorkDir Entity and return error
-	MsgErrorParseStringToWorkDir = "{HORUSEC_CLI} Error when try parse workdir string to entity. Returning default values"
-	// Fired when to be parse string of the WorkDir Entity and return error
-	MsgErrorParseStringToToolsConfig = "{HORUSEC_CLI} Error when try parse tools config string to entity." +
-		" Returning default values"
-	// Fired when finish analysis and send to print results and exists errors in analysis
-	MsgErrorFoundErrorsInAnalysis   = "{HORUSEC_CLI} During execution we found some problems:"
+	MsgErrorInvalidWorkDir           = "{HORUSEC_CLI} Workdir is nil! Check the configuration and try again"
+	MsgErrorParseStringToToolsConfig = "{HORUSEC_CLI} Error when try parse tools config string to entity. " +
+		"Returning default values"
 	MsgErrorNotFoundRequirementsTxt = "{HORUSEC_CLI} Error The file requirements.txt not found in python project to " +
 		"start analysis. It would be a good idea to commit it so horusec can check for vulnerabilities"
 	MsgErrorPacketJSONNotFound = "{HORUSEC_CLI} Error It looks like your project doesn't have a package-lock.json " +
@@ -84,16 +35,41 @@ const (
 	MsgErrorYarnLockNotFound = "{HORUSEC_CLI} Error It looks like your project doesn't have a yarn.lock file. " +
 		"If you use Yarn to handle your dependencies, it would be a good idea to commit it so horusec " +
 		"can check for vulnerabilities"
-	MsgErrorYarnProcess             = "{HORUSEC_CLI} Error Yarn returned an error: "
-	MsgErrorDeferFileClose          = "{HORUSEC_CLI} Error defer file close: "
-	MsgErrorGetCurrentPath          = "{HORUSEC-CLI} Error on get current path"
-	MsgErrorSetHeadersOnConfig      = "{HORUSEC-CLI} Error on set headers on configurations"
-	MsgErrorReplayWrong             = "{HORUSEC-CLI} Error on set reply, Please type Y or N. Your current response was: "
-	MsgErrorErrorOnCreateConfigFile = "{HORUSEC-CLI} Error on create config file: "
-	MsgErrorErrorOnReadConfigFile   = "{HORUSEC-CLI} Error on read config file on path: "
-	MsgErrorGemLockNotFound         = "{HORUSEC_CLI} Error It looks like your project doesn't have a gemfile.lock file, " +
+	MsgErrorYarnProcess     = "{HORUSEC_CLI} Error Yarn returned an error: "
+	MsgErrorGemLockNotFound = "{HORUSEC_CLI} Error It looks like your project doesn't have a gemfile.lock file, " +
 		"it would be a good idea to commit it so horusec can check for vulnerabilities"
+)
+
+// Block of messages usage into log of the level error
+const (
+	MsgErrorFalsePositiveNotValid        = "False positive is not valid because is duplicated in risk accept:"
+	MsgErrorRiskAcceptNotValid           = "Risk Accept is not valid because is duplicated in false positive:"
+	MsgErrorWhenCheckRequirementsGit     = "{HORUSEC_CLI} Error when check if git requirement it's ok!"
+	MsgErrorWhenCheckRequirementsDocker  = "{HORUSEC_CLI} Error when check if docker requirement it's ok!"
+	MsgErrorWhenCheckDockerRunning       = "{HORUSEC_CLI} Error when check if docker is running."
+	MsgErrorWhenDockerIsLowerVersion     = "{HORUSEC_CLI} Your docker version is below of: "
+	MsgErrorWhenGitIsLowerVersion        = "{HORUSEC_CLI} Your git version is below of: "
+	MsgErrorInvalidConfigs               = "{HORUSEC_CLI} Errors on validate configuration: "
+	MsgErrorRemoveAnalysisFolder         = "{HORUSEC_CLI} Error when remove analysis project inside .horusec"
+	MsgErrorDetectLanguage               = "{HORUSEC_CLI} Error when detect language"
+	MsgErrorCopyProjectToHorusecAnalysis = "{HORUSEC_CLI} Error when copy project to .horusec folder"
+	MsgErrorGenerateJSONFile             = "{HORUSEC_CLI} Error when try parse horusec analysis to output"
+	MsgErrorDockerPullImage              = "{HORUSEC_CLI} Error when pull new image: "
+	MsgErrorDockerListImages             = "{HORUSEC_CLI} Error when list all images enable: "
+	MsgErrorDockerCreateContainer        = "{HORUSEC_CLI} Error when create container of analysis: "
+	MsgErrorDockerStartContainer         = "{HORUSEC_CLI} Error when start container of analysis: "
+	MsgErrorDockerListAllContainers      = "{HORUSEC_CLI} Error when list all containers of analysis: "
+	MsgErrorDockerRemoveContainer        = "{HORUSEC_CLI} Error when remove container of analysis: "
+	MsgErrorGitCommitAuthorsExecute      = "{HORUSEC_CLI} Error when execute commit author command: "
+	MsgErrorGitCommitAuthorsParseOutput  = "{HORUSEC_CLI} Error when to parse output to commit author struct: "
+	MsgErrorParseStringToWorkDir         = "{HORUSEC_CLI} Error when try parse workdir string to entity." +
+		"Returning default values"
+	MsgErrorDeferFileClose           = "{HORUSEC_CLI} Error defer file close: "
+	MsgErrorSetHeadersOnConfig       = "{HORUSEC-CLI} Error on set headers on configurations"
+	MsgErrorReplayWrong              = "{HORUSEC-CLI} Error on set reply, Please type Y or N. Your current response was: "
+	MsgErrorErrorOnCreateConfigFile  = "{HORUSEC-CLI} Error on create config file: "
+	MsgErrorErrorOnReadConfigFile    = "{HORUSEC-CLI} Error on read config file on path: "
 	MsgErrorFailedToPullImage        = "{HORUSEC_CLI} Failed to pull docker image"
 	MsgErrorWhileParsingCustomImages = "{HORUSEC_CLI} Error when parsing custom images config."
-	MsgErrorSettingLogFile           = "{HORUSEC_CLI} Error when setting log file."
+	MsgErrorSettingLogFile           = "{HORUSEC_CLI} Error when setting log file"
 )

--- a/internal/helpers/messages/info.go
+++ b/internal/helpers/messages/info.go
@@ -14,30 +14,19 @@
 
 package messages
 
+// Block of messages usage into log of the level info
 const (
 	MsgInfoConfigAlreadyExist       = `{HORUSEC_CLI} Horusec configuration already exists on path: `
 	MsgInfoConfigFileCreatedSuccess = `{HORUSEC_CLI} Horusec created file of configuration with success on path: `
-	// Fired when is necessary show how to install docker
-	MsgInfoHowToInstallDocker = `{HORUSEC_CLI} If your docker is not installed check in docs of how to install in:
+	MsgInfoHowToInstallDocker       = `{HORUSEC_CLI} If your docker is not installed check in docs of how to install in:
 		https://docs.docker.com/get-docker
 	`
-	// Fired when is necessary show how to install git
 	MsgInfoHowToInstallGit = `{HORUSEC_CLI} If your git is not installed check in docs of how to install in:
 		https://git-scm.com/downloads
 	`
-	// Fired when is setup to the output is sonarqube
 	MsgInfoStartGenerateSonarQubeFile = "{HORUSEC_CLI} Generating SonarQube output..."
-	// Fired when is setup to the output is sonarqube
-	MsgInfoStartWriteFile   = "{HORUSEC_CLI} Writing output JSON to file in the path: "
-	MsgInfoMonitorTimeoutIn = "Horusec will return a timeout after %d seconds. " +
-		"This time can be customized in the cli settings."
-	MsgInfoAnalysisLoading = " Scanning code ..."
-	// Fired in print results service when analysis is finished
-	MsgAnalysisFoundVulns = "[HORUSEC] %d VULNERABILITIES WERE FOUND IN YOUR CODE SENT TO HORUSEC, " +
-		"TO SEE MORE DETAILS USE THE LOG LEVEL AS DEBUG AND TRY AGAIN"
-	// Fired in print results service when analysis is finished
-	MsgAnalysisFinishedWithoutVulns = "YOUR ANALYSIS HAD FINISHED WITHOUT ANY VULNERABILITY!"
-	// Occurs when o docker is lower version than recommend
-	MsgDockerLowerVersion = "{HORUSEC_CLI} We recommend version 19.03 or higher of the docker." +
+	MsgInfoStartWriteFile             = "{HORUSEC_CLI} Writing output JSON to file in the path: "
+	MsgInfoAnalysisLoading            = " Scanning code ..."
+	MsgInfoDockerLowerVersion         = "{HORUSEC_CLI} We recommend version 19.03 or higher of the docker." +
 		" Versions prior to this may have problems during execution"
 )

--- a/internal/helpers/messages/panic.go
+++ b/internal/helpers/messages/panic.go
@@ -14,14 +14,11 @@
 
 package messages
 
+// Block of messages usage into log of the level panic
 const (
-	// Fired when starting horusec does not have all the necessary settings to proceed
 	MsgPanicDockerRequirementsToRunHorusec = "{HORUSEC_CLI} Missing required DOCKER in min. version 19.03 to start"
-	// Fired when starting horusec does not have all the necessary settings to proceed
-	MsgPanicGitRequirementsToRunHorusec = "{HORUSEC_CLI} Missing required GIT in min. version 2.01 to start"
-	// Fired when horusec failed to acquire $HOME directory on user's machine
-	MsgPanicGetFlagValue = "{HORUSEC_CLI} Error on getting flag value, check and try again: "
-	// Fired when is necessary connect in docker
-	MsgPanicNotConnectDocker  = "{HORUSEC_CLI} Error when try connect in docker."
-	MsgPanicGetConfigFilePath = "{HORUSEC-CLI} Error on get config file path."
+	MsgPanicGitRequirementsToRunHorusec    = "{HORUSEC_CLI} Missing required GIT in min. version 2.01 to start"
+	MsgPanicGetFlagValue                   = "{HORUSEC_CLI} Error on getting flag value, check and try again: "
+	MsgPanicNotConnectDocker               = "{HORUSEC_CLI} Error when try connect in docker."
+	MsgPanicGetConfigFilePath              = "{HORUSEC-CLI} Error on get config file path."
 )

--- a/internal/helpers/messages/trace.go
+++ b/internal/helpers/messages/trace.go
@@ -14,7 +14,7 @@
 
 package messages
 
+// Block of messages usage into log of the level trace
 const (
-	// Fired when found language in file to start analysis
 	MsgTraceLanguageFound = "{HORUSEC_CLI} When start analysis we found the file in path with the language: "
 )

--- a/internal/helpers/messages/warn.go
+++ b/internal/helpers/messages/warn.go
@@ -14,17 +14,15 @@
 
 package messages
 
+// Block of messages usage into log of the level warn
 const (
-	// Fired when not found authorization token
 	MsgWarnAuthorizationNotFound = "{HORUSEC_CLI} No authorization token was found, " +
 		"your code it is not going to be sent to horusec. " +
 		"Please enter a token with the -a flag to configure and save your analysis"
-	// Fired when return success in copy project to .horusec folder
 	MsgWarnDontRemoveHorusecFolder = "{HORUSEC_CLI} PLEASE DON'T REMOVE \".horusec\" FOLDER BEFORE THE ANALYSIS FINISH!" +
 		" Don’t worry, we’ll remove it after the analysis ends automatically! Project sent to folder in location: "
-	// Fired when bandit found vulnerability but is not really an vulnerability and yes an informative assert detected
-	MsgWarnBanditFoundInformative = "{HORUSEC_CLI} CAUTION! In your project was found {{0}} details of type: "
-	// Fired when occurs of ignore folder or file to send horusec analysis
+	MsgWarnBanditFoundInformative = "{HORUSEC_CLI} CAUTION! In your project was found " +
+		"{{0}} details of type informative"
 	MsgWarnTotalFolderOrFileWasIgnored = "{HORUSEC_CLI} When starting the analysis WE SKIP A TOTAL OF {{0}} FILES " +
 		"that are not considered to be analyzed. To see more details use flag --log-level=debug"
 	MsgWarnGitHistoryEnable = "{HORUSEC_CLI} Starting the analysis with git history enabled. " +
@@ -34,6 +32,19 @@ const (
 	MsgWarnInfoVulnerabilitiesDisabled = "{HORUSEC_CLI} Horusec not show info vulnerabilities in this analysis, " +
 		"to see info vulnerabilities add option \"--information-severity=true\". " +
 		"For more details use (horusec start --help) command."
+	MsgWarnMonitorTimeoutIn = "Horusec will return a timeout after %d seconds. " +
+		"This time can be customized in the cli settings."
+	MsgWarnAnalysisFoundVulns = "{HORUSEC_CLI} %d VULNERABILITIES WERE FOUND IN YOUR CODE SENT TO HORUSEC, " +
+		"TO SEE MORE DETAILS USE THE LOG LEVEL AS DEBUG AND TRY AGAIN"
+	MsgWarnAnalysisFinishedWithoutVulns = "YOUR ANALYSIS HAD FINISHED WITHOUT ANY VULNERABILITY!"
+	MsgWarnConfigFileNotFoundOnPath     = "{HORUSEC_CLI} Config file not found"
+
+	MsgWarnTimeoutOccurs = "{HORUSEC_CLI} Some analysis was not completed due to the timeout, " +
+		"increase the time with -t flag and try again."
+	MsgWarnWhenAskDirToRun = "{HORUSEC_CLI} Error when ask if can run prompt question.: \n" +
+		"Please use the command below informing the directory you want to run the analysis: \n" +
+		"horusec start -p ./"
+	MsgWarnFoundErrorsInAnalysis        = "{HORUSEC_CLI} During execution we found some problems:"
 	MsgWarnGitRepositoryIsNotFullCloned = "{HORUSEC_CLI} Repository is not fully cloned." +
 		"Commit author can result wrong authors. Check the documentation for more info." +
 		"https://horusec.io/docs/cli/installation/#2-installation-via-pipeline"

--- a/internal/services/formatters/csharp/dotnet_cli/formatter.go
+++ b/internal/services/formatters/csharp/dotnet_cli/formatter.go
@@ -76,12 +76,17 @@ func (f *Formatter) getConfigData(projectSubPath string) *dockerEntities.Analysi
 	return analysisData.SetData(f.GetCustomImageByLanguage(languages.CSharp), images.Csharp)
 }
 
+// nolint:gocyclo // function simple is not necessarily broken any validation
 func (f *Formatter) parseOutput(output, projectSubPath string) {
 	if f.isInvalidOutput(output) {
 		return
 	}
-	//nolint
-	for _, value := range strings.Split(output[strings.Index(output, enums.Separator):], enums.Separator) {
+
+	startedIndex := strings.Index(output, enums.Separator)
+	if startedIndex < 0 {
+		startedIndex = 0
+	}
+	for _, value := range strings.Split(output[startedIndex:], enums.Separator) {
 		dependency := f.parseDependencyValue(value)
 		if dependency != nil && *dependency != (entities.Dependency{}) {
 			f.AddNewVulnerabilityIntoAnalysis(f.setVulnerabilityData(dependency, projectSubPath))

--- a/internal/services/formatters/javascript/npmaudit/formatter.go
+++ b/internal/services/formatters/javascript/npmaudit/formatter.go
@@ -173,5 +173,5 @@ func (f *Formatter) getLine(version, module string, scanner *bufio.Scanner) stri
 }
 
 func (f *Formatter) isModuleInScannerText(module, scannerText string) bool {
-	return strings.Contains(strings.ToLower(scannerText), strings.ToLower(fmt.Sprintf(`%q: {`, module)))
+	return strings.Contains(strings.ToLower(scannerText), strings.ToLower(fmt.Sprintf("%q: {", module)))
 }

--- a/internal/services/formatters/javascript/npmaudit/formatter_test.go
+++ b/internal/services/formatters/javascript/npmaudit/formatter_test.go
@@ -158,4 +158,19 @@ func TestParseOutputNpm(t *testing.T) {
 		assert.Error(t, err)
 		assert.Equal(t, 0, len(analysis.AnalysisVulnerabilities))
 	})
+	t.Run("Check if get version contains double quote using %q", func(t *testing.T) {
+		analysis := &entitiesAnalysis.Analysis{}
+		dockerAPIControllerMock := &docker.Mock{}
+		config := &cliConfig.Config{}
+		config.WorkDir = &workdir.WorkDir{}
+		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, config)
+
+		formatter := Formatter{
+			service,
+		}
+
+		extractedVersion := formatter.getVersionText("v1.0.0")
+
+		assert.Equal(t, `"version": "v1.0.0"`, extractedVersion)
+	})
 }

--- a/internal/usecases/cli/cli_test.go
+++ b/internal/usecases/cli/cli_test.go
@@ -19,8 +19,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/ZupIT/horusec/internal/enums/outputtype"
 	validation "github.com/go-ozzo/ozzo-validation/v4"
+
+	"github.com/ZupIT/horusec/internal/enums/outputtype"
 
 	"github.com/stretchr/testify/assert"
 
@@ -62,7 +63,7 @@ func TestValidateConfigs(t *testing.T) {
 
 		err := useCases.ValidateConfig(cfg)
 		assert.Error(t, err)
-		expected := "severities_to_ignore: Type of severity not valid:  test. See severities enable: [CRITICAL HIGH MEDIUM LOW UNKNOWN INFO]."
+		expected := "severities_to_ignore: test Type of severity not valid. See severities enable: [CRITICAL HIGH MEDIUM LOW UNKNOWN INFO]."
 		assert.Equal(t, expected, err.Error())
 	})
 	t.Run("Should return error when invalid json output file is empty", func(t *testing.T) {
@@ -73,7 +74,7 @@ func TestValidateConfigs(t *testing.T) {
 
 		err := useCases.ValidateConfig(cfg)
 		assert.Error(t, err)
-		assert.Equal(t, "json_output_file_path: Output File path is required or is invalid: not valid file of type .json.",
+		assert.Equal(t, "json_output_file_path: Output File path not valid file of type: .json.",
 			err.Error())
 	})
 	t.Run("Should return error when invalid json output file is invalid", func(t *testing.T) {
@@ -84,7 +85,7 @@ func TestValidateConfigs(t *testing.T) {
 
 		err := useCases.ValidateConfig(cfg)
 		assert.Error(t, err)
-		assert.Equal(t, "json_output_file_path: Output File path is required or is invalid: not valid file of type .json.",
+		assert.Equal(t, "json_output_file_path: Output File path not valid file of type: .json.",
 			err.Error())
 	})
 	t.Run("Should return error when the text output file is invalid", func(t *testing.T) {
@@ -96,7 +97,7 @@ func TestValidateConfigs(t *testing.T) {
 
 		err := useCases.ValidateConfig(cfg)
 		assert.Error(t, err)
-		assert.EqualError(t, err, "json_output_file_path: Output File path is required or is invalid: not valid file of type .txt.")
+		assert.EqualError(t, err, "json_output_file_path: Output File path not valid file of type: .txt.")
 	})
 	t.Run("Should not return error when the text output file is valid", func(t *testing.T) {
 		cfg := config.New()
@@ -174,7 +175,7 @@ func TestValidateConfigs(t *testing.T) {
 		cfg.RiskAcceptHashes = []string{hash}
 
 		err := useCases.ValidateConfig(cfg)
-		expected := "false_positive_hashes: False positive is not valid because is duplicated in risk accept: 1e836029-4e90-4151-bb4a-d86ef47f96b6; risk_accept_hashes: Risk Accept is not valid because is duplicated in false positive: 1e836029-4e90-4151-bb4a-d86ef47f96b6."
+		expected := "false_positive_hashes: False positive is not valid because is duplicated in risk accept:1e836029-4e90-4151-bb4a-d86ef47f96b6; risk_accept_hashes: Risk Accept is not valid because is duplicated in false positive: 1e836029-4e90-4151-bb4a-d86ef47f96b6."
 		assert.Equal(t, expected, err.Error())
 	})
 	t.Run("Should return not error when validate false positive and risk accepted", func(t *testing.T) {


### PR DESCRIPTION
Some error messages were with the warning type naming, so I changed them so they all had the correct naming.
Another change was that the error message file had two types of messages:
    * Return messages in functions like fmt.Errorf or errros.New
    * Error log messages in functions such as logger.LogError or logger.LogErrorWithLevel
Signed-off-by: wilian <wilian.silva@zup.com.br>