### PR TITLE
engine/nodejs: create tests for rules

### DIFF
--- a/internal/services/engines/nodejs/rules.go
+++ b/internal/services/engines/nodejs/rules.go
@@ -162,7 +162,7 @@ func NewSQLInjectionUsingParams() text.TextRule {
 		},
 		Type: text.Regular,
 		Expressions: []*regexp.Regexp{
-			regexp.MustCompile(`\.(find|drop|create|explain|delete|count|bulk|copy).*\n*{.*\n*\$where(?:'|\"|):.*(?:req\.|req\.query|req\.body|req\.param)`),
+			regexp.MustCompile(`\.(find|drop|create|explain|delete|count|bulk|copy).*\n*{.*\n*(\$|)where(?:'|\"|):.*(?:req\.|req\.query|req\.body|req\.param)`),
 		},
 	}
 }
@@ -279,7 +279,7 @@ func NewAlertStatementsShouldNotBeUsed() text.TextRule {
 		},
 		Type: text.Regular,
 		Expressions: []*regexp.Regexp{
-			regexp.MustCompile(`(?m)(?i)(^| |;)(alert|confirm|prompt)\(.*`),
+			regexp.MustCompile(`(?m)(?i)(^||;)(alert|confirm|prompt)\(.*`),
 		},
 	}
 }

--- a/internal/services/engines/nodejs/rules_test.go
+++ b/internal/services/engines/nodejs/rules_test.go
@@ -142,6 +142,181 @@ func TestRulesVulnerableCode(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "HS-JAVASCRIPT-9",
+			Rule: NewSQLInjectionUsingParams(),
+			Src:  SampleVulnerableHSJAVASCRIPT9,
+			Findings: []engine.Finding{
+				{
+					CodeSample: `Model.find({ where: { foo: req.body}});`,
+					SourceLocation: engine.Location{
+						Line:   3,
+						Column: 6,
+					},
+				},
+			},
+		},
+		{
+			Name: "HS-JAVASCRIPT-10",
+			Rule: NewXMLParsersShouldNotBeVulnerableToXXEAttacks(),
+			Src:  SampleVulnerableHSJAVASCRIPT10,
+			Findings: []engine.Finding{
+				{
+					CodeSample: `var xmlDoc = libxml.parseXmlString(xml, {});`,
+					SourceLocation: engine.Location{
+						Line:   4,
+						Column: 19,
+					},
+				},
+			},
+		},
+		{
+			Name: "HS-JAVASCRIPT-11",
+			Rule: NewOriginsNotVerified(),
+			Src:  SampleVulnerableHSJAVASCRIPT11,
+			Findings: []engine.Finding{
+				{
+					CodeSample: `popup.postMessage("message", "https://foo.bar", "*");`,
+					SourceLocation: engine.Location{
+						Line:   4,
+						Column: 6,
+					},
+				},
+				{
+					CodeSample: `window.addEventListener("message", (event) => {});`,
+					SourceLocation: engine.Location{
+						Line:   8,
+						Column: 7,
+					},
+				},
+			},
+		},
+		{
+			Name: "HS-JAVASCRIPT-12",
+			Rule: NewWeakSSLTLSProtocolsShouldNotBeUsed(),
+			Src:  SampleVulnerableHSJAVASCRIPT12,
+			Findings: []engine.Finding{
+				{
+					CodeSample: `secureProtocol: 'TLSv1_method'`,
+					SourceLocation: engine.Location{
+						Line:   4,
+						Column: 19,
+					},
+				},
+				{
+					CodeSample: `secureProtocol: 'TLSv1.1'`,
+					SourceLocation: engine.Location{
+						Line:   10,
+						Column: 19,
+					},
+				},
+			},
+		},
+		{
+			Name: "HS-JAVASCRIPT-13",
+			Rule: NewWebSQLDatabasesShouldNotBeUsed(),
+			Src:  SampleVulnerableHSJAVASCRIPT13,
+			Findings: []engine.Finding{
+				{
+					CodeSample: `const db = window.openDatabase();`,
+					SourceLocation: engine.Location{
+						Line:   2,
+						Column: 11,
+					},
+				},
+			},
+		},
+		{
+			Name: "HS-JAVASCRIPT-14",
+			Rule: NewLocalStorageShouldNotBeUsed(),
+			Src:  SampleVulnerableHSJAVASCRIPT14,
+			Findings: []engine.Finding{
+				{
+					CodeSample: `localStorage.setItem("foo", "bar");`,
+					SourceLocation: engine.Location{
+						Line:   3,
+						Column: 1,
+					},
+				},
+				{
+					CodeSample: `sessionStorage.setItem("foo", "bar");`,
+					SourceLocation: engine.Location{
+						Line:   7,
+						Column: 1,
+					},
+				},
+			},
+		},
+		{
+			Name: "HS-JAVASCRIPT-15",
+			Rule: NewDebuggerStatementsShouldNotBeUsed(),
+			Src:  SampleVulnerableHSJAVASCRIPT15,
+			Findings: []engine.Finding{
+				{
+					CodeSample: `debugger;`,
+					SourceLocation: engine.Location{
+						Line:   2,
+						Column: 1,
+					},
+				},
+			},
+		},
+		{
+			Name: "HS-JAVASCRIPT-16",
+			Rule: NewAlertStatementsShouldNotBeUsed(),
+			Src:  SampleVulnerableHSJAVASCRIPT16,
+			Findings: []engine.Finding{
+				{
+					CodeSample: `alert("testing");`,
+					SourceLocation: engine.Location{
+						Line:   3,
+						Column: 1,
+					},
+				},
+				{
+					CodeSample: `confirm("testing");`,
+					SourceLocation: engine.Location{
+						Line:   7,
+						Column: 1,
+					},
+				},
+				{
+					CodeSample: `prompt("testing");`,
+					SourceLocation: engine.Location{
+						Line:   11,
+						Column: 1,
+					},
+				},
+			},
+		},
+		{
+			Name: "HS-JAVASCRIPT-17",
+			Rule: NewStaticallyServingHiddenFilesIsSecuritySensitive(),
+			Src:  SampleVulnerableHSJAVASCRIPT17,
+			Findings: []engine.Finding{
+				{
+					CodeSample: `dotfiles : 'allow'`,
+					SourceLocation: engine.Location{
+						Line:   3,
+						Column: 2,
+					},
+				},
+			},
+		},
+		{
+			Name: "HS-JAVASCRIPT-18",
+			Rule: NewUsingIntrusivePermissionsWithGeolocation(),
+			Src:  SampleVulnerableHSJAVASCRIPT18,
+			Findings: []engine.Finding{
+				{
+					CodeSample: `navigator.geolocation.getCurrentPosition(success, error, {});`,
+					SourceLocation: engine.Location{
+						Line:   10,
+						Column: 10,
+					},
+				},
+			},
+		},
 	}
 
 	testutil.TestVulnerableCode(t, testcases)
