### PR TITLE
Update constants names in samples files tests of the engine rules

### DIFF
--- a/internal/services/engines/csharp/rules_test.go
+++ b/internal/services/engines/csharp/rules_test.go
@@ -26,7 +26,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-CSHARP-1",
 			Rule: NewCommandInjection(),
-			Src:  SampleVulnerableCsharpNewCommandInjection,
+			Src:  SampleVulnerableHSCSHARP1,
 			Findings: []engine.Finding{
 				{
 					CodeSample: "var p = new Process();",

--- a/internal/services/engines/csharp/samples_test.go
+++ b/internal/services/engines/csharp/samples_test.go
@@ -15,7 +15,7 @@
 package csharp
 
 const (
-	SampleVulnerableCsharpNewCommandInjection = `var p = new Process();
+	SampleVulnerableHSCSHARP1 = `var p = new Process();
 p.StartInfo.FileName = "exportLegacy.exe";
 p.StartInfo.Arguments = " -user " + input + " -role user";
 p.Start();`

--- a/internal/services/engines/dart/rules_test.go
+++ b/internal/services/engines/dart/rules_test.go
@@ -26,7 +26,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-DART-1",
 			Rule: NewUsageLocalDataWithoutCryptography(),
-			Src:  SampleVulnerableUsageLocalDataWithoutCryptography,
+			Src:  SampleVulnerableHSDART1,
 			Findings: []engine.Finding{
 				{
 					CodeSample: "SharedPreferences prefs = await SharedPreferences.getInstance();",
@@ -40,7 +40,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-DART-2",
 			Rule: NewNoSendSensitiveInformation(),
-			Src:  SampleVulnerableNoSendSensitiveInformation,
+			Src:  SampleVulnerableHSDART2,
 			Findings: []engine.Finding{
 				{
 					CodeSample: "_firebaseMessaging.configure(",
@@ -54,7 +54,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-DART-3",
 			Rule: NewNoUseBiometricsTypeIOS(),
-			Src:  SampleVulnerableNoUseBiometricsTypeIOS,
+			Src:  SampleVulnerableHSDART3,
 			Findings: []engine.Finding{
 				{
 					CodeSample: "await auth.getAvailableBiometrics();",
@@ -68,7 +68,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-DART-4",
 			Rule: NewXmlReaderExternalEntityExpansion(),
-			Src:  SampleVulnerableXmlReaderExternalEntityExpansion,
+			Src:  SampleVulnerableHSDART4,
 			Findings: []engine.Finding{
 				{
 					CodeSample: "final file = new File(FileFromUserInput);",
@@ -82,7 +82,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-DART-5",
 			Rule: NewNoUseConnectionWithoutSSL(),
-			Src:  SampleVulnerableNoUseConnectionWithoutSSL,
+			Src:  SampleVulnerableHSDART5,
 			Findings: []engine.Finding{
 				{
 					CodeSample: "return _HttpServer.bindSecure('http://my-api.com.br', port, context, backlog, v6Only, requestClientCertificate, shared);",
@@ -96,7 +96,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-DART-6",
 			Rule: NewSendSMS(),
-			Src:  SampleVulnerableDartSendSMS,
+			Src:  SampleVulnerableHSDART6,
 			Findings: []engine.Finding{
 				{
 					CodeSample: "import 'package:flutter_sms/flutter_sms.dart';",
@@ -110,7 +110,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-DART-7",
 			Rule: NewXSSAttack(),
-			Src:  SampleVulnerableXSSAttack,
+			Src:  SampleVulnerableHSDART7,
 			Findings: []engine.Finding{
 				{
 					CodeSample: "var element = new Element.html(sprintf(\"<div class=\"foo\">%s</div>\", [content]));",
@@ -124,7 +124,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-DART-8",
 			Rule: NewNoLogSensitive(),
-			Src:  SampleVulnerableNoLogSensitive,
+			Src:  SampleVulnerableHSDART8,
 			Findings: []engine.Finding{
 				{
 					CodeSample: "print(sprintf(\"User identity is: %s\", [identity]));",
@@ -145,7 +145,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-DART-9",
 			Rule: NewWeakHashingFunctionMd5OrSha1(),
-			Src:  SampleVulnerableWeakHashingFunctionMd5OrSha1,
+			Src:  SampleVulnerableHSDART9,
 			Findings: []engine.Finding{
 				{
 					CodeSample: "var digest = md5.convert(content);",
@@ -159,7 +159,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-DART-10",
 			Rule: NewNoUseSelfSignedCertificate(),
-			Src:  SampleVulnerableNoUseSelfSignedCertificate,
+			Src:  SampleVulnerableHSDART10,
 			Findings: []engine.Finding{
 				{
 					CodeSample: "context.setTrustedCertificates(\"client.cer\");",
@@ -173,7 +173,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-DART-11",
 			Rule: NewNoUseBiometricsTypeAndroid(),
-			Src:  SampleVulnerableNoUseBiometricsTypeAndroid,
+			Src:  SampleVulnerableHSDART11,
 			Findings: []engine.Finding{
 				{
 					CodeSample: "authenticated = await auth.authenticateWithBiometrics(",
@@ -187,7 +187,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-DART-12",
 			Rule: NewNoListClipboardChanges(),
-			Src:  SampleVulnerableNoListClipboardChanges,
+			Src:  SampleVulnerableHSDART12,
 			Findings: []engine.Finding{
 				{
 					CodeSample: "Map<String, dynamic> result = await SystemChannels.platform.invokeMethod('Clipboard.getData');",
@@ -201,7 +201,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-DART-13",
 			Rule: NewSQLInjection(),
-			Src:  SampleVulnerableSQLInjection,
+			Src:  SampleVulnerableHSDART13,
 			Findings: []engine.Finding{
 				{
 					CodeSample: "List<Map> list = await database.rawQuery(\"SELECT * FROM Users WHERE username = '\" + username + \"';\");",
@@ -215,7 +215,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-DART-14",
 			Rule: NewNoUseNSTemporaryDirectory(),
-			Src:  SampleVulnerableNoUseNSTemporaryDirectory,
+			Src:  SampleVulnerableHSDART14,
 			Findings: []engine.Finding{
 				{
 					CodeSample: "let temporaryDirectoryURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true);",
@@ -229,7 +229,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-DART-15",
 			Rule: NewNoUseCipherMode(),
-			Src:  SampleVulnerableNoUseCipherMode,
+			Src:  SampleVulnerableHSDART15,
 			Findings: []engine.Finding{
 				{
 					CodeSample: "final encrypter = Encrypter(AES(key, mode: AESMode.cts));",
@@ -243,7 +243,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-DART-16",
 			Rule: NewCorsAllowOriginWildCard(),
-			Src:  SampleVulnerableCorsAllowOriginWildCard,
+			Src:  SampleVulnerableHSDART16,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `request.response.headers.add("Access-Control-Allow-Origin", "*");`,
@@ -257,7 +257,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-DART-17",
 			Rule: NewUsingShellInterpreterWhenExecutingOSCommand(),
-			Src:  SampleVulnerableUsingShellInterpreterWhenExecutingOSCommand,
+			Src:  SampleVulnerableHSDART17,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `var result = await Process.run("netcfg", [UserParams]);`,
@@ -278,12 +278,12 @@ func TestRulesSafeCode(t *testing.T) {
 		{
 			Name: "HS-DART-1",
 			Rule: NewUsageLocalDataWithoutCryptography(),
-			Src:  SampleSafeUsageLocalDataWithoutCryptography,
+			Src:  SampleSafeHSDART1,
 		},
 		{
 			Name: "HS-DART-2",
 			Rule: NewNoSendSensitiveInformation(),
-			Src:  SampleSafeNoSendSensitiveInformation,
+			Src:  SampleSafeHSDART2,
 		},
 		{
 			Name: "HS-DART-3",
@@ -293,12 +293,12 @@ func TestRulesSafeCode(t *testing.T) {
 		{
 			Name: "HS-DART-4",
 			Rule: NewXmlReaderExternalEntityExpansion(),
-			Src:  SampleSafeXmlReaderExternalEntityExpansion,
+			Src:  SampleSafeHSDART4,
 		},
 		{
 			Name: "HS-DART-5",
 			Rule: NewNoUseConnectionWithoutSSL(),
-			Src:  SampleSafeNoUseConnectionWithoutSSL,
+			Src:  SampleSafeHSDART5,
 		},
 		{
 			Name: "HS-DART-6",
@@ -308,57 +308,57 @@ func TestRulesSafeCode(t *testing.T) {
 		{
 			Name: "HS-DART-7",
 			Rule: NewXSSAttack(),
-			Src:  SampleSafeXSSAttack,
+			Src:  SampleSafeHSDART7,
 		},
 		{
 			Name: "HS-DART-8",
 			Rule: NewNoLogSensitive(),
-			Src:  SampleSafeNoLogSensitive,
+			Src:  SampleSafeHSDART8,
 		},
 		{
 			Name: "HS-DART-9",
 			Rule: NewWeakHashingFunctionMd5OrSha1(),
-			Src:  SampleSafeWeakHashingFunctionMd5OrSha1,
+			Src:  SampleSafeHSDART9,
 		},
 		{
 			Name: "HS-DART-10",
 			Rule: NewNoUseSelfSignedCertificate(),
-			Src:  SampleSafeNoUseSelfSignedCertificate,
+			Src:  SampleSafeHSDART10,
 		},
 		{
 			Name: "HS-DART-11",
 			Rule: NewNoUseBiometricsTypeAndroid(),
-			Src:  SampleSafeNoUseBiometricsTypeAndroid,
+			Src:  SampleSafeHSDART11,
 		},
 		{
 			Name: "HS-DART-12",
 			Rule: NewNoListClipboardChanges(),
-			Src:  SampleSafeNoListClipboardChanges,
+			Src:  SampleSafeHSDART12,
 		},
 		{
 			Name: "HS-DART-13",
 			Rule: NewSQLInjection(),
-			Src:  SampleSafeSQLInjection,
+			Src:  SampleSafeHSDART13,
 		},
 		{
 			Name: "HS-DART-14",
 			Rule: NewNoUseNSTemporaryDirectory(),
-			Src:  SampleSafeNoUseNSTemporaryDirectory,
+			Src:  SampleSafeHSDART14,
 		},
 		{
 			Name: "HS-DART-15",
 			Rule: NewNoUseCipherMode(),
-			Src:  SampleSafeNoUseCipherMode,
+			Src:  SampleSafeHSDART15,
 		},
 		{
 			Name: "HS-DART-16",
 			Rule: NewCorsAllowOriginWildCard(),
-			Src:  SampleSafeCorsAllowOriginWildCard,
+			Src:  SampleSafeHSDART16,
 		},
 		{
 			Name: "HS-DART-17",
 			Rule: NewUsingShellInterpreterWhenExecutingOSCommand(),
-			Src:  SampleSafeUsingShellInterpreterWhenExecutingOSCommand,
+			Src:  SampleSafeHSDART17,
 		},
 	}
 

--- a/internal/services/engines/dart/sample_test.go
+++ b/internal/services/engines/dart/sample_test.go
@@ -15,9 +15,9 @@
 package dart
 
 const (
-	SampleVulnerableDartSendSMS = `import 'package:flutter_sms/flutter_sms.dart';
+	SampleVulnerableHSDART6 = `import 'package:flutter_sms/flutter_sms.dart';
 `
-	SampleVulnerableUsageLocalDataWithoutCryptography = `
+	SampleVulnerableHSDART1 = `
 ...
 final CpfExposedFromUserInput = "";
 ...
@@ -35,7 +35,7 @@ void onButtonClick() async {
 }
 ...
 `
-	SampleVulnerableNoSendSensitiveInformation = `
+	SampleVulnerableHSDART2 = `
 ...
   FirebaseMessaging _firebaseMessaging = FirebaseMessaging();
   
@@ -61,7 +61,7 @@ void onButtonClick() async {
   }
 ...
 `
-	SampleVulnerableNoUseBiometricsTypeIOS = `
+	SampleVulnerableHSDART3 = `
 List<BiometricType> availableBiometrics;
     await auth.getAvailableBiometrics();
 
@@ -73,12 +73,12 @@ if (Platform.isIOS) {
     }
 }
 `
-	SampleVulnerableXmlReaderExternalEntityExpansion = `
+	SampleVulnerableHSDART4 = `
 // Possible vulnerable code: user can pass other path in your input and causes attacks in the application.
 final file = new File(FileFromUserInput);
 final document = XmlDocument.parse(file.readAsStringSync());
 `
-	SampleVulnerableNoUseConnectionWithoutSSL = `
+	SampleVulnerableHSDART5 = `
 ...
 static Future<HttpServer> SentToApi(
 	int port,
@@ -92,7 +92,7 @@ static Future<HttpServer> SentToApi(
     return _HttpServer.bindSecure('http://my-api.com.br', port, context, backlog, v6Only, requestClientCertificate, shared);
 }
 `
-	SampleVulnerableXSSAttack = `
+	SampleVulnerableHSDART7 = `
 import 'package:sprintf/sprintf.dart';
 import 'dart:html';
 ...
@@ -103,7 +103,7 @@ void RenderHTML(String content) {
 	document.body.append(element);
 }
 `
-	SampleVulnerableNoLogSensitive = `
+	SampleVulnerableHSDART8 = `
 import 'package:sprintf/sprintf.dart';
 import 'package:logging/logging.dart';
 ...
@@ -117,7 +117,7 @@ void ShowUserSensitiveInformation(String identity) {
 	sentToAPIUserIdentity(identity);
 }
 `
-	SampleVulnerableWeakHashingFunctionMd5OrSha1 = `
+	SampleVulnerableHSDART9 = `
 import 'dart:convert';
 import 'package:convert/convert.dart';
 import 'package:crypto/crypto.dart' as crypto;
@@ -131,7 +131,7 @@ generateMd5(String data) {
   return hex.encode(digest.bytes);
 }
 `
-	SampleVulnerableNoUseSelfSignedCertificate = `
+	SampleVulnerableHSDART10 = `
 final SecurityContext context = SecurityContext(withTrustedRoots: false);
 // Possible vulnerable code: This code is bad because if you can exposed for MITM attacks
 context.setTrustedCertificates("client.cer");
@@ -139,7 +139,7 @@ Socket socket = await Socket.connect(serverIp, port);
 socket = await SecureSocket.secure(socket, host: "server"
   , context: context, onBadCertificate: (cert) => true);
 `
-	SampleVulnerableNoUseBiometricsTypeAndroid = `
+	SampleVulnerableHSDART11 = `
 try {
 // Possible vulnerable code: This code is bad because your authentication can be passed easy form when exists only 1 method to authenticate
   authenticated = await auth.authenticateWithBiometrics(
@@ -151,7 +151,7 @@ try {
   print("error using biometric auth: $e");
 }
 `
-	SampleVulnerableNoListClipboardChanges = `
+	SampleVulnerableHSDART12 = `
 _getFromClipboard() async {
 	// Possible vulnerable code: Is not good idea read content from clipboard.
 	Map<String, dynamic> result = await SystemChannels.platform.invokeMethod('Clipboard.getData');
@@ -173,7 +173,7 @@ void sendToAPIToKeepChangesInDatabase() {
 	}
 }
 `
-	SampleVulnerableSQLInjection = `
+	SampleVulnerableHSDART13 = `
 Database database = await openDatabase(path, version: 1,
     onCreate: (Database db, int version) async {
   await db.execute('CREATE TABLE Users (id INTEGER PRIMARY KEY, username TEXT, password TEXT);');
@@ -189,15 +189,15 @@ getCheckIfUserExists(String username) {
 	}
 }
 `
-	SampleVulnerableNoUseNSTemporaryDirectory = `
+	SampleVulnerableHSDART14 = `
 // Possible vulnerable code: If You get NSTemporaryDirectory you can get anywhere content from this directory
 let temporaryDirectoryURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true);
 `
-	SampleVulnerableNoUseCipherMode = `
+	SampleVulnerableHSDART15 = `
 // Possible vulnerable code: This code is bad because this type cryptography is easy of to be broken.
 final encrypter = Encrypter(AES(key, mode: AESMode.cts));
 `
-	SampleVulnerableCorsAllowOriginWildCard = `
+	SampleVulnerableHSDART16 = `
 HttpServer.bind('127.0.0.1', 8080).then((server){
 	server.listen((HttpRequest request){     
 		request.uri.queryParameters.forEach((param,val){
@@ -214,7 +214,7 @@ HttpServer.bind('127.0.0.1', 8080).then((server){
     });
 });
 `
-	SampleVulnerableUsingShellInterpreterWhenExecutingOSCommand = `
+	SampleVulnerableHSDART17 = `
 getIPFromLoggedUser (List<String> UserParams) async {
 	// Possible vulnerable code: User can be inject malicious code and run others commands after this command 
 	var result = await Process.run("netcfg", [UserParams]);
@@ -224,7 +224,7 @@ getIPFromLoggedUser (List<String> UserParams) async {
 )
 
 const (
-	SampleSafeUsageLocalDataWithoutCryptography = `
+	SampleSafeHSDART1 = `
 ...
 final CpfExposedFromUserInput = "";
 ...
@@ -239,7 +239,7 @@ void onButtonClick() async {
 }
 ...
 `
-	SampleSafeNoSendSensitiveInformation = `
+	SampleSafeHSDART2 = `
 ...
   FirebaseMessaging _firebaseMessaging = FirebaseMessaging();
   
@@ -257,12 +257,12 @@ void onButtonClick() async {
   }
 ...
 `
-	SampleSafeXmlReaderExternalEntityExpansion = `
+	SampleSafeHSDART4 = `
 final file = new File('static-file.xml');
 final document = XmlDocument.parse(file.readAsStringSync());
 `
 
-	SampleSafeNoUseConnectionWithoutSSL = `
+	SampleSafeHSDART5 = `
 static Future<HttpServer> SentToApi(
 	int port,
 	SecurityContext context,
@@ -272,7 +272,7 @@ static Future<HttpServer> SentToApi(
 	bool shared = false}
 ) => _HttpServer.bindSecure('https://my-api.com.br', port, context, backlog, v6Only, requestClientCertificate, shared);
 `
-	SampleSafeXSSAttack = `
+	SampleSafeHSDART7 = `
 import 'package:sprintf/sprintf.dart';
 import 'dart:html';
 ...
@@ -283,7 +283,7 @@ void RenderHTML(String content) {
 	document.body.append(element);
 }
 `
-	SampleSafeNoLogSensitive = `
+	SampleSafeHSDART8 = `
 import 'package:logging/logging.dart';
 ...
 final _logger = Logger('YourClassName');
@@ -295,7 +295,7 @@ void ShowUserSensitiveInformation(String identity) {
 }
 ...
 `
-	SampleSafeWeakHashingFunctionMd5OrSha1 = `
+	SampleSafeHSDART9 = `
 import 'dart:convert';
 import 'package:convert/convert.dart';
 import 'package:crypto/crypto.dart' as crypto;
@@ -308,13 +308,13 @@ generateSha256(String data) {
   return hex.encode(digest.bytes);
 }
 `
-	SampleSafeNoUseSelfSignedCertificate = `
+	SampleSafeHSDART10 = `
 final SecurityContext context = SecurityContext(withTrustedRoots: false);
 Socket socket = await Socket.connect(serverIp, port);
 socket = await SecureSocket.secure(socket, host: "server"
   , context: context, onBadCertificate: (cert) => true);
 `
-	SampleSafeNoUseBiometricsTypeAndroid = `
+	SampleSafeHSDART11 = `
 try {
   authenticated = await auth.CheckTwoFactorAuthenticationAndAuthenticateWithBiometrics(
 	  localizedReason: 'Touch your finger on the sensor to login',
@@ -325,7 +325,7 @@ try {
   print("error using biometric auth: $e");
 }
 `
-	SampleSafeNoListClipboardChanges = `
+	SampleSafeHSDART12 = `
 _getFromClipboard() async {
 	var cp = Clipboard
 	Map<String, dynamic> result = await cp.getData;
@@ -347,7 +347,7 @@ void sendToAPIToKeepChangesInDatabase() {
 	}
 }
 `
-	SampleSafeSQLInjection = `
+	SampleSafeHSDART13 = `
 Database database = await openDatabase(path, version: 1,
     onCreate: (Database db, int version) async {
   await db.execute('CREATE TABLE Users (id INTEGER PRIMARY KEY, username TEXT, password TEXT);');
@@ -362,13 +362,13 @@ getCheckIfUserExists(String username) {
 	}
 }
 `
-	SampleSafeNoUseNSTemporaryDirectory = `
+	SampleSafeHSDART14 = `
 let temporaryDirectoryURL = URL(fileURLWithPath: "Some/Other/Path", isDirectory: true)
 `
-	SampleSafeNoUseCipherMode = `
+	SampleSafeHSDART15 = `
 final encrypter = Encrypter(AES(key, mode: AESMode.cbc));
 `
-	SampleSafeCorsAllowOriginWildCard = `
+	SampleSafeHSDART16 = `
 HttpServer.bind('127.0.0.1', 8080).then((server){
 	server.listen((HttpRequest request){     
 		request.uri.queryParameters.forEach((param,val){
@@ -384,7 +384,7 @@ HttpServer.bind('127.0.0.1', 8080).then((server){
     });
 });
 `
-	SampleSafeUsingShellInterpreterWhenExecutingOSCommand = `
+	SampleSafeHSDART17 = `
 // You can get IP using library or interact with your backend application
 var getIPFromLoggedUser => await MyIpPost()
 `

--- a/internal/services/engines/java/rules_test.go
+++ b/internal/services/engines/java/rules_test.go
@@ -27,7 +27,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-JAVA-1",
 			Rule: NewXMLParsingVulnerableToXXE(),
-			Src:  SampleVulnerableJavaXMLParsingVulnerableToXXE,
+			Src:  SampleVulnerableHSJAVA1,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `XMLReader reader = XMLReaderFactory.createXMLReader();`,
@@ -41,7 +41,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-JAVA-3",
 			Rule: NewXMLParsingVulnerableToXXEWithDocumentBuilder(),
-			Src:  SampleVulnerableXMLParsingVulnerableToXXEWithDocumentBuilder,
+			Src:  SampleVulnerableHSJAVA3,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();`,
@@ -55,7 +55,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-JAVA-4",
 			Rule: NewXMLParsingVulnerableToXXEWithSAXParserFactory(),
-			Src:  SampleVulnerableXMLParsingVulnerableToXXEWithSAXParserFactory,
+			Src:  SampleVulnerableHSJAVA4,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `SAXParser parser = SAXParserFactory.newInstance().newSAXParser();`,
@@ -69,7 +69,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-JAVA-134",
 			Rule: NewSQLInjection(),
-			Src:  SampleVulnerableJavaSQLInjection,
+			Src:  SampleVulnerableHSJAVA134,
 			Findings: []engine.Finding{
 				{
 					CodeSample: "var pstmt = con.prepareStatement(\"select * from mytable where field01 = '\" + field01 + \"'\");",
@@ -90,22 +90,22 @@ func TestRulesSafeCode(t *testing.T) {
 		{
 			Name: "HS-JAVA-1",
 			Rule: NewXMLParsingVulnerableToXXE(),
-			Src:  SampleSafeJavaXMLParsingVulnerableToXXE,
+			Src:  SampleSafeHSJAVA1,
 		},
 		{
 			Name: "HS-JAVA-3",
 			Rule: NewXMLParsingVulnerableToXXEWithDocumentBuilder(),
-			Src:  SampleSafeXMLParsingVulnerableToXXEWithDocumentBuilder,
+			Src:  SampleSafeHSJAVA3,
 		},
 		{
 			Name: "HS-JAVA-4",
 			Rule: NewXMLParsingVulnerableToXXEWithSAXParserFactory(),
-			Src:  SampleSafeXMLParsingVulnerableToXXEWithSAXParserFactory,
+			Src:  SampleSafeHSJAVA4,
 		},
 		{
 			Name: "HS-JAVA-134",
 			Rule: NewSQLInjection(),
-			Src:  SampleSafeJavaSQLInjection,
+			Src:  SampleSafeHSJAVA134,
 		},
 	}
 	testutil.TestSafeCode(t, testcases)

--- a/internal/services/engines/java/sample_test.go
+++ b/internal/services/engines/java/sample_test.go
@@ -15,7 +15,7 @@
 package java
 
 const (
-	SampleVulnerableJavaSQLInjection = `
+	SampleVulnerableHSJAVA134 = `
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -38,7 +38,7 @@ public class VulnerableCodeSQLInjection134 {
 }
 `
 
-	SampleSafeJavaSQLInjection = `
+	SampleSafeHSJAVA134 = `
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -62,7 +62,7 @@ public class VulnerableCodeSQLInjection134 {
 }
 `
 
-	SampleVulnerableJavaXMLParsingVulnerableToXXE = `
+	SampleVulnerableHSJAVA1 = `
 class Foo {
 	void fn(String input) {
 		XMLReader reader = XMLReaderFactory.createXMLReader();
@@ -71,7 +71,7 @@ class Foo {
 }
 	`
 
-	SampleSafeJavaXMLParsingVulnerableToXXE = `
+	SampleSafeHSJAVA1 = `
 class Foo {
 	void bar() {
 		XMLReader reader = XMLReaderFactory.createXMLReader();
@@ -83,7 +83,7 @@ class Foo {
 }
 	`
 
-	SampleVulnerableXMLParsingVulnerableToXXEWithDocumentBuilder = `
+	SampleVulnerableHSJAVA3 = `
 class Foo {
 	void bar() {
 		DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
@@ -93,7 +93,7 @@ class Foo {
 }
 	`
 
-	SampleSafeXMLParsingVulnerableToXXEWithDocumentBuilder = `
+	SampleSafeHSJAVA3 = `
 class Foo {
 	void bar() {
 		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
@@ -105,7 +105,7 @@ class Foo {
 }
 	`
 
-	SampleVulnerableXMLParsingVulnerableToXXEWithSAXParserFactory = `
+	SampleVulnerableHSJAVA4 = `
 class Foo {
 	void bar() {
 		SAXParser parser = SAXParserFactory.newInstance().newSAXParser();
@@ -115,7 +115,7 @@ class Foo {
 }
 	`
 
-	SampleSafeXMLParsingVulnerableToXXEWithSAXParserFactory = `
+	SampleSafeHSJAVA4 = `
 class Foo {
 	void bar() {
 		SAXParserFactory spf = SAXParserFactory.newInstance();

--- a/internal/services/engines/kubernetes/rules_test.go
+++ b/internal/services/engines/kubernetes/rules_test.go
@@ -26,7 +26,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-KUBERNETES-1",
 			Rule: NewAllowPrivilegeEscalation(),
-			Src:  SampleVulnerableAllowPrivilegeEscalation,
+			Src:  SampleVulnerableHSKUBERNETES1,
 			Findings: []engine.Finding{
 				{
 					CodeSample: "allowPrivilegeEscalation: true",
@@ -47,7 +47,7 @@ func TestRulesSafeCode(t *testing.T) {
 		{
 			Name: "HS-KUBERNETES-1",
 			Rule: NewAllowPrivilegeEscalation(),
-			Src:  SampleSafeAllowPrivilegeEscalation,
+			Src:  SampleSafeHSKUBERNETES1,
 		},
 	}
 

--- a/internal/services/engines/kubernetes/samples_test.go
+++ b/internal/services/engines/kubernetes/samples_test.go
@@ -15,7 +15,7 @@
 package kubernetes
 
 const (
-	SampleVulnerableAllowPrivilegeEscalation = `apiVersion: v1
+	SampleVulnerableHSKUBERNETES1 = `apiVersion: v1
 kind: Pod
 metadata:
   name: security-context-demo
@@ -35,7 +35,8 @@ spec:
     volumeMounts:
     - name: sec-ctx-vol
       mountPath: /data/demo`
-	SampleSafeAllowPrivilegeEscalation = `apiVersion: v1
+
+	SampleSafeHSKUBERNETES1 = `apiVersion: v1
 kind: Pod
 metadata:
   name: security-context-demo

--- a/internal/services/engines/leaks/rules_test.go
+++ b/internal/services/engines/leaks/rules_test.go
@@ -26,7 +26,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-LEAKS-1",
 			Rule: NewAWSManagerID(),
-			Src:  SampleVulnerableLeaksRegularAWSManagerID,
+			Src:  SampleVulnerableHSLEAKS1,
 			Findings: []engine.Finding{
 				{
 					CodeSample: "ACCESS_KEY: 'AKIAJSIE27KKMHXI3BJQ'",
@@ -40,7 +40,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-LEAKS-2",
 			Rule: NewAWSSecretKey(),
-			Src:  SampleVulnerableLeaksRegularAWSSecretKey,
+			Src:  SampleVulnerableHSLEAKS2,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `AWS_SECRET_KEY: 'doc5eRXFpsWllGC5yKJV/Ymm5KwF+IRZo95EudOm'`,
@@ -54,7 +54,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-LEAKS-3",
 			Rule: NewAWSMWSKey(),
-			Src:  SampleVulnerableLeaksRegularAWSMWSKey,
+			Src:  SampleVulnerableHSLEAKS3,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `AWS_WMS_KEY: 'amzn.mws.986478f0-9775-eabc-2af4-e499a8496828'`,
@@ -68,7 +68,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-LEAKS-4",
 			Rule: NewFacebookSecretKey(),
-			Src:  SampleVulnerableLeaksRegularFacebookSecretKey,
+			Src:  SampleVulnerableHSLEAKS4,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `FB_SECRET_KEY: 'cb6f53505911332d30867f44a1c1b9b5'`,
@@ -82,7 +82,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-LEAKS-5",
 			Rule: NewFacebookClientID(),
-			Src:  SampleVulnerableLeaksRegularFacebookClientID,
+			Src:  SampleVulnerableHSLEAKS5,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `FB_CLIENT_ID: '148695999071979'`,
@@ -94,23 +94,9 @@ func TestRulesVulnerableCode(t *testing.T) {
 			},
 		},
 		{
-			Name: "HS-LEAKS-7",
-			Rule: NewTwitterClientID(),
-			Src:  SampleVulnerableLeaksRegularTwitterClientID,
-			Findings: []engine.Finding{
-				{
-					CodeSample: `TWITTER_CLIENT_ID: '1h6433fsvygnyre5a40'`,
-					SourceLocation: engine.Location{
-						Line:   7,
-						Column: 6,
-					},
-				},
-			},
-		},
-		{
-			Name: "LEAKS-6",
+			Name: "HS-LEAKS-6",
 			Rule: NewTwitterSecretKey(),
-			Src:  SampleVulnerableLeaksRegularTwitterSecretKey,
+			Src:  SampleVulnerableHSLEAKS6,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `TWITTER_SECRET_KEY: 'ej64cqk9k8px9ae3e47ip89l7if58tqhpxi1r'`,
@@ -122,9 +108,23 @@ func TestRulesVulnerableCode(t *testing.T) {
 			},
 		},
 		{
+			Name: "HS-LEAKS-7",
+			Rule: NewTwitterClientID(),
+			Src:  SampleVulnerableHSLEAKS7,
+			Findings: []engine.Finding{
+				{
+					CodeSample: `TWITTER_CLIENT_ID: '1h6433fsvygnyre5a40'`,
+					SourceLocation: engine.Location{
+						Line:   7,
+						Column: 6,
+					},
+				},
+			},
+		},
+		{
 			Name: "HS-LEAKS-8",
 			Rule: NewGithub(),
-			Src:  SampleVulnerableLeaksRegularGithub,
+			Src:  SampleVulnerableHSLEAKS8,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `GITHUB_SECRET_KEY: 'edzvPbU3SYUc7pFc9le20lzIRErTOaxCABQ1'`,
@@ -138,7 +138,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-LEAKS-9",
 			Rule: NewLinkedInClientID(),
-			Src:  SampleVulnerableLeaksRegularLinkedInClientID,
+			Src:  SampleVulnerableHSLEAKS9,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `LINKEDIN_CLIENT_ID: 'g309xttlaw25'`,
@@ -150,9 +150,9 @@ func TestRulesVulnerableCode(t *testing.T) {
 			},
 		},
 		{
-			Name: "LEAKS-10",
+			Name: "HS-LEAKS-10",
 			Rule: NewLinkedInSecretKey(),
-			Src:  SampleVulnerableLeaksRegularLinkedInSecretKey,
+			Src:  SampleVulnerableHSLEAKS10,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `LINKEDIN_SECRET_KEY: '0d16kcnjyfzmcmjp'`,
@@ -164,9 +164,9 @@ func TestRulesVulnerableCode(t *testing.T) {
 			},
 		},
 		{
-			Name: "LEAKS-11",
+			Name: "HS-LEAKS-11",
 			Rule: NewSlack(),
-			Src:  SampleVulnerableLeaksRegularSlack,
+			Src:  SampleVulnerableHSLEAKS11,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `SLACK_WEBHOOK: 'https://hooks.slack.com/services/TNeqvYPeO/BncTJ74Hf/NlvFFKKAKPkd6h7FlQCz1Blu'`,
@@ -180,7 +180,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-LEAKS-12",
 			Rule: NewAsymmetricPrivateKey(),
-			Src:  SampleVulnerableLeaksRegularAsymmetricPrivateKey,
+			Src:  SampleVulnerableHSLEAKS12,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `SSH_PRIVATE_KEY: '-----BEGIN PRIVATE KEY-----MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDBj08sp5++4anGcmQxJjAkBgNVBAoTHVByb2dyZXNzIFNvZnR3YXJlIENvcnBvcmF0aW9uMSAwHgYDVQQDDBcqLmF3cy10ZXN0LnByb2dyZXNzLmNvbTCCASIwDQYJKoZIhvcNAQEBBQAD...bml6YXRpb252YWxzaGEyZzIuY3JsMIGgBggrBgEFBQcBAQSBkzCBkDBNBggrBgEFBQcwAoZBaHR0cDovL3NlY3VyZS5nbG9iYWxzaWduLmNvbS9jYWNlcnQvZ3Nvcmdhz3P668YfhUbKdRF6S42Cg6zn-----END PRIVATE KEY-----'`,
@@ -194,7 +194,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-LEAKS-13",
 			Rule: NewGoogleAPIKey(),
-			Src:  SampleVulnerableLeaksRegularGoogleAPIKey,
+			Src:  SampleVulnerableHSLEAKS13,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `GCP_API_KEY: 'AIzaMPZHYiu1RdzE1nG2SaVyOoz244TuacQIR6m'`,
@@ -208,7 +208,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-LEAKS-14",
 			Rule: NewGoogleGCPServiceAccount(),
-			Src:  SampleVulnerableLeaksRegularGoogleGCPServiceAccount,
+			Src:  SampleVulnerableHSLEAKS14,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `GCP_SERVICE_ACCOUNT: '18256698220617903267772185514630273595-oy8_uzouz8tyy46y84ckrwei9_6rq_pb.apps.googleusercontent.com'`,
@@ -222,7 +222,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-LEAKS-15",
 			Rule: NewHerokuAPIKey(),
-			Src:  SampleVulnerableLeaksRegularHerokuAPIKey,
+			Src:  SampleVulnerableHSLEAKS15,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `HEROKU_API_KEY: '3623f8e9-2d05-c9bb-2209082d6b5c'`,
@@ -236,7 +236,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-LEAKS-16",
 			Rule: NewMailChimpAPIKey(),
-			Src:  SampleVulnerableLeaksRegularMailChimpAPIKey,
+			Src:  SampleVulnerableHSLEAKS16,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `MAILCHIMP_API_KEY: 'f7e9c13c10d0b19c3bb003a9f635d488-us72'`,
@@ -250,7 +250,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-LEAKS-17",
 			Rule: NewMailgunAPIKey(),
-			Src:  SampleVulnerableLeaksRegularMailgunAPIKey,
+			Src:  SampleVulnerableHSLEAKS17,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `MAILGUN_API_KEY: 'key-xke9nbc2i5po5cjw3ngyxiz450zxpapu'`,
@@ -264,7 +264,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-LEAKS-18",
 			Rule: NewPayPalBraintreeAccessToken(),
-			Src:  SampleVulnerableLeaksRegularPayPalBraintreeAccessToken,
+			Src:  SampleVulnerableHSLEAKS18,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `PAY_PAL_ACCESS_TOKEN: 'access_token$production$mk0sech2v7qqsol3$db651af2221c22b4ca2f0f583798135e'`,
@@ -278,7 +278,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-LEAKS-19",
 			Rule: NewPicaticAPIKey(),
-			Src:  SampleVulnerableLeaksRegularPicaticAPIKey,
+			Src:  SampleVulnerableHSLEAKS19,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `PICATIC_API_KEY: 'sk_live_voy1p9k7r9g9j8ezmif488nk2p8310nl'`,
@@ -292,7 +292,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-LEAKS-20",
 			Rule: NewSendGridAPIKey(),
-			Src:  SampleVulnerableLeaksRegularSendGridAPIKey,
+			Src:  SampleVulnerableHSLEAKS20,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `SEND_GRID_API_KEY: 'SG.44b7kq3FurdH0bSHBGjPSWhE8vJ.1evu4Un0TXFIb1_6zW4YOdjTMeE'`,
@@ -306,7 +306,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-LEAKS-21",
 			Rule: NewStripeAPIKey(),
-			Src:  SampleVulnerableLeaksRegularStripeAPIKey,
+			Src:  SampleVulnerableHSLEAKS21,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `STRIPE_API_KEY: 'rk_live_8qSZpoI9t0BOGkOLVzvesc6K'`,
@@ -320,7 +320,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-LEAKS-22",
 			Rule: NewSquareAccessToken(),
-			Src:  SampleVulnerableLeaksRegularSquareAccessToken,
+			Src:  SampleVulnerableHSLEAKS22,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `SQUARE_ACCESS_TOKEN: 'sq0atp-clYRBSht6oefa7w_2R56ra'`,
@@ -334,7 +334,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-LEAKS-23",
 			Rule: NewSquareOAuthSecret(),
-			Src:  SampleVulnerableLeaksRegularSquareOAuthSecret,
+			Src:  SampleVulnerableHSLEAKS23,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `SQUARE_SECRET: 'sq0csp-LsEBYQNja]OgT3hRxjJV5cWX^XjpT12n3QkRY_vep2z'`,
@@ -348,7 +348,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-LEAKS-24",
 			Rule: NewTwilioAPIKey(),
-			Src:  SampleVulnerableLeaksRegularTwilioAPIKey,
+			Src:  SampleVulnerableHSLEAKS24,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `TWILIO_API_KEY: '^SK9ae6bd84ccd091eb6bfad8e2a474af95'`,
@@ -362,7 +362,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-LEAKS-25",
 			Rule: NewHardCodedCredentialGeneric(),
-			Src:  SampleVulnerableLeaksRegularHardCodedCredentialGeneric,
+			Src:  SampleVulnerableHSLEAKS25,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `POSTGRES_DBPASSWD: 'Ch@ng3m3'`,
@@ -376,7 +376,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-LEAKS-26",
 			Rule: NewHardCodedPassword(),
-			Src:  SampleVulnerableLeaksRegularHardCodedPassword,
+			Src:  SampleVulnerableHSLEAKS26,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `DB_PASSWORD="gorm"`,
@@ -390,7 +390,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-LEAKS-27",
 			Rule: NewPasswordExposedInHardcodedURL(),
-			Src:  SampleVulnerableLeaksRegularPasswordExposedInHardcodedURL,
+			Src:  SampleVulnerableHSLEAKS27,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `dsn := "postgresql://gorm:gorm@127.0.0.1:5432/gorm?sslmode=disable"`,
@@ -404,7 +404,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-LEAKS-28",
 			Rule: NewWPConfig(),
-			Src:  SampleVulnerableLeaksRegularWPConfig,
+			Src:  SampleVulnerableHSLEAKS28,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `define('AUTH_KEY', 'put your unique phrase here');`,
@@ -431,142 +431,142 @@ func TestRulesSafeCode(t *testing.T) {
 		{
 			Name: "HS-LEAKS-1",
 			Rule: NewAWSManagerID(),
-			Src:  SampleSafeLeaksRegularAWSManagerID,
+			Src:  SampleSafeHSLEAKS1,
 		},
 		{
 			Name: "HS-LEAKS-2",
 			Rule: NewAWSSecretKey(),
-			Src:  SampleSafeLeaksRegularAWSSecretKey,
+			Src:  SampleSafeHSLEAKS2,
 		},
 		{
 			Name: "HS-LEAKS-3",
 			Rule: NewAWSMWSKey(),
-			Src:  SampleSafeLeaksRegularAWSMWSKey,
+			Src:  SampleSafeHSLEAKS3,
 		},
 		{
 			Name: "HS-LEAKS-4",
 			Rule: NewFacebookSecretKey(),
-			Src:  SampleSafeLeaksRegularFacebookSecretKey,
+			Src:  SampleSafeHSLEAKS4,
 		},
 		{
 			Name: "HS-LEAKS-5",
 			Rule: NewFacebookClientID(),
-			Src:  SampleSafeLeaksRegularFacebookClientID,
+			Src:  SampleSafeHSLEAKS5,
+		},
+		{
+			Name: "HS-LEAKS-6",
+			Rule: NewTwitterSecretKey(),
+			Src:  SampleSafeHSLEAKS6,
 		},
 		{
 			Name: "HS-LEAKS-7",
 			Rule: NewTwitterClientID(),
-			Src:  SampleSafeLeaksRegularTwitterClientID,
-		},
-		{
-			Name: "LEAKS-6",
-			Rule: NewTwitterSecretKey(),
-			Src:  SampleSafeLeaksRegularTwitterSecretKey,
+			Src:  SampleSafeHSLEAKS7,
 		},
 		{
 			Name: "HS-LEAKS-8",
 			Rule: NewGithub(),
-			Src:  SampleSafeLeaksRegularGithub,
+			Src:  SampleSafeHSLEAKS8,
 		},
 		{
 			Name: "HS-LEAKS-9",
 			Rule: NewLinkedInClientID(),
-			Src:  SampleSafeLeaksRegularLinkedInClientID,
+			Src:  SampleSafeHSLEAKS9,
 		},
 		{
-			Name: "LEAKS-10",
+			Name: "HS-LEAKS-10",
 			Rule: NewLinkedInSecretKey(),
-			Src:  SampleSafeLeaksRegularLinkedInSecretKey,
+			Src:  SampleSafeHSLEAKS10,
 		},
 		{
-			Name: "LEAKS-11",
+			Name: "HS-LEAKS-11",
 			Rule: NewSlack(),
-			Src:  SampleSafeLeaksRegularSlack,
+			Src:  SampleSafeHSLEAKS11,
 		},
 		{
 			Name: "HS-LEAKS-12",
 			Rule: NewAsymmetricPrivateKey(),
-			Src:  SampleSafeLeaksRegularAsymmetricPrivateKey,
+			Src:  SampleSafeHSLEAKS12,
 		},
 		{
 			Name: "HS-LEAKS-13",
 			Rule: NewGoogleAPIKey(),
-			Src:  SampleSafeLeaksRegularGoogleAPIKey,
+			Src:  SampleSafeHSLEAKS13,
 		},
 		{
 			Name: "HS-LEAKS-14",
 			Rule: NewGoogleGCPServiceAccount(),
-			Src:  SampleSafeLeaksRegularGoogleGCPServiceAccount,
+			Src:  SampleSafeHSLEAKS14,
 		},
 		{
 			Name: "HS-LEAKS-15",
 			Rule: NewHerokuAPIKey(),
-			Src:  SampleSafeLeaksRegularHerokuAPIKey,
+			Src:  SampleSafeHSLEAKS15,
 		},
 		{
 			Name: "HS-LEAKS-16",
 			Rule: NewMailChimpAPIKey(),
-			Src:  SampleSafeLeaksRegularMailChimpAPIKey,
+			Src:  SampleSafeHSLEAKS16,
 		},
 		{
 			Name: "HS-LEAKS-17",
 			Rule: NewMailgunAPIKey(),
-			Src:  SampleSafeLeaksRegularMailgunAPIKey,
+			Src:  SampleSafeHSLEAKS17,
 		},
 		{
 			Name: "HS-LEAKS-18",
 			Rule: NewPayPalBraintreeAccessToken(),
-			Src:  SampleSafeLeaksRegularPayPalBraintreeAccessToken,
+			Src:  SampleSafeHSLEAKS18,
 		},
 		{
 			Name: "HS-LEAKS-19",
 			Rule: NewPicaticAPIKey(),
-			Src:  SampleSafeLeaksRegularPicaticAPIKey,
+			Src:  SampleSafeHSLEAKS19,
 		},
 		{
 			Name: "HS-LEAKS-20",
 			Rule: NewSendGridAPIKey(),
-			Src:  SampleSafeLeaksRegularSendGridAPIKey,
+			Src:  SampleSafeHSLEAKS20,
 		},
 		{
 			Name: "HS-LEAKS-21",
 			Rule: NewStripeAPIKey(),
-			Src:  SampleSafeLeaksRegularStripeAPIKey,
+			Src:  SampleSafeHSLEAKS21,
 		},
 		{
 			Name: "HS-LEAKS-22",
 			Rule: NewSquareAccessToken(),
-			Src:  SampleSafeLeaksRegularSquareAccessToken,
+			Src:  SampleSafeHSLEAKS22,
 		},
 		{
 			Name: "HS-LEAKS-23",
 			Rule: NewSquareOAuthSecret(),
-			Src:  SampleSafeLeaksRegularSquareOAuthSecret,
+			Src:  SampleSafeHSLEAKS23,
 		},
 		{
 			Name: "HS-LEAKS-24",
 			Rule: NewTwilioAPIKey(),
-			Src:  SampleSafeLeaksRegularTwilioAPIKey,
+			Src:  SampleSafeHSLEAKS24,
 		},
 		{
 			Name: "HS-LEAKS-25",
 			Rule: NewHardCodedCredentialGeneric(),
-			Src:  SampleSafeLeaksRegularHardCodedCredentialGeneric,
+			Src:  SampleSafeHSLEAKS25,
 		},
 		{
 			Name: "HS-LEAKS-26",
 			Rule: NewHardCodedPassword(),
-			Src:  SampleSafeLeaksRegularHardCodedPassword,
+			Src:  SampleSafeHSLEAKS26,
 		},
 		{
 			Name: "HS-LEAKS-27",
 			Rule: NewPasswordExposedInHardcodedURL(),
-			Src:  SampleSafeLeaksRegularPasswordExposedInHardcodedURL,
+			Src:  SampleSafeHSLEAKS27,
 		},
 		{
 			Name: "HS-LEAKS-28",
 			Rule: NewWPConfig(),
-			Src:  SampleSafeLeaksRegularWPConfig,
+			Src:  SampleSafeHSLEAKS28,
 		},
 	}
 	testutil.TestSafeCode(t, testcases)

--- a/internal/services/engines/leaks/samples_test.go
+++ b/internal/services/engines/leaks/samples_test.go
@@ -15,7 +15,7 @@
 package leaks
 
 const (
-	SampleVulnerableLeaksRegularAWSManagerID = `
+	SampleVulnerableHSLEAKS1 = `
 version: '3'
 services:
   backend:
@@ -24,7 +24,7 @@ services:
 	    ACCESS_KEY: 'AKIAJSIE27KKMHXI3BJQ'
 	`
 
-	SampleVulnerableLeaksRegularAWSSecretKey = `
+	SampleVulnerableHSLEAKS2 = `
 version: '3'
 services:
   backend:
@@ -33,7 +33,7 @@ services:
       AWS_SECRET_KEY: 'doc5eRXFpsWllGC5yKJV/Ymm5KwF+IRZo95EudOm'
 	`
 
-	SampleVulnerableLeaksRegularAWSMWSKey = `
+	SampleVulnerableHSLEAKS3 = `
 version: '3'
 services:
   backend:
@@ -41,7 +41,7 @@ services:
     environment:
       AWS_WMS_KEY: 'amzn.mws.986478f0-9775-eabc-2af4-e499a8496828'
 	`
-	SampleVulnerableLeaksRegularFacebookSecretKey = `
+	SampleVulnerableHSLEAKS4 = `
 version: '3'
 services:
   backend:
@@ -50,7 +50,7 @@ services:
       FB_SECRET_KEY: 'cb6f53505911332d30867f44a1c1b9b5'
 	`
 
-	SampleVulnerableLeaksRegularFacebookClientID = `
+	SampleVulnerableHSLEAKS5 = `
 version: '3'
 services:
   backend:
@@ -59,7 +59,7 @@ services:
       FB_CLIENT_ID: '148695999071979'
 	`
 
-	SampleVulnerableLeaksRegularTwitterClientID = `
+	SampleVulnerableHSLEAKS7 = `
 version: '3'
 services:
   backend:
@@ -68,7 +68,7 @@ services:
       TWITTER_CLIENT_ID: '1h6433fsvygnyre5a40'
 	`
 
-	SampleVulnerableLeaksRegularTwitterSecretKey = `
+	SampleVulnerableHSLEAKS6 = `
 version: '3'
 services:
   backend:
@@ -77,7 +77,7 @@ services:
       TWITTER_SECRET_KEY: 'ej64cqk9k8px9ae3e47ip89l7if58tqhpxi1r'
 	`
 
-	SampleVulnerableLeaksRegularGithub = `
+	SampleVulnerableHSLEAKS8 = `
 version: '3'
 services:
   backend:
@@ -86,7 +86,7 @@ services:
       GITHUB_SECRET_KEY: 'edzvPbU3SYUc7pFc9le20lzIRErTOaxCABQ1'
 	`
 
-	SampleVulnerableLeaksRegularLinkedInClientID = `
+	SampleVulnerableHSLEAKS9 = `
 version: '3'
 services:
   backend:
@@ -95,7 +95,7 @@ services:
       LINKEDIN_CLIENT_ID: 'g309xttlaw25'
 	`
 
-	SampleVulnerableLeaksRegularLinkedInSecretKey = `
+	SampleVulnerableHSLEAKS10 = `
 version: '3'
 services:
   backend:
@@ -104,7 +104,7 @@ services:
       LINKEDIN_SECRET_KEY: '0d16kcnjyfzmcmjp'
 	`
 
-	SampleVulnerableLeaksRegularSlack = `
+	SampleVulnerableHSLEAKS11 = `
 version: '3'
 services:
   backend:
@@ -113,7 +113,7 @@ services:
       SLACK_WEBHOOK: 'https://hooks.slack.com/services/TNeqvYPeO/BncTJ74Hf/NlvFFKKAKPkd6h7FlQCz1Blu'
 	`
 
-	SampleVulnerableLeaksRegularAsymmetricPrivateKey = `
+	SampleVulnerableHSLEAKS12 = `
 version: '3'
 services:
   backend:
@@ -122,7 +122,7 @@ services:
       SSH_PRIVATE_KEY: '-----BEGIN PRIVATE KEY-----MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDBj08sp5++4anGcmQxJjAkBgNVBAoTHVByb2dyZXNzIFNvZnR3YXJlIENvcnBvcmF0aW9uMSAwHgYDVQQDDBcqLmF3cy10ZXN0LnByb2dyZXNzLmNvbTCCASIwDQYJKoZIhvcNAQEBBQAD...bml6YXRpb252YWxzaGEyZzIuY3JsMIGgBggrBgEFBQcBAQSBkzCBkDBNBggrBgEFBQcwAoZBaHR0cDovL3NlY3VyZS5nbG9iYWxzaWduLmNvbS9jYWNlcnQvZ3Nvcmdhz3P668YfhUbKdRF6S42Cg6zn-----END PRIVATE KEY-----'
 	`
 
-	SampleVulnerableLeaksRegularGoogleAPIKey = `
+	SampleVulnerableHSLEAKS13 = `
 version: '3'
 services:
   backend:
@@ -131,7 +131,7 @@ services:
       GCP_API_KEY: 'AIzaMPZHYiu1RdzE1nG2SaVyOoz244TuacQIR6m'
 	`
 
-	SampleVulnerableLeaksRegularGoogleGCPServiceAccount = `
+	SampleVulnerableHSLEAKS14 = `
 version: '3'
 services:
   backend:
@@ -140,7 +140,7 @@ services:
       GCP_SERVICE_ACCOUNT: '18256698220617903267772185514630273595-oy8_uzouz8tyy46y84ckrwei9_6rq_pb.apps.googleusercontent.com'
 	`
 
-	SampleVulnerableLeaksRegularHerokuAPIKey = `
+	SampleVulnerableHSLEAKS15 = `
 version: '3'
 services:
   backend:
@@ -149,7 +149,7 @@ services:
       HEROKU_API_KEY: '3623f8e9-2d05-c9bb-2209082d6b5c'
 	`
 
-	SampleVulnerableLeaksRegularMailChimpAPIKey = `
+	SampleVulnerableHSLEAKS16 = `
 version: '3'
 services:
   backend:
@@ -158,7 +158,7 @@ services:
       MAILCHIMP_API_KEY: 'f7e9c13c10d0b19c3bb003a9f635d488-us72'
 	`
 
-	SampleVulnerableLeaksRegularMailgunAPIKey = `
+	SampleVulnerableHSLEAKS17 = `
 version: '3'
 services:
   backend:
@@ -167,7 +167,7 @@ services:
       MAILGUN_API_KEY: 'key-xke9nbc2i5po5cjw3ngyxiz450zxpapu'
 	`
 
-	SampleVulnerableLeaksRegularPayPalBraintreeAccessToken = `
+	SampleVulnerableHSLEAKS18 = `
 version: '3'
 services:
   backend:
@@ -176,7 +176,7 @@ services:
       PAY_PAL_ACCESS_TOKEN: 'access_token$production$mk0sech2v7qqsol3$db651af2221c22b4ca2f0f583798135e'
 	`
 
-	SampleVulnerableLeaksRegularPicaticAPIKey = `
+	SampleVulnerableHSLEAKS19 = `
 version: '3'
 services:
   backend:
@@ -185,7 +185,7 @@ services:
       PICATIC_API_KEY: 'sk_live_voy1p9k7r9g9j8ezmif488nk2p8310nl'
 	`
 
-	SampleVulnerableLeaksRegularSendGridAPIKey = `
+	SampleVulnerableHSLEAKS20 = `
 version: '3'
 services:
   backend:
@@ -194,7 +194,7 @@ services:
       SEND_GRID_API_KEY: 'SG.44b7kq3FurdH0bSHBGjPSWhE8vJ.1evu4Un0TXFIb1_6zW4YOdjTMeE'
 	`
 
-	SampleVulnerableLeaksRegularStripeAPIKey = `
+	SampleVulnerableHSLEAKS21 = `
 version: '3'
 services:
   backend:
@@ -203,7 +203,7 @@ services:
       STRIPE_API_KEY: 'rk_live_8qSZpoI9t0BOGkOLVzvesc6K'
 	`
 
-	SampleVulnerableLeaksRegularSquareAccessToken = `
+	SampleVulnerableHSLEAKS22 = `
 version: '3'
 services:
   backend:
@@ -212,7 +212,7 @@ services:
       SQUARE_ACCESS_TOKEN: 'sq0atp-clYRBSht6oefa7w_2R56ra'
 	`
 
-	SampleVulnerableLeaksRegularSquareOAuthSecret = `
+	SampleVulnerableHSLEAKS23 = `
 version: '3'
 services:
   backend:
@@ -221,7 +221,7 @@ services:
       SQUARE_SECRET: 'sq0csp-LsEBYQNja]OgT3hRxjJV5cWX^XjpT12n3QkRY_vep2z'
 	`
 
-	SampleVulnerableLeaksRegularTwilioAPIKey = `
+	SampleVulnerableHSLEAKS24 = `
 version: '3'
 services:
   backend:
@@ -230,7 +230,7 @@ services:
       TWILIO_API_KEY: '^SK9ae6bd84ccd091eb6bfad8e2a474af95'
 	`
 
-	SampleVulnerableLeaksRegularHardCodedCredentialGeneric = `
+	SampleVulnerableHSLEAKS25 = `
 version: '3'
 services:
   backend:
@@ -239,7 +239,7 @@ services:
       POSTGRES_DBPASSWD: 'Ch@ng3m3'
 	`
 
-	SampleVulnerableLeaksRegularHardCodedPassword = `
+	SampleVulnerableHSLEAKS26 = `
 package main
 
 import (
@@ -262,7 +262,7 @@ func main() {
 }
 	`
 
-	SampleVulnerableLeaksRegularPasswordExposedInHardcodedURL = `
+	SampleVulnerableHSLEAKS27 = `
 package main
 
 import (
@@ -280,7 +280,7 @@ func main() {
 }
 	`
 
-	SampleVulnerableLeaksRegularWPConfig = `
+	SampleVulnerableHSLEAKS28 = `
 	<?php
 define('AUTH_KEY', 'put your unique phrase here');
 define('DB_PASSWORD', 'wen0221!');
@@ -312,7 +312,7 @@ process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
 )
 
 const (
-	SampleSafeLeaksRegularAWSManagerID = `
+	SampleSafeHSLEAKS1 = `
 version: '3'
 services:
   backend:
@@ -321,7 +321,7 @@ services:
 	  ACCESS_KEY: ${SECRET_KEY}
 	`
 
-	SampleSafeLeaksRegularAWSSecretKey = `
+	SampleSafeHSLEAKS2 = `
 version: '3'
 services:
   backend:
@@ -331,7 +331,7 @@ services:
 
 	`
 
-	SampleSafeLeaksRegularAWSMWSKey = `
+	SampleSafeHSLEAKS3 = `
 version: '3'
 services:
   backend:
@@ -340,7 +340,7 @@ services:
       WMS_KEY: ${SECRET_KEY}
 	`
 
-	SampleSafeLeaksRegularFacebookSecretKey = `
+	SampleSafeHSLEAKS4 = `
 version: '3'
 services:
   backend:
@@ -349,7 +349,7 @@ services:
 	  FB_SECRET_KEY: ${SECRET_KEY}
 	`
 
-	SampleSafeLeaksRegularFacebookClientID = `
+	SampleSafeHSLEAKS5 = `
 version: '3'
 services:
   backend:
@@ -358,16 +358,7 @@ services:
 	  FB_CLIENT_ID: ${SECRET_KEY}
 	`
 
-	SampleSafeLeaksRegularTwitterClientID = `
-version: '3'
-services:
-  backend:
-    image: image/my-backend:latest
-    environment:
-	  TWITTER_CLIENT_ID: ${SECRET_KEY}
-	`
-
-	SampleSafeLeaksRegularTwitterSecretKey = `
+	SampleSafeHSLEAKS6 = `
 version: '3'
 services:
   backend:
@@ -376,7 +367,16 @@ services:
 	  TWITTER_SECRET_KEY: ${SECRET_KEY}
 	`
 
-	SampleSafeLeaksRegularGithub = `
+	SampleSafeHSLEAKS7 = `
+version: '3'
+services:
+  backend:
+    image: image/my-backend:latest
+    environment:
+	  TWITTER_CLIENT_ID: ${SECRET_KEY}
+	`
+
+	SampleSafeHSLEAKS8 = `
 version: '3'
 services:
   backend:
@@ -385,7 +385,7 @@ services:
 	  GITHUB_SECRET_KEY: ${SECRET_KEY}
 	`
 
-	SampleSafeLeaksRegularLinkedInClientID = `
+	SampleSafeHSLEAKS9 = `
 version: '3'
 services:
   backend:
@@ -394,7 +394,7 @@ services:
 	  LINKEDIN_CLIENT_ID: ${SECRET_KEY}
 	`
 
-	SampleSafeLeaksRegularLinkedInSecretKey = `
+	SampleSafeHSLEAKS10 = `
 version: '3'
 services:
   backend:
@@ -403,7 +403,7 @@ services:
 	  LINKEDIN_SECRET_KEY: ${SECRET_KEY}
 	`
 
-	SampleSafeLeaksRegularSlack = `
+	SampleSafeHSLEAKS11 = `
 version: '3'
 services:
   backend:
@@ -412,7 +412,7 @@ services:
 	  SLACK_WEBHOOK: ${SECRET_KEY}
 	`
 
-	SampleSafeLeaksRegularAsymmetricPrivateKey = `
+	SampleSafeHSLEAKS12 = `
 version: '3'
 services:
   backend:
@@ -421,7 +421,7 @@ services:
 	  SSH_PRIVATE_KEY: ${SECRET_KEY}
 	`
 
-	SampleSafeLeaksRegularGoogleAPIKey = `
+	SampleSafeHSLEAKS13 = `
 version: '3'
 services:
   backend:
@@ -430,7 +430,7 @@ services:
 	  GCP_API_KEY: ${SECRET_KEY}
 	`
 
-	SampleSafeLeaksRegularGoogleGCPServiceAccount = `
+	SampleSafeHSLEAKS14 = `
 version: '3'
 services:
   backend:
@@ -439,7 +439,7 @@ services:
 	  GCP_SERVICE_ACCOUNT: ${SECRET_KEY}
 	`
 
-	SampleSafeLeaksRegularHerokuAPIKey = `
+	SampleSafeHSLEAKS15 = `
 version: '3'
 services:
   backend:
@@ -448,7 +448,7 @@ services:
 	  HEROKU_API_KEY: ${SECRET_KEY}
 	`
 
-	SampleSafeLeaksRegularMailChimpAPIKey = `
+	SampleSafeHSLEAKS16 = `
 version: '3'
 services:
   backend:
@@ -457,7 +457,7 @@ services:
 	  MAILCHIMP_API_KEY: ${SECRET_KEY}
 	`
 
-	SampleSafeLeaksRegularMailgunAPIKey = `
+	SampleSafeHSLEAKS17 = `
 version: '3'
 services:
   backend:
@@ -466,7 +466,7 @@ services:
 	  MAILGUN_API_KEY: ${SECRET_KEY}
 	`
 
-	SampleSafeLeaksRegularPayPalBraintreeAccessToken = `
+	SampleSafeHSLEAKS18 = `
 version: '3'
 services:
   backend:
@@ -475,7 +475,7 @@ services:
 	  PAY_PAL_ACCESS_TOKEN: ${SECRET_KEY}
 	`
 
-	SampleSafeLeaksRegularPicaticAPIKey = `
+	SampleSafeHSLEAKS19 = `
 version: '3'
 services:
   backend:
@@ -484,7 +484,7 @@ services:
 	  PICATIC_API_KEY: ${SECRET_KEY}
 	`
 
-	SampleSafeLeaksRegularSendGridAPIKey = `
+	SampleSafeHSLEAKS20 = `
 version: '3'
 services:
   backend:
@@ -493,7 +493,7 @@ services:
 	  SEND_GRID_API_KEY: ${SECRET_KEY}
 	`
 
-	SampleSafeLeaksRegularStripeAPIKey = `
+	SampleSafeHSLEAKS21 = `
 version: '3'
 services:
   backend:
@@ -502,7 +502,7 @@ services:
 	  STRIPE_API_KEY: ${SECRET_KEY}
 	`
 
-	SampleSafeLeaksRegularSquareAccessToken = `
+	SampleSafeHSLEAKS22 = `
 version: '3'
 services:
   backend:
@@ -511,7 +511,7 @@ services:
 	  SQUARE_ACCESS_TOKEN: ${SECRET_KEY}
 	`
 
-	SampleSafeLeaksRegularSquareOAuthSecret = `
+	SampleSafeHSLEAKS23 = `
 version: '3'
 services:
   backend:
@@ -520,7 +520,7 @@ services:
 	  SQUARE_SECRET: ${SECRET_KEY}
 	`
 
-	SampleSafeLeaksRegularTwilioAPIKey = `
+	SampleSafeHSLEAKS24 = `
 version: '3'
 services:
   backend:
@@ -529,7 +529,7 @@ services:
 	  TWILIO_API_KEY: ${SECRET_KEY}
 	`
 
-	SampleSafeLeaksRegularHardCodedCredentialGeneric = `
+	SampleSafeHSLEAKS25 = `
 version: '3'
 services:
   backend:
@@ -538,7 +538,7 @@ services:
 	  POSTGRES_DBPASSWD: ${SECRET_KEY}
 	`
 
-	SampleSafeLeaksRegularHardCodedPassword = `
+	SampleSafeHSLEAKS26 = `
 package main
 
 import (
@@ -562,7 +562,7 @@ func main() {
 }
 	`
 
-	SampleSafeLeaksRegularPasswordExposedInHardcodedURL = `
+	SampleSafeHSLEAKS27 = `
 package main
 
 import (
@@ -581,7 +581,7 @@ func main() {
 }
 	`
 
-	SampleSafeLeaksRegularWPConfig = `
+	SampleSafeHSLEAKS28 = `
 <?php
 define('AUTH_KEY', getenv("AUTH_KEY"));
 	`

--- a/internal/services/engines/nginx/rules_test.go
+++ b/internal/services/engines/nginx/rules_test.go
@@ -26,7 +26,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-NGINX-1",
 			Rule: NewIncludeXFrameOptionsHeader(),
-			Src:  SampleVulnerableIncludeXFrameOptionsHeader,
+			Src:  SampleVulnerableHSNGINX1,
 			Findings: []engine.Finding{
 				{
 					CodeSample: "",
@@ -40,7 +40,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-NGINX-2",
 			Rule: NewIncludeXContentTypeOptionsHeader(),
-			Src:  SampleVulnerableIncludeXContentTypeOptionsHeader,
+			Src:  SampleVulnerableHSNGINX2,
 			Findings: []engine.Finding{
 				{
 					CodeSample: "",
@@ -54,7 +54,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-NGINX-3",
 			Rule: NewIncludeContentSecurityPolicyHeader(),
-			Src:  SampleVulnerableIncludeContentSecurityPolicyHeader,
+			Src:  SampleVulnerableHSNGINX3,
 			Findings: []engine.Finding{
 				{
 					CodeSample: "",
@@ -68,7 +68,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-NGINX-4",
 			Rule: NewIncludeServerTokensOff(),
-			Src:  SampleVulnerableIncludeServerTokensOff,
+			Src:  SampleVulnerableHSNGINX4,
 			Findings: []engine.Finding{
 				{
 					CodeSample: "",
@@ -89,22 +89,22 @@ func TestRulesSafeCode(t *testing.T) {
 		{
 			Name: "HS-NGINX-1",
 			Rule: NewIncludeXFrameOptionsHeader(),
-			Src:  SampleSafeIncludeXFrameOptionsHeader,
+			Src:  SampleSafeHSNGINX1,
 		},
 		{
 			Name: "HS-NGINX-2",
 			Rule: NewIncludeXContentTypeOptionsHeader(),
-			Src:  SampleSafeIncludeXContentTypeOptionsHeader,
+			Src:  SampleSafeHSNGINX2,
 		},
 		{
 			Name: "HS-NGINX-3",
 			Rule: NewIncludeContentSecurityPolicyHeader(),
-			Src:  SampleSafeIncludeContentSecurityPolicyHeader,
+			Src:  SampleSafeHSNGINX3,
 		},
 		{
 			Name: "HS-NGINX-4",
 			Rule: NewIncludeServerTokensOff(),
-			Src:  SampleSafeIncludeServerTokensOff,
+			Src:  SampleSafeHSNGINX4,
 		},
 	}
 

--- a/internal/services/engines/nginx/samples_test.go
+++ b/internal/services/engines/nginx/samples_test.go
@@ -15,7 +15,7 @@
 package nginx
 
 const (
-	SampleVulnerableIncludeXContentTypeOptionsHeader = `
+	SampleVulnerableHSNGINX2 = `
 add_header X-Frame-Options "SAMEORIGIN";
 add_header Strict-Transport-Security "max-age=15768000; includeSubDomains";
 add_header X-XSS-Protection "1; mode=block";
@@ -23,7 +23,7 @@ add_header Content-Security-Policy "default-src 'self'; img-src *; style-src 'se
 upstream plone52 {
     server 127.0.0.1:8080;
 }`
-	SampleSafeIncludeXContentTypeOptionsHeader = `
+	SampleSafeHSNGINX2 = `
 add_header X-Frame-Options "SAMEORIGIN";
 add_header Strict-Transport-Security "max-age=15768000; includeSubDomains";
 add_header X-XSS-Protection "1; mode=block";
@@ -32,14 +32,14 @@ add_header Content-Security-Policy "default-src 'self'; img-src *; style-src 'se
 upstream plone52 {
     server 127.0.0.1:8080;
 }`
-	SampleVulnerableIncludeXFrameOptionsHeader = `
+	SampleVulnerableHSNGINX1 = `
 add_header Strict-Transport-Security "max-age=15768000; includeSubDomains";
 add_header X-XSS-Protection "1; mode=block";
 add_header Content-Security-Policy "default-src 'self'; img-src *; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'";
 upstream plone52 {
     server 127.0.0.1:8080;
 }`
-	SampleSafeIncludeXFrameOptionsHeader = `
+	SampleSafeHSNGINX1 = `
 add_header X-Frame-Options "SAMEORIGIN";
 add_header Strict-Transport-Security "max-age=15768000; includeSubDomains";
 add_header X-XSS-Protection "1; mode=block";
@@ -47,13 +47,13 @@ add_header Content-Security-Policy "default-src 'self'; img-src *; style-src 'se
 upstream plone52 {
     server 127.0.0.1:8080;
 }`
-	SampleVulnerableIncludeContentSecurityPolicyHeader = `
+	SampleVulnerableHSNGINX3 = `
 add_header Strict-Transport-Security "max-age=15768000; includeSubDomains";
 add_header X-XSS-Protection "1; mode=block";
 upstream plone52 {
     server 127.0.0.1:8080;
 }`
-	SampleSafeIncludeContentSecurityPolicyHeader = `
+	SampleSafeHSNGINX3 = `
 add_header X-Frame-Options "SAMEORIGIN";
 add_header Strict-Transport-Security "max-age=15768000; includeSubDomains";
 add_header X-XSS-Protection "1; mode=block";
@@ -61,13 +61,13 @@ add_header Content-Security-Policy "default-src 'self'; img-src *; style-src 'se
 upstream plone52 {
     server 127.0.0.1:8080;
 }`
-	SampleVulnerableIncludeServerTokensOff = `
+	SampleVulnerableHSNGINX4 = `
 add_header Strict-Transport-Security "max-age=15768000; includeSubDomains";
 add_header X-XSS-Protection "1; mode=block";
 upstream plone52 {
     server 127.0.0.1:8080;
 }`
-	SampleSafeIncludeServerTokensOff = `
+	SampleSafeHSNGINX4 = `
 server_tokens off;
 add_header X-Frame-Options "SAMEORIGIN";
 add_header Strict-Transport-Security "max-age=15768000; includeSubDomains";

--- a/internal/services/engines/nodejs/rules_test.go
+++ b/internal/services/engines/nodejs/rules_test.go
@@ -26,7 +26,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-JAVASCRIPT-1",
 			Rule: NewNoLogSensitiveInformationInConsole(),
-			Src:  SampleVulnerableJavaScriptLogSensitiveInformation,
+			Src:  SampleVulnerableHSJAVASCRIPT1,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `console.log("user email: ", email)`,
@@ -47,7 +47,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-JAVASCRIPT-2",
 			Rule: NewNoUseEval(),
-			Src:  SampleVulnerableJavaScriptUseEval,
+			Src:  SampleVulnerableHSJAVASCRIPT2,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `eval("bash -c" + req.body);`,
@@ -61,7 +61,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-JAVASCRIPT-3",
 			Rule: NewNoDisableTlsRejectUnauthorized(),
-			Src:  SampleVulnerableJavaScriptDisableTlsRejectUnauthorized,
+			Src:  SampleVulnerableHSJAVASCRIPT3,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";`,
@@ -75,7 +75,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-JAVASCRIPT-4",
 			Rule: NewNoUseMD5Hashing(),
-			Src:  SampleVulnerableJavaScriptNoUseMD5Hashing,
+			Src:  SampleVulnerableHSJAVASCRIPT4,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `const hash = crypto.createHash('md5')`,
@@ -89,7 +89,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-JAVASCRIPT-5",
 			Rule: NewNoUseSHA1Hashing(),
-			Src:  SampleVulnerableJavaScriptNoUseSHA1Hashing,
+			Src:  SampleVulnerableHSJAVASCRIPT5,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `const hash = crypto.createHash('sha1')`,
@@ -103,7 +103,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-JAVASCRIPT-6",
 			Rule: NewNoUseWeakRandom(),
-			Src:  SampleVulnerableJavaScriptNoUseWeakRandom,
+			Src:  SampleVulnerableHSJAVASCRIPT6,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `return Math.random();`,
@@ -117,7 +117,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-JAVASCRIPT-7",
 			Rule: NewNoReadFileUsingDataFromRequest(),
-			Src:  SampleVulnerableJavaScriptNoReadFileUsingDataFromRequest,
+			Src:  SampleVulnerableHSJAVASCRIPT7,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `return fs.readFileSync(req.body, 'utf8')`,
@@ -131,7 +131,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-JAVASCRIPT-8",
 			Rule: NewNoCreateReadStreamUsingDataFromRequest(),
-			Src:  SampleVulnerableJavaScriptNoCreateReadStreamUsingDataFromRequest,
+			Src:  SampleVulnerableHSJAVASCRIPT8,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `return fs.createReadStream(req.body)`,
@@ -152,7 +152,7 @@ func TestRulesSafeCode(t *testing.T) {
 		{
 			Name: "HS-JAVASCRIPT-2",
 			Rule: NewNoUseEval(),
-			Src:  SampleSafeJavaScriptUseEval,
+			Src:  SampleSafeHSJAVASCRIPT2,
 		},
 	}
 

--- a/internal/services/engines/nodejs/samples_test.go
+++ b/internal/services/engines/nodejs/samples_test.go
@@ -15,43 +15,53 @@
 package nodejs
 
 const (
-	SampleSafeJavaScriptUseEval = `
-function f() {
-	eval("echo foo");
-}
-	`
+	SampleVulnerableHSJAVASCRIPT1 = `
+console.log("user email: ", email)
+console.debug("user password: ", pwd)
+`
 
-	SampleVulnerableJavaScriptDisableTlsRejectUnauthorized = `
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
-	`
-	SampleVulnerableJavaScriptUseEval = `
+	SampleVulnerableHSJAVASCRIPT2 = `
 function f(req) {
 	eval("bash -c" + req.body);
 }
-	`
-	SampleVulnerableJavaScriptLogSensitiveInformation = `
-console.log("user email: ", email) 
-console.debug("user password: ", pwd) 
-	`
-	SampleVulnerableJavaScriptNoUseMD5Hashing = `
+`
+
+	SampleVulnerableHSJAVASCRIPT3 = `
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+`
+
+	SampleVulnerableHSJAVASCRIPT4 = `
 const hash = crypto.createHash('md5')
-	`
-	SampleVulnerableJavaScriptNoUseSHA1Hashing = `
+`
+
+	SampleVulnerableHSJAVASCRIPT5 = `
 const hash = crypto.createHash('sha1')
-	`
-	SampleVulnerableJavaScriptNoUseWeakRandom = `
+`
+
+	SampleVulnerableHSJAVASCRIPT6 = `
 function f() {
 	return Math.random();
 }
-	`
-	SampleVulnerableJavaScriptNoReadFileUsingDataFromRequest = `
+`
+
+	SampleVulnerableHSJAVASCRIPT7 = `
 function f(req) {
 	return fs.readFileSync(req.body, 'utf8')
 }
-	`
-	SampleVulnerableJavaScriptNoCreateReadStreamUsingDataFromRequest = `
+`
+
+	SampleVulnerableHSJAVASCRIPT8 = `
 function f(req) {
 	return fs.createReadStream(req.body)
 }
-	`
+`
+
+)
+
+const (
+	SampleSafeHSJAVASCRIPT2 = `
+function f() {
+	eval("echo foo");
+}
+`
 )

--- a/internal/services/engines/swift/rules_test.go
+++ b/internal/services/engines/swift/rules_test.go
@@ -26,7 +26,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 		{
 			Name: "HS-SWIFT-6",
 			Rule: NewWeakMD5CryptoCipher(),
-			Src:  SampleVulnerableWeakMD5CryptoCipher,
+			Src:  SampleVulnerableHSSWIFT6,
 			Findings: []engine.Finding{
 				{
 					CodeSample: `import CryptoSwift`,
@@ -47,7 +47,7 @@ func TestRulesSafeCode(t *testing.T) {
 		{
 			Name: "HS-SWIFT-6",
 			Rule: NewWeakMD5CryptoCipher(),
-			Src:  SampleSafeWeakMD5CryptoCipher,
+			Src:  SampleSafeHSSWIFT6,
 		},
 	}
 	testutil.TestSafeCode(t, testcases)

--- a/internal/services/engines/swift/samples_test.go
+++ b/internal/services/engines/swift/samples_test.go
@@ -15,10 +15,11 @@
 package swift
 
 const (
-	SampleVulnerableWeakMD5CryptoCipher = `import CryptoSwift
+	SampleVulnerableHSSWIFT6 = `import CryptoSwift
 
 		"SwiftSummit".md5()`
-	SampleSafeWeakMD5CryptoCipher = `import Foundation
+
+	SampleSafeHSSWIFT6 = `import Foundation
 import var CommonCrypto.CC_MD5_DIGEST_LENGTH
 import func CommonCrypto.CC_MD5
 import typealias CommonCrypto.CC_LONG

--- a/internal/utils/testutil/rules_test_generic.go
+++ b/internal/utils/testutil/rules_test_generic.go
@@ -30,6 +30,7 @@ func TestVulnerableCode(t *testing.T, testcases []*RuleTestCase) {
 		t.Run(tt.Name, func(t *testing.T) {
 			findings := executeRule(t, tt)
 			assert.Len(t, findings, len(tt.Findings), "Expected equal issues on vulnerable code")
+			assert.Equal(t, tt.Name, tt.Rule.ID, "Test case rule name is not match with rule id")
 			assertExpectedFindingAndRuleCase(t, findings, tt)
 		})
 	}
@@ -53,6 +54,7 @@ func TestSafeCode(t *testing.T, testcases []*RuleTestCase) {
 		t.Run(tt.Name, func(t *testing.T) {
 			Findings := executeRule(t, tt)
 			assert.Empty(t, Findings, "Expected not issues on safe code to Rule %s", tt.Name)
+			assert.Equal(t, tt.Name, tt.Rule.ID)
 		})
 	}
 }


### PR DESCRIPTION
Before we were adding the examples of safe code and insecure code using the name of the rule, but this pattern is very difficult to identify where it is in the code seen in engines that have enough rule, its use is impracticable.
So I'm switching so we can use the default "Sample" + "Vulnerable" or "Safe" + "RuleID"

Signed-off-by: wilian <wilian.silva@zup.com.br>
