### PR TITLE
docker: improvement logs on pulling image

### DIFF
--- a/internal/helpers/messages/debug.go
+++ b/internal/helpers/messages/debug.go
@@ -32,4 +32,5 @@ const (
 	MsgDebugShowWorkdir                  = "{HORUSEC_CLI} The workdir setup for run in path:"
 	MsgDebugToolIgnored                  = "{HORUSEC_CLI} The tool was ignored for run in this analysis: "
 	MsgDebugVulnHashToFix                = "{HORUSEC_CLI} Vulnerability Hash expected to be FIXED: "
+	MsgDebugDockerImageDoesNotExists     = "{HORUSEC_CLI} Image %s does not exists. Pulling from registry"
 )


### PR DESCRIPTION
Previously when we call `checkIfImageNotExists` function we check for
errors and if image does not exists on the same statement and only log
if some errors occurs, which turn the code a bit confuse to read.

This commit change to check for errors and if image does not exists on
different statements and also add a debug logging to inform that image
does not exists on cache and we will try to pull from registry.

This commit also add some tests to assert that we are pulling the image
only if its not exists on cache.

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