@@ -153,6 +328,31 @@ func TestRulesSafeCode(t *testing.T) {
 			Name: "HS-JAVASCRIPT-2",
 			Rule: NewNoUseEval(),
 			Src:  SampleSafeHSJAVASCRIPT2,
+		},
+		{
+			Name: "HS-JAVASCRIPT-9",
+			Rule: NewSQLInjectionUsingParams(),
+			Src:  SampleSafeHSJAVASCRIPT9,
+		},
+		{
+			Name: "HS-JAVASCRIPT-10",
+			Rule: NewXMLParsersShouldNotBeVulnerableToXXEAttacks(),
+			Src:  SampleSafeHSJAVASCRIPT10,
+		},
+		{
+			Name: "HS-JAVASCRIPT-11",
+			Rule: NewOriginsNotVerified(),
+			Src:  SampleSafeHSJAVASCRIPT11,
+		},
+		{
+			Name: "HS-JAVASCRIPT-12",
+			Rule: NewWeakSSLTLSProtocolsShouldNotBeUsed(),
+			Src:  SampleSafeHSJAVASCRIPT12,
+		},
+		{
+			Name: "HS-JAVASCRIPT-17",
+			Rule: NewStaticallyServingHiddenFilesIsSecuritySensitive(),
+			Src:  SampleSafeHSJAVASCRIPT17,
 		},
 	}
 

