### PR TITLE
workflow: execute unit tests on MacOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,14 +25,23 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
+          - macOS-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: true
           fetch-depth: 0
+
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version }}
+
+      - name: Setup docker for MacOS
+        if: ${{ matrix.os == 'macos-latest' }} 
+        uses: docker-practice/actions-setup-docker@master
+        with:
+          docker_buildx: false
+
       - name: test
         run: make test

--- a/cmd/app/start/start_test.go
+++ b/cmd/app/start/start_test.go
@@ -262,7 +262,7 @@ func TestStartCommand_ExecuteUnitTests(t *testing.T) {
 			},
 			assertFn: func(t *testing.T, prompt *prompt.Mock, requirements *requirements.Mock, analyzer *analyzer.Mock, cfg *config.Config) {
 				assert.True(t, cfg.ReturnErrorIfFoundVulnerability)
-				assert.Equal(t, os.TempDir(), cfg.ProjectPath)
+				assert.Equal(t, filepath.Clean(os.TempDir()), cfg.ProjectPath)
 
 				prompt.AssertNotCalled(t, "Ask")
 				analyzer.AssertCalled(t, "Analyze")
@@ -295,7 +295,7 @@ func TestStartCommand_ExecuteUnitTests(t *testing.T) {
 				requirements.On("ValidateDocker")
 			},
 			assertFn: func(t *testing.T, prompt *prompt.Mock, requirements *requirements.Mock, analyzer *analyzer.Mock, cfg *config.Config) {
-				assert.Equal(t, os.TempDir(), cfg.ProjectPath)
+				assert.Equal(t, filepath.Clean(os.TempDir()), cfg.ProjectPath)
 				assert.Equal(t, "NOT_VALID_AUTHORIZATION", cfg.RepositoryAuthorization)
 				assert.True(t, cfg.ReturnErrorIfFoundVulnerability)
 
@@ -314,7 +314,7 @@ func TestStartCommand_ExecuteUnitTests(t *testing.T) {
 				requirements.On("ValidateDocker")
 			},
 			assertFn: func(t *testing.T, prompt *prompt.Mock, requirements *requirements.Mock, analyzer *analyzer.Mock, cfg *config.Config) {
-				assert.Equal(t, os.TempDir(), cfg.ProjectPath)
+				assert.Equal(t, filepath.Clean(os.TempDir()), cfg.ProjectPath)
 				assert.Equal(t, "76034e43-bdb8-48d9-a0ad-fc674f0354bb", cfg.RepositoryAuthorization)
 				assert.True(t, cfg.ReturnErrorIfFoundVulnerability)
 


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
Previously the configuration of workflow tests was testing only Linux
and Windows. This commit add macOS-latest as a new runner.

Note that the goal of this commit is only to add macOS runner and fix
some tests to make them work on MacOS, we still need to make some
improvements on some of these tests to have a better assertiveness.

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
