### PR TITLE
tests: fix unnecessary file created on config tests

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -187,7 +187,9 @@ func TestNewHorusecConfig(t *testing.T) {
 		assert.NoError(t, os.Setenv(config.EnvEnableShellCheck, "true"))
 		assert.NoError(t, os.Setenv(config.EnvCustomRulesPath, "test"))
 		assert.NoError(t, os.Setenv(config.EnvEnableInformationSeverity, "true"))
-		assert.NoError(t, os.Setenv(config.EnvLogFilePath, "test"))
+		assert.NoError(t, os.Setenv(
+			config.EnvLogFilePath, filepath.Join(os.TempDir(), "test.log")),
+		)
 		configs.LoadFromEnvironmentVariables()
 
 		assert.Equal(t, configFilePath, configs.ConfigFilePath)


### PR DESCRIPTION
Previously when running the config tests a file `config/test` was
created with all the logs. This commit change the behaviour to create
this test log file on temp directory.

This is related with #726 and #731

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
