### PR TITLE
gitleaks-chore: fixing gitleaks formatter error and improving config

### DIFF
--- a/internal/controllers/analyzer/analyzer.go
+++ b/internal/controllers/analyzer/analyzer.go
@@ -171,6 +171,12 @@ func (a *Analyzer) runAnalysis() (totalVulns int, err error) {
 	if err != nil {
 		return 0, err
 	}
+
+	if a.config.EnableGitHistoryAnalysis {
+		logger.LogWarnWithLevel(messages.MsgWarnGitHistoryEnable)
+		fmt.Println()
+	}
+
 	a.startDetectVulnerabilities(langs)
 	return a.sendAnalysisAndStartPrintResults()
 }
@@ -312,13 +318,12 @@ func (a *Analyzer) detectVulnerabilityLeaks(wg *sync.WaitGroup, projectSubPath s
 	spawn(wg, horusecleaks.NewFormatter(a.formatter), projectSubPath)
 
 	if a.config.EnableGitHistoryAnalysis {
-		logger.LogWarnWithLevel(messages.MsgWarnGitHistoryEnable)
-
 		if err := a.docker.PullImage(a.getCustomOrDefaultImage(languages.Leaks)); err != nil {
 			return err
 		}
 		gitleaks.NewFormatter(a.formatter).StartAnalysis(projectSubPath)
 	}
+
 	return nil
 }
 

--- a/internal/services/formatters/leaks/deployments/Dockerfile
+++ b/internal/services/formatters/leaks/deployments/Dockerfile
@@ -16,7 +16,5 @@ FROM zricethezav/gitleaks:v7.6.1
 
 COPY ./internal/services/formatters/leaks/deployments/rules.toml /rules/rules.toml
 
-RUN apk --no-cache add ca-certificates openssh-client jq
-
 ENTRYPOINT []
 CMD ["/bin/sh"]

--- a/internal/services/formatters/leaks/gitleaks/config.go
+++ b/internal/services/formatters/leaks/gitleaks/config.go
@@ -17,12 +17,6 @@ package gitleaks
 
 const CMD = `
 		{{WORK_DIR}}
-		touch /tmp/results-ANALYSISID.json /tmp/error-ANALYSISID.txt
-		gitleaks --config-path="/rules/rules.toml" --path="./" --leaks-exit-code="0" --verbose --report="/tmp/results-ANALYSISID.json" &> /tmp/error-ANALYSISID.txt
-		if [ $? -eq 0 ];
-		then
-            jq -j -M -c . /tmp/results-ANALYSISID.json
-        else
-            cat /tmp/error-ANALYSISID.txt
-        fi
+		gitleaks --config-path /rules/rules.toml --path . --leaks-exit-code 0 --format json --report /tmp/leaks-result.json &> /tmp/leaks-runner-output.txt
+		cat /tmp/leaks-result.json
   `


### PR DESCRIPTION
Signed-off-by: Nathan Martins <nathan.martins@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
- Removed unnecessary apk add from leaks dockerfile that was causing an error during the image build.
- Changed gitleaks config to use its own tool's flag for json export.
- Fixed a bug that broke analysis loading due to a warning stating that the git history is active.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
