### PR TITLE
feat:docker: use env variables to configure docker client

### DIFF
--- a/internal/services/docker/client/docker_config.go
+++ b/internal/services/docker/client/docker_config.go
@@ -22,7 +22,7 @@ import (
 )
 
 func NewDockerClient() *docker.Client {
-	dockerClient, err := docker.NewClientWithOpts(docker.WithAPIVersionNegotiation())
+	dockerClient, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
 	if err != nil {
 		logger.LogPanicWithLevel(messages.MsgPanicNotConnectDocker, err)
 	}

--- a/internal/services/docker/client/docker_config_test.go
+++ b/internal/services/docker/client/docker_config_test.go
@@ -16,6 +16,7 @@ package client
 
 import (
 	"io"
+	"os"
 	"strings"
 	"testing"
 
@@ -29,6 +30,15 @@ func TestNewDockerAPI(t *testing.T) {
 		assert.NotPanics(t, func() {
 			NewDockerClient()
 		})
+	})
+
+	t.Run("Should use docker host from environment variable", func(t *testing.T) {
+		dockerHost := "http://localhost:1234"
+		os.Setenv("DOCKER_HOST", dockerHost)
+
+		c := NewDockerClient()
+
+		assert.Equal(t, dockerHost, c.DaemonHost())
 	})
 }
 


### PR DESCRIPTION
Previously when an user use a different DOCKER_HOST we was not able to
connect because we was not reading the environment variables.

This commit change the docker client initialization to read
configuration from environment variables if they exists.

Fixes #525

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