--- a/internal/services/engines/nodejs/samples_test.go
+++ b/internal/services/engines/nodejs/samples_test.go
@@ -55,6 +55,92 @@ function f(req) {
 	return fs.createReadStream(req.body)
 }
 `
+	SampleVulnerableHSJAVASCRIPT9 = `
+function f(req) {
+	Model.find({ where: { foo: req.body}});
+}
+	`
+
+	SampleVulnerableHSJAVASCRIPT10 = `
+var libxml = require("libxmljs2");
+
+var xmlDoc = libxml.parseXmlString(xml, {});
+	`
+
+	SampleVulnerableHSJAVASCRIPT11 = `
+function f() {
+	var popup = window.open();
+	popup.postMessage("message", "https://foo.bar", "*");
+}
+
+function f2() {
+	window.addEventListener("message", (event) => {});
+}
+	`
+
+	SampleVulnerableHSJAVASCRIPT12 = `
+function f() {
+	const options = {
+		secureProtocol: 'TLSv1_method'
+	}
+}
+
+function f2() {
+	const options = {
+		secureProtocol: 'TLSv1.1'
+	}
+}
+	`
+
+	SampleVulnerableHSJAVASCRIPT13 = `
+const db = window.openDatabase();
+	`
+
+	SampleVulnerableHSJAVASCRIPT14 = `
+function f() {
+	localStorage.setItem("foo", "bar");
+}
+
+function f2() {
+	sessionStorage.setItem("foo", "bar");
+}
+	`
+
+	SampleVulnerableHSJAVASCRIPT15 = `
+	debugger;
+	`
+
+	SampleVulnerableHSJAVASCRIPT16 = `
+function f() {
+	alert("testing");
+}
+
+function f2() {
+	confirm("testing");
+}
+
+function f3() {
+	prompt("testing");
+}
+	`
+
+	SampleVulnerableHSJAVASCRIPT17 = `
+app.use('/', express.static('public', {
+  dotfiles : 'allow'
+}));
+	`
+
+	SampleVulnerableHSJAVASCRIPT18 = `
+function success(pos) {
+	console.log(pos)
+}
+
+function error(err) {
+  console.warn(err);
+}
+
+navigator.geolocation.getCurrentPosition(success, error, {});
+	`
 )
 
 const (
@@ -63,4 +149,45 @@ function f() {
 	eval("echo foo");
 }
 `
+
+	SampleSafeHSJAVASCRIPT9 = `
+function f(foo) {
+	Model.find({ where: { foo: foo}});
+}
+`
+
+	SampleSafeHSJAVASCRIPT10 = `
+var libxml = require("libxmljs2");
+
+var xmlDoc = libxml.parseXmlString(xml);
+	`
+
+	SampleSafeHSJAVASCRIPT11 = `
+function f() {
+	var popup = window.open();
+	popup.postMessage("message", "https://foo.bar");
+}
+
+function f2() {
+	window.addEventListener("message", (event) => {
+		if (event.origin !== "http://example.org:8080") {
+			return;
+		}
+	});
+}
+	`
+
+	SampleSafeHSJAVASCRIPT12 = `
+
+function f() {
+	const options = {
+		secureProtocol: 'SSLv23_method'
+	}
+}
+	`
+
+	SampleSafeHSJAVASCRIPT17 = `
+app.use('/', express.static('public', { }));
+
+	`
 )


### PR DESCRIPTION
Create tests for rules HS-JAVASCRIPT-9, HS-JAVASCRIPT-10,
HS-JAVASCRIPT-11, HS-JAVASCRIPT-12, HS-JAVASCRIPT-13, HS-JAVASCRIPT-14,
HS-JAVASCRIPT-15, HS-JAVASCRIPT-16, HS-JAVASCRIPT-17, HS-JAVASCRIPT-18

Note that the regex from rule HS-JAVASCRIPT-9 was changed to
optionally match `$` on where field since this is not valid on
sequealize https://sequelize.org/master/manual/model-querying-basics.html#applying-where-clauses

Note too that this commit fix the regex of rule HS-JAVASCRIPT-16 that
was not matching indentation.

Updates #630

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
