### PR TITLE
analyzer: disable scan loading when debug level log is set

### DIFF
--- a/internal/controllers/analyzer/analyzer.go
+++ b/internal/controllers/analyzer/analyzer.go
@@ -16,6 +16,7 @@ package analyzer
 
 import (
 	"fmt"
+	"io"
 	"path/filepath"
 
 	"log"
@@ -27,6 +28,7 @@ import (
 
 	"github.com/briandowns/spinner"
 	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
 
 	"github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
 	"github.com/ZupIT/horusec-devkit/pkg/entities/vulnerability"
@@ -134,7 +136,7 @@ func NewAnalyzer(cfg *config.Config) *Analyzer {
 		printController: printresults.NewPrintResults(entity, cfg),
 		horusec:         horusecAPI.NewHorusecAPIService(cfg),
 		formatter:       formatters.NewFormatterService(entity, dockerAPI, cfg),
-		loading:         newScanLoading(),
+		loading:         newScanLoading(cfg),
 	}
 }
 
@@ -661,9 +663,13 @@ func spawn(wg *sync.WaitGroup, f formatters.IFormatter, src string) {
 	}()
 }
 
-func newScanLoading() *spinner.Spinner {
+func newScanLoading(cfg *config.Config) *spinner.Spinner {
 	loading := spinner.New(spinner.CharSets[11], LoadingDelay)
 	loading.Suffix = messages.MsgInfoAnalysisLoading
+
+	if cfg.LogLevel == logrus.DebugLevel.String() || cfg.LogLevel == logrus.TraceLevel.String() {
+		loading.Writer = io.Discard
+	}
 
 	return loading
 }

--- a/internal/controllers/analyzer/analyzer_test.go
+++ b/internal/controllers/analyzer/analyzer_test.go
@@ -250,7 +250,7 @@ func TestAnalyzer_AnalysisDirectory(t *testing.T) {
 			printController: printResultMock,
 			horusec:         horusecAPIMock,
 			formatter:       formatters.NewFormatterService(&entitiesAnalysis.Analysis{}, dockerSDK, configs),
-			loading:         newScanLoading(),
+			loading:         newScanLoading(configs),
 		}
 
 		controller.analysis = &entitiesAnalysis.Analysis{ID: uuid.New()}
@@ -308,7 +308,7 @@ func TestAnalyzer_AnalysisDirectory(t *testing.T) {
 			printController: printResultMock,
 			horusec:         horusecAPIMock,
 			formatter:       formatters.NewFormatterService(&entitiesAnalysis.Analysis{}, dockerSDK, configs),
-			loading:         newScanLoading(),
+			loading:         newScanLoading(configs),
 		}
 
 		controller.analysis = &entitiesAnalysis.Analysis{ID: uuid.New()}
@@ -351,7 +351,7 @@ func TestAnalyzer_AnalysisDirectory(t *testing.T) {
 			printController: printResultMock,
 			horusec:         horusecAPIMock,
 			formatter:       formatters.NewFormatterService(&entitiesAnalysis.Analysis{}, dockerSDK, configs),
-			loading:         newScanLoading(),
+			loading:         newScanLoading(configs),
 		}
 
 		controller.analysis = &entitiesAnalysis.Analysis{ID: uuid.New()}


### PR DESCRIPTION
Previously when we set the log level for debug the output is hard to
read since the we are printing the debug messages and the scan loading.

This commit change the newScanLoading constructor to set the writer of
loading to io.Discard when the log level is debug or trace.

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
