### PR TITLE
e2e:feature - Add build locally in e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,6 +24,9 @@ on:
 permissions: read-all
 jobs:
   test:
+    permissions:
+      contents: write
+      packages: write
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -38,6 +41,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
+          fetch-depth: 0
           submodules: true
 
       - name: Setup Golang
@@ -50,6 +54,14 @@ jobs:
         uses: docker-practice/actions-setup-docker@master
         with:
           docker_buildx: false
-
-      - name: Run e2e test for ${{ matrix.os }}
-        run: go test -v ./e2e/... -timeout 60m -failfast -race
+      - name: Build local images
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: sh ./deployments/scripts/build-all-tools.sh
+      - name: Run e2e analysis test for ${{ matrix.os }}
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: go test -v ./e2e/analysis/... -timeout 60m -failfast -race
+      - name: Run e2e commands test for ${{ matrix.os }}
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: go test -v ./e2e/commands/... -timeout 60m -failfast -race

--- a/Makefile
+++ b/Makefile
@@ -34,23 +34,26 @@ test:
 	$(GO) test -v $(GO_LIST_TO_TEST) -race -timeout=5m -parallel=1 -failfast -short
 
 test-e2e:
+	sh ./deployments/scripts/build-all-tools.sh
 	$(GO) clean -testcache
-	$(GO) test -v ./e2e/... -timeout=10m -parallel=1 -failfast
+	$(GO) test -v ./e2e/analysis/... -timeout=30m -parallel=1 -failfast
+	$(GO) clean -testcache
+	$(GO) test -v ./e2e/commands/... -timeout=30m -parallel=1 -failfast
 
 fix-imports:
     ifeq (, $(shell which $(GO_IMPORTS)))
-		$(GO) get -u golang.org/x/tools/cmd/goimports
+		$(GO) install golang.org/x/tools/cmd/goimports
 		$(GO_IMPORTS) -local $(GO_IMPORTS_LOCAL) -w $(GO_FILES)
     else
 		$(GO_IMPORTS) -local $(GO_IMPORTS_LOCAL) -w $(GO_FILES)
     endif
 
 license:
-	$(GO) get -u github.com/google/addlicense
+	$(GO) install github.com/google/addlicense
 	@$(ADDLICENSE) -check -f ./copyright.txt $(shell find -regex '.*\.\(go\|js\|ts\|yml\|yaml\|sh\|dockerfile\)')
 
 license-fix:
-	$(GO) get -u github.com/google/addlicense
+	$(GO) install github.com/google/addlicense
 	@$(ADDLICENSE) -f ./copyright.txt $(shell find -regex '.*\.\(go\|js\|ts\|yml\|yaml\|sh\|dockerfile\)')
 
 security:

--- a/deployments/scripts/build-all-tools.sh
+++ b/deployments/scripts/build-all-tools.sh
@@ -1,0 +1,40 @@
+# Copyright 2021 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+IMAGE_BASE_NAME=$1
+IMAGE_TAG=$2
+
+setDefaultImageBaseName() {
+    if [ -z "$IMAGE_BASE_NAME" ]; then
+        IMAGE_BASE_NAME="local"
+    fi
+    if [ -z "$IMAGE_TAG" ]; then
+        IMAGE_TAG="local"
+    fi
+}
+
+getDirectoryAndImagesNameByLanguageName() {
+    # shellcheck disable=SC2044
+    for DOCKERFILE in $(find internal -type f -iname "Dockerfile"); do
+        LANGUAGE=$(echo $DOCKERFILE | cut -d "/" -f4)
+        if ! docker build -t "$IMAGE_BASE_NAME-$LANGUAGE:$IMAGE_TAG" -f "$DOCKERFILE" .; then
+            echo "Error on build docker file in path: $DOCKERFILE"
+            exit 1
+        fi
+    done
+}
+
+setDefaultImageBaseName
+
+getDirectoryAndImagesNameByLanguageName

--- a/e2e/analysis/analysis_suite_test.go
+++ b/e2e/analysis/analysis_suite_test.go
@@ -17,11 +17,14 @@ package analysis_test
 import (
 	"testing"
 
+	ginkgoconfig "github.com/onsi/ginkgo/config"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 func TestAnalysis(t *testing.T) {
+	ginkgoconfig.GinkgoConfig.FailFast = true
 	RegisterFailHandler(Fail)
 	defer GinkgoRecover()
 	RunSpecs(t, "Analysis Suite")

--- a/e2e/analysis/test_case.go
+++ b/e2e/analysis/test_case.go
@@ -1,0 +1,673 @@
+// Copyright 2021 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analysis
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/ZupIT/horusec-devkit/pkg/enums/analysis"
+	"github.com/ZupIT/horusec/internal/helpers/messages"
+
+	"github.com/onsi/gomega/gexec"
+
+	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
+	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
+	"github.com/ZupIT/horusec/internal/utils/testutil"
+
+	. "github.com/onsi/ginkgo"
+)
+
+// Expected struct represents the validations that will be expected when comparing the final results of the analysis
+type Expected struct {
+	Language           languages.Language
+	OutputsContains    []string
+	OutputsNotContains []string
+	ExitCode           int
+}
+
+// Command struct represents all content for run command and your result who: output and exit code
+type Command struct {
+	Flags    map[string]string
+	Output   string
+	ExitCode int
+}
+
+// TestCase struct represents group of content for validate the test e2e of the tool and if is necessary docker for run this tool or not
+type TestCase struct {
+	Tool           tools.Tool
+	RequiredDocker bool
+	Command        Command
+	Expected       Expected
+}
+
+func (tc TestCase) RunAnalysisTestCase() (*gexec.Session, error) {
+	isWindows := runtime.GOOS == "windows"
+	if isWindows || !tc.RequiredDocker {
+		tc.Command.Flags[testutil.StartFlagDisableDocker] = "true"
+	}
+	cmd := testutil.GinkgoGetHorusecCmdWithFlags(testutil.CmdStart, tc.Command.Flags)
+	return gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+}
+
+func NewTestCase() []*TestCase {
+	return []*TestCase{
+		{
+			Tool:           tools.HorusecEngine,
+			RequiredDocker: false,
+			Command: Command{
+				Flags: map[string]string{
+					testutil.StartFlagProjectPath: testutil.ExamplesPath,
+				},
+			},
+			Expected: Expected{
+				Language: languages.Generic,
+				ExitCode: 0,
+				OutputsContains: []string{
+					fmt.Sprintf(messages.MsgPrintFinishAnalysisWithStatus, analysis.Success),
+					messages.MsgDebugVulnHashToFix,
+					messages.MsgWarnAnalysisFoundVulns[16:],
+					"In this analysis, a total of 66 possible vulnerabilities were found and we classified them into:",
+					"Total of Vulnerability CRITICAL is: 17",
+					"Total of Vulnerability HIGH is: 22",
+					"Total of Vulnerability MEDIUM is: 24",
+					"Total of Vulnerability LOW is: 3",
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.HorusecEngine, languages.CSharp),
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.HorusecEngine, languages.Dart),
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.HorusecEngine, languages.Java),
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.HorusecEngine, languages.Javascript),
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.HorusecEngine, languages.Kotlin),
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.HorusecEngine, languages.Leaks),
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.HorusecEngine, languages.Nginx),
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.HorusecEngine, languages.Swift),
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.HorusecEngine, languages.Yaml),
+					fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.GoSec),
+					fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.SecurityCodeScan),
+					fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.Brakeman),
+					fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.Safety),
+					fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.Bandit),
+					fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.NpmAudit),
+					fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.YarnAudit),
+					// TODO: This log show only if pass --enable-git-history, we can see if this tool was runned or not without this flag
+					//fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.GitLeaks),
+					fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.TfSec),
+					fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.Checkov),
+					fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.Semgrep),
+					fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.Flawfinder),
+					fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.PhpCS),
+					fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.MixAudit),
+					fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.Sobelow),
+					// TODO: This log show only if pass --enable-shellcheck, we can see if this tool was runned or not without this flag
+					//fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.ShellCheck),
+					fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.BundlerAudit),
+					// TODO: This log show only if pass --enable-owasp-dependency-check, we can see if this tool was runned or not without this flag
+					//fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.OwaspDependencyCheck),
+					fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.DotnetCli),
+					fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.Nancy),
+					fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.Trivy),
+				},
+				OutputsNotContains: []string{
+					fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.HorusecEngine),
+				},
+			},
+		},
+		{
+			Tool:           tools.Bandit,
+			RequiredDocker: true,
+			Command: Command{
+				Flags: map[string]string{
+					testutil.StartFlagProjectPath: testutil.PythonExample2,
+				},
+			},
+			Expected: Expected{
+				Language: languages.Python,
+				ExitCode: 0,
+				OutputsContains: []string{
+					fmt.Sprintf(messages.MsgPrintFinishAnalysisWithStatus, analysis.Success),
+					messages.MsgDebugVulnHashToFix,
+					messages.MsgWarnAnalysisFoundVulns[16:],
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.Bandit, languages.Python),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.Bandit, languages.Python),
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.Safety, languages.Python),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.Safety, languages.Python),
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.Semgrep, languages.Generic),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.Semgrep, languages.Generic),
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.Trivy, languages.Generic),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.Trivy, languages.Generic),
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.HorusecEngine, languages.Leaks),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.HorusecEngine, languages.Leaks),
+				},
+				OutputsNotContains: []string{
+					fmt.Sprintf("{HORUSEC_CLI} Something error went wrong in %s tool", tools.Bandit),
+				},
+			},
+		},
+		{
+			Tool:           tools.Safety,
+			RequiredDocker: true,
+			Command: Command{
+				Flags: map[string]string{
+					testutil.StartFlagProjectPath: testutil.PythonExample2,
+				},
+			},
+			Expected: Expected{
+				Language: languages.Python,
+				ExitCode: 0,
+				OutputsContains: []string{
+					fmt.Sprintf(messages.MsgPrintFinishAnalysisWithStatus, analysis.Success),
+					messages.MsgDebugVulnHashToFix,
+					messages.MsgWarnAnalysisFoundVulns[16:],
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.Bandit, languages.Python),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.Bandit, languages.Python),
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.Safety, languages.Python),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.Safety, languages.Python),
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.Semgrep, languages.Generic),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.Semgrep, languages.Generic),
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.Trivy, languages.Generic),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.Trivy, languages.Generic),
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.HorusecEngine, languages.Leaks),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.HorusecEngine, languages.Leaks),
+				},
+				OutputsNotContains: []string{
+					fmt.Sprintf("{HORUSEC_CLI} Something error went wrong in %s tool", tools.Safety),
+				},
+			},
+		},
+		{
+			Tool:           tools.GoSec,
+			RequiredDocker: true,
+			Command: Command{
+				Flags: map[string]string{
+					testutil.StartFlagProjectPath: testutil.GoExample1,
+				},
+			},
+			Expected: Expected{
+				Language: languages.Go,
+				ExitCode: 0,
+				OutputsContains: []string{
+					fmt.Sprintf(messages.MsgPrintFinishAnalysisWithStatus, analysis.Success),
+					messages.MsgDebugVulnHashToFix,
+					messages.MsgWarnAnalysisFoundVulns[16:],
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.GoSec, languages.Go),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.GoSec, languages.Go),
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.HorusecEngine, languages.Leaks),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.HorusecEngine, languages.Leaks),
+				},
+				OutputsNotContains: []string{
+					fmt.Sprintf("{HORUSEC_CLI} Something error went wrong in %s tool", tools.GoSec),
+				},
+			},
+		},
+		{
+			Tool:           tools.SecurityCodeScan,
+			RequiredDocker: true,
+			Command: Command{
+				Flags: map[string]string{
+					testutil.StartFlagProjectPath: testutil.CsharpExample1,
+				},
+			},
+			Expected: Expected{
+				Language: languages.CSharp,
+				ExitCode: 0,
+				OutputsContains: []string{
+					fmt.Sprintf(messages.MsgPrintFinishAnalysisWithStatus, analysis.Success),
+					messages.MsgDebugVulnHashToFix,
+					messages.MsgWarnAnalysisFoundVulns[16:],
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.SecurityCodeScan, languages.CSharp),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.SecurityCodeScan, languages.CSharp),
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.HorusecEngine, languages.Leaks),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.HorusecEngine, languages.Leaks),
+				},
+				OutputsNotContains: []string{
+					fmt.Sprintf("{HORUSEC_CLI} Something error went wrong in %s tool", tools.SecurityCodeScan),
+				},
+			},
+		},
+		{
+			Tool:           tools.NpmAudit,
+			RequiredDocker: true,
+			Command: Command{
+				Flags: map[string]string{
+					testutil.StartFlagProjectPath: testutil.JavaScriptExample1,
+				},
+			},
+			Expected: Expected{
+				Language: languages.Javascript,
+				ExitCode: 0,
+				OutputsContains: []string{
+					fmt.Sprintf(messages.MsgPrintFinishAnalysisWithStatus, analysis.Success),
+					messages.MsgDebugVulnHashToFix,
+					messages.MsgWarnAnalysisFoundVulns[16:],
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.NpmAudit, languages.Javascript),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.NpmAudit, languages.Javascript),
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.HorusecEngine, languages.Leaks),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.HorusecEngine, languages.Leaks),
+				},
+				OutputsNotContains: []string{
+					fmt.Sprintf("{HORUSEC_CLI} Something error went wrong in %s tool", tools.NpmAudit),
+				},
+			},
+		},
+		{
+			Tool:           tools.YarnAudit,
+			RequiredDocker: true,
+			Command: Command{
+				Flags: map[string]string{
+					testutil.StartFlagProjectPath: testutil.JavaScriptExample2,
+				},
+			},
+			Expected: Expected{
+				Language: languages.Javascript,
+				ExitCode: 0,
+				OutputsContains: []string{
+					fmt.Sprintf(messages.MsgPrintFinishAnalysisWithStatus, analysis.Success),
+					messages.MsgDebugVulnHashToFix,
+					messages.MsgWarnAnalysisFoundVulns[16:],
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.YarnAudit, languages.Javascript),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.YarnAudit, languages.Javascript),
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.HorusecEngine, languages.Leaks),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.HorusecEngine, languages.Leaks),
+				},
+				OutputsNotContains: []string{
+					fmt.Sprintf("{HORUSEC_CLI} Something error went wrong in %s tool", tools.YarnAudit),
+				},
+			},
+		},
+		{
+			Tool:           tools.TfSec,
+			RequiredDocker: true,
+			Command: Command{
+				Flags: map[string]string{
+					testutil.StartFlagProjectPath: testutil.Hclxample1,
+				},
+			},
+			Expected: Expected{
+				Language: languages.HCL,
+				ExitCode: 0,
+				OutputsContains: []string{
+					fmt.Sprintf(messages.MsgPrintFinishAnalysisWithStatus, analysis.Success),
+					messages.MsgDebugVulnHashToFix,
+					messages.MsgWarnAnalysisFoundVulns[16:],
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.TfSec, languages.HCL),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.TfSec, languages.HCL),
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.HorusecEngine, languages.Leaks),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.HorusecEngine, languages.Leaks),
+				},
+				OutputsNotContains: []string{
+					fmt.Sprintf("{HORUSEC_CLI} Something error went wrong in %s tool", tools.TfSec),
+				},
+			},
+		},
+		{
+			Tool:           tools.Checkov,
+			RequiredDocker: true,
+			Command: Command{
+				Flags: map[string]string{
+					testutil.StartFlagProjectPath: testutil.Hclxample1,
+				},
+			},
+			Expected: Expected{
+				Language: languages.HCL,
+				ExitCode: 0,
+				OutputsContains: []string{
+					fmt.Sprintf(messages.MsgPrintFinishAnalysisWithStatus, analysis.Success),
+					messages.MsgDebugVulnHashToFix,
+					messages.MsgWarnAnalysisFoundVulns[16:],
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.Checkov, languages.HCL),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.Checkov, languages.HCL),
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.HorusecEngine, languages.Leaks),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.HorusecEngine, languages.Leaks),
+				},
+				OutputsNotContains: []string{
+					fmt.Sprintf("{HORUSEC_CLI} Something error went wrong in %s tool", tools.Checkov),
+				},
+			},
+		},
+		{
+			Tool:           tools.Flawfinder,
+			RequiredDocker: true,
+			Command: Command{
+				Flags: map[string]string{
+					testutil.StartFlagProjectPath: testutil.CExample1,
+				},
+			},
+			Expected: Expected{
+				Language: languages.C,
+				ExitCode: 0,
+				OutputsContains: []string{
+					fmt.Sprintf(messages.MsgPrintFinishAnalysisWithStatus, analysis.Success),
+					messages.MsgDebugVulnHashToFix,
+					messages.MsgWarnAnalysisFoundVulns[16:],
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.Flawfinder, languages.C),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.Flawfinder, languages.C),
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.HorusecEngine, languages.Leaks),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.HorusecEngine, languages.Leaks),
+				},
+				OutputsNotContains: []string{
+					fmt.Sprintf("{HORUSEC_CLI} Something error went wrong in %s tool", tools.Flawfinder),
+				},
+			},
+		},
+		{
+			Tool:           tools.PhpCS,
+			RequiredDocker: true,
+			Command: Command{
+				Flags: map[string]string{
+					testutil.StartFlagProjectPath: testutil.PHPExample1,
+				},
+			},
+			Expected: Expected{
+				Language: languages.PHP,
+				ExitCode: 0,
+				OutputsContains: []string{
+					fmt.Sprintf(messages.MsgPrintFinishAnalysisWithStatus, analysis.Success),
+					messages.MsgDebugVulnHashToFix,
+					messages.MsgWarnAnalysisFoundVulns[16:],
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.PhpCS, languages.PHP),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.PhpCS, languages.PHP),
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.HorusecEngine, languages.Leaks),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.HorusecEngine, languages.Leaks),
+				},
+				OutputsNotContains: []string{
+					fmt.Sprintf("{HORUSEC_CLI} Something error went wrong in %s tool", tools.PhpCS),
+				},
+			},
+		},
+		{
+			Tool:           tools.MixAudit,
+			RequiredDocker: true,
+			Command: Command{
+				Flags: map[string]string{
+					testutil.StartFlagProjectPath: testutil.ElixirExample1,
+				},
+			},
+			Expected: Expected{
+				Language: languages.Elixir,
+				ExitCode: 0,
+				OutputsContains: []string{
+					fmt.Sprintf(messages.MsgPrintFinishAnalysisWithStatus, analysis.Success),
+					messages.MsgDebugVulnHashToFix,
+					messages.MsgWarnAnalysisFoundVulns[16:],
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.MixAudit, languages.Elixir),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.MixAudit, languages.Elixir),
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.HorusecEngine, languages.Leaks),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.HorusecEngine, languages.Leaks),
+				},
+				OutputsNotContains: []string{
+					fmt.Sprintf("{HORUSEC_CLI} Something error went wrong in %s tool", tools.MixAudit),
+				},
+			},
+		},
+		{
+			Tool:           tools.Sobelow,
+			RequiredDocker: true,
+			Command: Command{
+				Flags: map[string]string{
+					testutil.StartFlagProjectPath: testutil.ElixirExample1,
+				},
+			},
+			Expected: Expected{
+				Language: languages.Elixir,
+				ExitCode: 0,
+				OutputsContains: []string{
+					fmt.Sprintf(messages.MsgPrintFinishAnalysisWithStatus, analysis.Success),
+					messages.MsgDebugVulnHashToFix,
+					messages.MsgWarnAnalysisFoundVulns[16:],
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.Sobelow, languages.Elixir),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.Sobelow, languages.Elixir),
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.HorusecEngine, languages.Leaks),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.HorusecEngine, languages.Leaks),
+				},
+				OutputsNotContains: []string{
+					fmt.Sprintf("{HORUSEC_CLI} Something error went wrong in %s tool", tools.Sobelow),
+				},
+			},
+		},
+		{
+			Tool:           tools.Brakeman,
+			RequiredDocker: true,
+			Command: Command{
+				Flags: map[string]string{
+					testutil.StartFlagProjectPath: testutil.RubyExample1,
+					testutil.StartFlagIgnore:      "**/*.js, **/*.html, **/*.py, **/*.ts",
+				},
+			},
+			Expected: Expected{
+				Language: languages.Ruby,
+				ExitCode: 0,
+				OutputsContains: []string{
+					fmt.Sprintf(messages.MsgPrintFinishAnalysisWithStatus, analysis.Success),
+					messages.MsgDebugVulnHashToFix,
+					messages.MsgWarnAnalysisFoundVulns[16:],
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.Brakeman, languages.Ruby),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.Brakeman, languages.Ruby),
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.HorusecEngine, languages.Leaks),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.HorusecEngine, languages.Leaks),
+				},
+				OutputsNotContains: []string{
+					fmt.Sprintf("{HORUSEC_CLI} Something error went wrong in %s tool", tools.Brakeman),
+				},
+			},
+		},
+		{
+			Tool:           tools.BundlerAudit,
+			RequiredDocker: true,
+			Command: Command{
+				Flags: map[string]string{
+					testutil.StartFlagProjectPath: testutil.RubyExample1,
+					testutil.StartFlagIgnore:      "**/*.js, **/*.html, **/*.py, **/*.ts",
+				},
+			},
+			Expected: Expected{
+				Language: languages.Ruby,
+				ExitCode: 0,
+				OutputsContains: []string{
+					fmt.Sprintf(messages.MsgPrintFinishAnalysisWithStatus, analysis.Success),
+					messages.MsgDebugVulnHashToFix,
+					messages.MsgWarnAnalysisFoundVulns[16:],
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.BundlerAudit, languages.Ruby),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.BundlerAudit, languages.Ruby),
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.HorusecEngine, languages.Leaks),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.HorusecEngine, languages.Leaks),
+				},
+				OutputsNotContains: []string{
+					fmt.Sprintf("{HORUSEC_CLI} Something error went wrong in %s tool", tools.BundlerAudit),
+				},
+			},
+		},
+		{
+			Tool:           tools.DotnetCli,
+			RequiredDocker: true,
+			Command: Command{
+				Flags: map[string]string{
+					testutil.StartFlagProjectPath: testutil.CsharpExample1,
+				},
+			},
+			Expected: Expected{
+				Language: languages.CSharp,
+				ExitCode: 0,
+				OutputsContains: []string{
+					fmt.Sprintf(messages.MsgPrintFinishAnalysisWithStatus, analysis.Success),
+					messages.MsgDebugVulnHashToFix,
+					messages.MsgWarnAnalysisFoundVulns[16:],
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.DotnetCli, languages.CSharp),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.DotnetCli, languages.CSharp),
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.HorusecEngine, languages.Leaks),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.HorusecEngine, languages.Leaks),
+				},
+				OutputsNotContains: []string{
+					fmt.Sprintf("{HORUSEC_CLI} Something error went wrong in %s tool", tools.DotnetCli),
+				},
+			},
+		},
+		{
+			Tool:           tools.Nancy,
+			RequiredDocker: true,
+			Command: Command{
+				Flags: map[string]string{
+					testutil.StartFlagProjectPath: testutil.GoExample1,
+				},
+			},
+			Expected: Expected{
+				Language: languages.Go,
+				ExitCode: 0,
+				OutputsContains: []string{
+					fmt.Sprintf(messages.MsgPrintFinishAnalysisWithStatus, analysis.Success),
+					messages.MsgDebugVulnHashToFix,
+					messages.MsgWarnAnalysisFoundVulns[16:],
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.Nancy, languages.Go),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.Nancy, languages.Go),
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.HorusecEngine, languages.Leaks),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.HorusecEngine, languages.Leaks),
+				},
+				OutputsNotContains: []string{
+					fmt.Sprintf("{HORUSEC_CLI} Something error went wrong in %s tool", tools.Nancy),
+				},
+			},
+		},
+		{
+			Tool:           tools.ShellCheck,
+			RequiredDocker: true,
+			Command: Command{
+				Flags: map[string]string{
+					testutil.StartFlagProjectPath:      testutil.LeaksExample1,
+					testutil.StartFlagEnableShellcheck: "true",
+				},
+			},
+			Expected: Expected{
+				Language: languages.Shell,
+				ExitCode: 0,
+				OutputsContains: []string{
+					fmt.Sprintf(messages.MsgPrintFinishAnalysisWithStatus, analysis.Success),
+					messages.MsgDebugVulnHashToFix,
+					messages.MsgWarnAnalysisFoundVulns[16:],
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.ShellCheck, languages.Shell),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.ShellCheck, languages.Shell),
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.HorusecEngine, languages.Leaks),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.HorusecEngine, languages.Leaks),
+				},
+				OutputsNotContains: []string{
+					fmt.Sprintf("{HORUSEC_CLI} Something error went wrong in %s tool", tools.ShellCheck),
+				},
+			},
+		},
+		{
+			Tool:           tools.Semgrep,
+			RequiredDocker: true,
+			Command: Command{
+				Flags: map[string]string{
+					testutil.StartFlagProjectPath: testutil.GoExample1,
+				},
+			},
+			Expected: Expected{
+				Language: languages.Generic,
+				ExitCode: 0,
+				OutputsContains: []string{
+					fmt.Sprintf(messages.MsgPrintFinishAnalysisWithStatus, analysis.Success),
+					messages.MsgDebugVulnHashToFix,
+					messages.MsgWarnAnalysisFoundVulns[16:],
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.Semgrep, languages.Generic),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.Semgrep, languages.Generic),
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.HorusecEngine, languages.Leaks),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.HorusecEngine, languages.Leaks),
+				},
+				OutputsNotContains: []string{
+					fmt.Sprintf("{HORUSEC_CLI} Something error went wrong in %s tool", tools.Semgrep),
+				},
+			},
+		},
+		{
+			Tool:           tools.Trivy,
+			RequiredDocker: true,
+			Command: Command{
+				Flags: map[string]string{
+					testutil.StartFlagProjectPath: testutil.LeaksExample1,
+				},
+			},
+			Expected: Expected{
+				Language: languages.Generic,
+				ExitCode: 0,
+				OutputsContains: []string{
+					fmt.Sprintf(messages.MsgPrintFinishAnalysisWithStatus, analysis.Success),
+					messages.MsgDebugVulnHashToFix,
+					messages.MsgWarnAnalysisFoundVulns[16:],
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.Trivy, languages.Generic),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.Trivy, languages.Generic),
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.HorusecEngine, languages.Leaks),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.HorusecEngine, languages.Leaks),
+				},
+				OutputsNotContains: []string{
+					fmt.Sprintf("{HORUSEC_CLI} Something error went wrong in %s tool", tools.Trivy),
+				},
+			},
+		},
+		{
+			Tool:           tools.OwaspDependencyCheck,
+			RequiredDocker: true,
+			Command: Command{
+				Flags: map[string]string{
+					testutil.StartFlagProjectPath:                testutil.JavaScriptExample1,
+					testutil.StartFlagEnableOwaspDependencyCheck: "true",
+					testutil.StartFlagAnalysisTimeout:            "10000",
+				},
+			},
+			Expected: Expected{
+				Language: languages.Generic,
+				ExitCode: 0,
+				OutputsContains: []string{
+					fmt.Sprintf(messages.MsgPrintFinishAnalysisWithStatus, analysis.Success),
+					messages.MsgDebugVulnHashToFix,
+					messages.MsgWarnAnalysisFoundVulns[16:],
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.OwaspDependencyCheck, languages.Generic),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.OwaspDependencyCheck, languages.Generic),
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.HorusecEngine, languages.Leaks),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.HorusecEngine, languages.Leaks),
+				},
+				OutputsNotContains: []string{
+					fmt.Sprintf("{HORUSEC_CLI} Something error went wrong in %s tool", tools.OwaspDependencyCheck),
+				},
+			},
+		},
+		{
+			Tool:           tools.GitLeaks,
+			RequiredDocker: true,
+			Command: Command{
+				Flags: map[string]string{
+					testutil.StartFlagProjectPath:        testutil.ExamplesPath,
+					testutil.StartFlagEnableGitHistory:   "true",
+					testutil.StartFlagEnableCommitAuthor: "true",
+					testutil.StartFlagAnalysisTimeout:    "10000",
+					testutil.StartFlagIgnore:             "**/ruby/**, **/javascript/**, **/python/**, **/go/**",
+				},
+			},
+			Expected: Expected{
+				Language: languages.Generic,
+				ExitCode: 0,
+				OutputsContains: []string{
+					fmt.Sprintf(messages.MsgPrintFinishAnalysisWithStatus, analysis.Success),
+					messages.MsgDebugVulnHashToFix,
+					messages.MsgWarnAnalysisFoundVulns[16:],
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.GitLeaks, languages.Leaks),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.GitLeaks, languages.Leaks),
+					fmt.Sprintf("{HORUSEC_CLI} Running %s - %s", tools.HorusecEngine, languages.Leaks),
+					fmt.Sprintf("{HORUSEC_CLI} %s - %s is finished in analysisID:", tools.HorusecEngine, languages.Leaks),
+				},
+				OutputsNotContains: []string{
+					fmt.Sprintf("{HORUSEC_CLI} Something error went wrong in %s tool", tools.GitLeaks),
+				},
+			},
+		},
+	}
+}

--- a/internal/controllers/language_detect/language_detect_test.go
+++ b/internal/controllers/language_detect/language_detect_test.go
@@ -286,4 +286,16 @@ func TestNewLanguageDetect(t *testing.T) {
 			}
 		})
 	})
+	t.Run("Should read git submodule path and copy to .horusec folder git submodule correctly", func(t *testing.T) {
+		analysisID := uuid.New()
+		configs := config.New()
+		configs.EnableGitHistoryAnalysis = true
+		controller := NewLanguageDetect(configs, analysisID)
+		_, err := controller.Detect(testutil.ExamplesPath)
+		assert.NoError(t, err)
+		projectClonedPath := filepath.Join(testutil.ExamplesPath, ".horusec", analysisID.String())
+		fileInfo, err := os.Stat(filepath.Join(projectClonedPath, ".git"))
+		assert.NoError(t, err)
+		assert.True(t, fileInfo.IsDir())
+	})
 }

--- a/internal/controllers/printresults/print_results.go
+++ b/internal/controllers/printresults/print_results.go
@@ -108,7 +108,7 @@ func (pr *PrintResults) printResultsText() error {
 	fmt.Fprint(pr.writer, "\n")
 	pr.logSeparator(true)
 
-	pr.printlnf(`HORUSEC ENDED THE ANALYSIS WITH STATUS OF %q AND WITH THE FOLLOWING RESULTS:`, pr.analysis.Status)
+	pr.printlnf(messages.MsgPrintFinishAnalysisWithStatus, pr.analysis.Status)
 
 	pr.logSeparator(true)
 

--- a/internal/helpers/messages/print.go
+++ b/internal/helpers/messages/print.go
@@ -12,16 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package trivy
+package messages
 
-const CmdFs = `
-		{{WORK_DIR}}
-		TRIVY_NEW_JSON_SCHEMA=true trivy fs  -f json -o resultFs.json ./ &> /dev/null
-		cat resultFs.json
-  `
-
-const CmdConfig = `
-		{{WORK_DIR}}
-		TRIVY_NEW_JSON_SCHEMA=true trivy config -f json -o resultConfig.json ./ &> /dev/null 
-		cat resultConfig.json
-  `
+const (
+	MsgPrintFinishAnalysisWithStatus = `HORUSEC ENDED THE ANALYSIS WITH STATUS OF %q AND WITH THE FOLLOWING RESULTS:`
+)

--- a/internal/services/docker/client/docker_config_test.go
+++ b/internal/services/docker/client/docker_config_test.go
@@ -20,10 +20,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ZupIT/horusec/internal/utils/testutil"
 	dockerTypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ZupIT/horusec/internal/utils/testutil"
 )
 
 func TestNewDockerAPI(t *testing.T) {

--- a/internal/services/docker/docker_api.go
+++ b/internal/services/docker/docker_api.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -277,6 +278,7 @@ func (d *API) getContainerConfig(imageNameWithTag, cmd string) *container.Config
 		Image: imageNameWithTag,
 		Tty:   true,
 		Cmd:   []string{"/bin/sh", "-c", fmt.Sprintf(`cd %s && %s`, d.pathDestinyInContainer, cmd)},
+		Env:   []string{fmt.Sprintf("GITHUB_TOKEN=%s", os.Getenv("GITHUB_TOKEN"))},
 	}
 }
 

--- a/internal/services/formatters/c/deployments/Dockerfile
+++ b/internal/services/formatters/c/deployments/Dockerfile
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.10.0-alpine
+FROM python:3.10.0-alpine3.14
 
 RUN pip install flawfinder==2.0.19

--- a/internal/services/formatters/c/flawfinder/formatter.go
+++ b/internal/services/formatters/c/flawfinder/formatter.go
@@ -45,19 +45,20 @@ func (f *Formatter) StartAnalysis(projectSubPath string) {
 		return
 	}
 
-	f.SetAnalysisError(f.startFlawfinder(projectSubPath), tools.Flawfinder, projectSubPath)
+	output, err := f.startFlawfinder(projectSubPath)
+	f.SetAnalysisError(err, tools.Flawfinder, output, projectSubPath)
 	f.LogDebugWithReplace(messages.MsgDebugToolFinishAnalysis, tools.Flawfinder, languages.C)
 }
 
-func (f *Formatter) startFlawfinder(projectSubPath string) error {
+func (f *Formatter) startFlawfinder(projectSubPath string) (string, error) {
 	f.LogDebugWithReplace(messages.MsgDebugToolStartAnalysis, tools.Flawfinder, languages.C)
 
 	output, err := f.ExecuteContainer(f.getConfigData(projectSubPath))
 	if err != nil {
-		return err
+		return output, err
 	}
 
-	return f.parseOutput(output)
+	return output, f.parseOutput(output)
 }
 
 func (f *Formatter) getConfigData(projectSubPath string) *dockerEntities.AnalysisData {

--- a/internal/services/formatters/csharp/dotnet_cli/formatter.go
+++ b/internal/services/formatters/csharp/dotnet_cli/formatter.go
@@ -50,20 +50,21 @@ func (f *Formatter) StartAnalysis(projectSubPath string) {
 		return
 	}
 
-	f.SetAnalysisError(f.startDotnetCli(projectSubPath), tools.DotnetCli, projectSubPath)
+	output, err := f.startDotnetCli(projectSubPath)
+	f.SetAnalysisError(err, tools.DotnetCli, output, projectSubPath)
 	f.LogDebugWithReplace(messages.MsgDebugToolFinishAnalysis, tools.DotnetCli, languages.CSharp)
 }
 
-func (f *Formatter) startDotnetCli(projectSubPath string) error {
+func (f *Formatter) startDotnetCli(projectSubPath string) (string, error) {
 	f.LogDebugWithReplace(messages.MsgDebugToolStartAnalysis, tools.DotnetCli, languages.CSharp)
 
 	output, err := f.checkOutputErrors(f.ExecuteContainer(f.getConfigData(projectSubPath)))
 	if err != nil {
-		return err
+		return output, err
 	}
 
 	f.parseOutput(output, projectSubPath)
-	return nil
+	return output, nil
 }
 
 func (f *Formatter) getConfigData(projectSubPath string) *dockerEntities.AnalysisData {

--- a/internal/services/formatters/default_engine_formatter.go
+++ b/internal/services/formatters/default_engine_formatter.go
@@ -48,7 +48,7 @@ func (f *DefaultFormatter) StartAnalysis(src string) {
 		logger.LogDebugWithLevel(messages.MsgDebugToolIgnored + tools.HorusecEngine.ToString())
 		return
 	}
-	f.svc.SetAnalysisError(f.execEngineAndParseResults(src), tools.HorusecEngine, src)
+	f.svc.SetAnalysisError(f.execEngineAndParseResults(src), tools.HorusecEngine, "", src)
 	f.svc.LogDebugWithReplace(messages.MsgDebugToolFinishAnalysis, tools.HorusecEngine, f.language)
 }
 

--- a/internal/services/formatters/elixir/mixaudit/formatter.go
+++ b/internal/services/formatters/elixir/mixaudit/formatter.go
@@ -48,19 +48,20 @@ func (f *Formatter) StartAnalysis(projectSubPath string) {
 		return
 	}
 
-	f.SetAnalysisError(f.startMixAudit(projectSubPath), tools.MixAudit, projectSubPath)
+	output, err := f.startMixAudit(projectSubPath)
+	f.SetAnalysisError(err, tools.MixAudit, output, projectSubPath)
 	f.LogDebugWithReplace(messages.MsgDebugToolFinishAnalysis, tools.MixAudit, languages.Elixir)
 }
 
-func (f *Formatter) startMixAudit(projectSubPath string) error {
+func (f *Formatter) startMixAudit(projectSubPath string) (string, error) {
 	f.LogDebugWithReplace(messages.MsgDebugToolStartAnalysis, tools.MixAudit, languages.Elixir)
 
 	output, err := f.ExecuteContainer(f.getConfigData(projectSubPath))
 	if err != nil {
-		return err
+		return output, err
 	}
 
-	return f.parseOutput(output)
+	return output, f.parseOutput(output)
 }
 
 func (f *Formatter) getConfigData(projectSubPath string) *dockerEntities.AnalysisData {

--- a/internal/services/formatters/generic/dependency_check/formatter.go
+++ b/internal/services/formatters/generic/dependency_check/formatter.go
@@ -47,19 +47,20 @@ func (f *Formatter) StartAnalysis(projectSubPath string) {
 		return
 	}
 
-	f.SetAnalysisError(f.startDependencyCheck(projectSubPath), tools.OwaspDependencyCheck, projectSubPath)
+	output, err := f.startDependencyCheck(projectSubPath)
+	f.SetAnalysisError(err, tools.OwaspDependencyCheck, output, projectSubPath)
 	f.LogDebugWithReplace(messages.MsgDebugToolFinishAnalysis, tools.OwaspDependencyCheck, languages.Generic)
 }
 
-func (f *Formatter) startDependencyCheck(projectSubPath string) error {
+func (f *Formatter) startDependencyCheck(projectSubPath string) (string, error) {
 	f.LogDebugWithReplace(messages.MsgDebugToolStartAnalysis, tools.OwaspDependencyCheck, languages.Generic)
 
 	output, err := f.ExecuteContainer(f.getConfigData(projectSubPath))
 	if err != nil {
-		return err
+		return output, err
 	}
 
-	return f.parseOutput(output)
+	return output, f.parseOutput(output)
 }
 
 func (f *Formatter) getConfigData(projectSubPath string) *dockerEntities.AnalysisData {

--- a/internal/services/formatters/generic/deployments/Dockerfile
+++ b/internal/services/formatters/generic/deployments/Dockerfile
@@ -19,7 +19,7 @@ RUN "$JAVA_HOME/bin/jlink" --compress=2 \
     --add-modules java.base,java.compiler,java.datatransfer,jdk.crypto.ec,java.desktop,java.instrument,java.logging,java.management,java.naming,java.rmi,java.scripting,java.security.sasl,java.sql,java.transaction.xa,java.xml,jdk.unsupported \
     --output /jlinked
 
-FROM python:3.10.0-alpine
+FROM python:3.10.0-alpine3.14
 
 RUN pip install semgrep==v0.63.0
 

--- a/internal/services/formatters/generic/semgrep/formatter.go
+++ b/internal/services/formatters/generic/semgrep/formatter.go
@@ -50,19 +50,20 @@ func (f *Formatter) StartAnalysis(projectSubPath string) {
 		return
 	}
 
-	f.SetAnalysisError(f.startSemgrep(projectSubPath), tools.SecurityCodeScan, projectSubPath)
+	output, err := f.startSemgrep(projectSubPath)
+	f.SetAnalysisError(err, tools.SecurityCodeScan, output, projectSubPath)
 	f.LogDebugWithReplace(messages.MsgDebugToolFinishAnalysis, tools.Semgrep, languages.Generic)
 }
 
-func (f *Formatter) startSemgrep(projectSubPath string) error {
+func (f *Formatter) startSemgrep(projectSubPath string) (string, error) {
 	f.LogDebugWithReplace(messages.MsgDebugToolStartAnalysis, tools.Semgrep, languages.Generic)
 
 	output, err := f.ExecuteContainer(f.getDockerConfig(projectSubPath))
 	if err != nil {
-		return err
+		return output, err
 	}
 
-	return f.parseOutput(output)
+	return output, f.parseOutput(output)
 }
 
 func (f *Formatter) getDockerConfig(projectSubPath string) *dockerEntities.AnalysisData {

--- a/internal/services/formatters/go/deployments/Dockerfile
+++ b/internal/services/formatters/go/deployments/Dockerfile
@@ -16,7 +16,7 @@ FROM golang:1.17.3-alpine
 
 RUN apk add curl
 
-RUN curl -fsSL https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.22/nancy-v1.0.22-linux-amd64 -o /bin/nancy
+RUN curl -fsSL https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.28/nancy-v1.0.28-linux-amd64 -o /bin/nancy
 RUN chmod +x /bin/nancy
 
 RUN wget -O - -q https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s v2.8.1

--- a/internal/services/formatters/go/gosec/formatter.go
+++ b/internal/services/formatters/go/gosec/formatter.go
@@ -50,19 +50,20 @@ func (f *Formatter) StartAnalysis(projectSubPath string) {
 		return
 	}
 
-	f.SetAnalysisError(f.startGoSec(projectSubPath), tools.GoSec, projectSubPath)
+	output, err := f.startGoSec(projectSubPath)
+	f.SetAnalysisError(err, tools.GoSec, output, projectSubPath)
 	f.LogDebugWithReplace(messages.MsgDebugToolFinishAnalysis, tools.GoSec, languages.Go)
 }
 
-func (f *Formatter) startGoSec(projectSubPath string) error {
+func (f *Formatter) startGoSec(projectSubPath string) (string, error) {
 	f.LogDebugWithReplace(messages.MsgDebugToolStartAnalysis, tools.GoSec, languages.Go)
 
 	output, err := f.ExecuteContainer(f.getDockerConfig(projectSubPath))
 	if err != nil {
-		return err
+		return output, err
 	}
 
-	return f.processOutput(output)
+	return "", f.processOutput(output)
 }
 
 // nolint: funlen

--- a/internal/services/formatters/go/nancy/formatter.go
+++ b/internal/services/formatters/go/nancy/formatter.go
@@ -51,23 +51,24 @@ func (f *Formatter) StartAnalysis(projectSubPath string) {
 		return
 	}
 
-	f.SetAnalysisError(f.startNancy(projectSubPath), tools.Nancy, projectSubPath)
+	output, err := f.startNancy(projectSubPath)
+	f.SetAnalysisError(err, tools.Nancy, output, projectSubPath)
 	f.LogDebugWithReplace(messages.MsgDebugToolFinishAnalysis, tools.Nancy, languages.Go)
 }
 
-func (f *Formatter) startNancy(projectSubPath string) error {
+func (f *Formatter) startNancy(projectSubPath string) (string, error) {
 	f.LogDebugWithReplace(messages.MsgDebugToolStartAnalysis, tools.Nancy, languages.Go)
 
 	output, err := f.ExecuteContainer(f.getDockerConfig(projectSubPath))
 	if err != nil {
-		return err
+		return output, err
 	}
 
 	if output == "" {
-		return nil
+		return output, nil
 	}
 
-	return f.processOutput(output, projectSubPath)
+	return output, f.processOutput(output, projectSubPath)
 }
 
 func (f *Formatter) processOutput(output, projectSubPath string) error {

--- a/internal/services/formatters/hcl/checkov/formatter.go
+++ b/internal/services/formatters/hcl/checkov/formatter.go
@@ -50,19 +50,20 @@ func (f *Formatter) StartAnalysis(projectSubPath string) {
 		return
 	}
 
-	f.SetAnalysisError(f.startCheckov(projectSubPath), tools.Checkov, projectSubPath)
+	output, err := f.startCheckov(projectSubPath)
+	f.SetAnalysisError(err, tools.Checkov, output, projectSubPath)
 	f.LogDebugWithReplace(messages.MsgDebugToolFinishAnalysis, tools.Checkov, languages.HCL)
 }
 
-func (f *Formatter) startCheckov(projectSubPath string) error {
+func (f *Formatter) startCheckov(projectSubPath string) (string, error) {
 	f.LogDebugWithReplace(messages.MsgDebugToolStartAnalysis, tools.Checkov, languages.HCL)
 
 	output, err := f.ExecuteContainer(f.getDockerConfig(projectSubPath))
 	if err != nil {
-		return err
+		return output, err
 	}
 
-	return f.parseOutput(output)
+	return output, f.parseOutput(output)
 }
 
 func (f *Formatter) getDockerConfig(projectSubPath string) *dockerEntities.AnalysisData {

--- a/internal/services/formatters/hcl/deployments/Dockerfile
+++ b/internal/services/formatters/hcl/deployments/Dockerfile
@@ -12,9 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.10.0-alpine
+FROM python:3.10.0-alpine3.14
 
 RUN apk add --quiet --no-cache wget
 
 RUN wget -O /usr/bin/tfsec https://github.com/aquasecurity/tfsec/releases/download/v0.55.1/tfsec-linux-amd64 && chmod +x /usr/bin/tfsec
-RUN pip3 install --upgrade pip==21.2.4 && pip3 install --upgrade setuptools==57.4.0 && pip3 install checkov==2.0.474
+
+# This installation is necessary if we can usage checkov tool
+# See more details in: https://github.com/bridgecrewio/checkov/issues/1947
+RUN pip install --upgrade pip==21.3.1 && pip install --upgrade setuptools==59.1.1
+RUN apk add --no-cache --virtual .build_deps build-base libffi-dev \
+ && pip install --no-cache-dir -U checkov \
+ && apk del .build_deps
+
+

--- a/internal/services/formatters/hcl/tfsec/formatter.go
+++ b/internal/services/formatters/hcl/tfsec/formatter.go
@@ -49,19 +49,20 @@ func (f *Formatter) StartAnalysis(projectSubPath string) {
 		return
 	}
 
-	f.SetAnalysisError(f.startTfSec(projectSubPath), tools.TfSec, projectSubPath)
+	output, err := f.startTfSec(projectSubPath)
+	f.SetAnalysisError(err, tools.TfSec, output, projectSubPath)
 	f.LogDebugWithReplace(messages.MsgDebugToolFinishAnalysis, tools.TfSec, languages.HCL)
 }
 
-func (f *Formatter) startTfSec(projectSubPath string) error {
+func (f *Formatter) startTfSec(projectSubPath string) (string, error) {
 	f.LogDebugWithReplace(messages.MsgDebugToolStartAnalysis, tools.TfSec, languages.HCL)
 
 	output, err := f.ExecuteContainer(f.getDockerConfig(projectSubPath))
 	if err != nil {
-		return err
+		return output, err
 	}
 
-	return f.parseOutput(output)
+	return output, f.parseOutput(output)
 }
 
 func (f *Formatter) getDockerConfig(projectSubPath string) *dockerEntities.AnalysisData {

--- a/internal/services/formatters/interface.go
+++ b/internal/services/formatters/interface.go
@@ -59,7 +59,7 @@ type IService interface {
 	GetConfigProjectPath() string
 
 	// SetAnalysisError add an error from a tool to current analysis.
-	SetAnalysisError(err error, tool tools.Tool, projectSubPath string)
+	SetAnalysisError(err error, tool tools.Tool, output, projectSubPath string)
 
 	// RemoveSrcFolderFromPath remove src prefix from filepath.
 	RemoveSrcFolderFromPath(filepath string) string

--- a/internal/services/formatters/leaks/deployments/Dockerfile
+++ b/internal/services/formatters/leaks/deployments/Dockerfile
@@ -17,4 +17,5 @@ FROM zricethezav/gitleaks:v7.6.1
 COPY ./internal/services/formatters/leaks/deployments/rules.toml /rules/rules.toml
 
 ENTRYPOINT []
+
 CMD ["/bin/sh"]

--- a/internal/services/formatters/leaks/gitleaks/config.go
+++ b/internal/services/formatters/leaks/gitleaks/config.go
@@ -17,6 +17,9 @@ package gitleaks
 
 const CMD = `
 		{{WORK_DIR}}
-		gitleaks --config-path /rules/rules.toml --path . --leaks-exit-code 0 --format json --report /tmp/leaks-result.json &> /tmp/leaks-runner-output.txt
-		cat /tmp/leaks-result.json
+		if ! gitleaks --config-path /rules/rules.toml --path . --leaks-exit-code 0 --format json --report /tmp/leaks-result.json &> /tmp/leaks-runner-output.txt; then
+			echo /tmp/leaks-runner-output.txt
+		else
+			cat /tmp/leaks-result.json
+		fi
   `

--- a/internal/services/formatters/leaks/gitleaks/formatter.go
+++ b/internal/services/formatters/leaks/gitleaks/formatter.go
@@ -51,19 +51,20 @@ func (f *Formatter) StartAnalysis(projectSubPath string) {
 		return
 	}
 
-	f.SetAnalysisError(f.startGitLeaks(projectSubPath), tools.GitLeaks, projectSubPath)
+	output, err := f.startGitLeaks(projectSubPath)
+	f.SetAnalysisError(err, tools.GitLeaks, output, projectSubPath)
 	f.LogDebugWithReplace(messages.MsgDebugToolFinishAnalysis, tools.GitLeaks, languages.Leaks)
 }
 
-func (f *Formatter) startGitLeaks(projectSubPath string) error {
+func (f *Formatter) startGitLeaks(projectSubPath string) (string, error) {
 	f.LogDebugWithReplace(messages.MsgDebugToolStartAnalysis, tools.GitLeaks, languages.Leaks)
 
 	output, err := f.ExecuteContainer(f.getDockerConfig(projectSubPath))
 	if err != nil {
-		return err
+		return output, err
 	}
 
-	return f.formatOutputGitLeaks(output)
+	return output, f.formatOutputGitLeaks(output)
 }
 
 func (f *Formatter) formatOutputGitLeaks(output string) error {
@@ -89,7 +90,6 @@ func (f *Formatter) parseOutputToIssues(output string) ([]entities.Issue, error)
 	if err != nil && strings.Contains(err.Error(), "invalid character") {
 		err = errors.New(output)
 	}
-	logger.LogErrorWithLevel(f.GetAnalysisIDErrorMessage(tools.GitLeaks, output), err)
 	return issues, err
 }
 

--- a/internal/services/formatters/php/phpcs/formatter.go
+++ b/internal/services/formatters/php/phpcs/formatter.go
@@ -49,19 +49,20 @@ func (f *Formatter) StartAnalysis(projectSubPath string) {
 		return
 	}
 
-	f.SetAnalysisError(f.startPhpCs(projectSubPath), tools.PhpCS, projectSubPath)
+	output, err := f.startPhpCs(projectSubPath)
+	f.SetAnalysisError(err, tools.PhpCS, output, projectSubPath)
 	f.LogDebugWithReplace(messages.MsgDebugToolFinishAnalysis, tools.PhpCS, languages.PHP)
 }
 
-func (f *Formatter) startPhpCs(projectSubPath string) error {
+func (f *Formatter) startPhpCs(projectSubPath string) (string, error) {
 	f.LogDebugWithReplace(messages.MsgDebugToolStartAnalysis, tools.PhpCS, languages.PHP)
 
 	output, err := f.ExecuteContainer(f.getDockerConfig(projectSubPath))
 	if err != nil {
-		return err
+		return output, err
 	}
 
-	return f.parseOutput(output)
+	return output, f.parseOutput(output)
 }
 
 func (f *Formatter) getDockerConfig(projectSubPath string) *dockerEntities.AnalysisData {

--- a/internal/services/formatters/python/deployments/Dockerfile
+++ b/internal/services/formatters/python/deployments/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.10.0-alpine
+FROM python:3.10.0-alpine3.14
 
 RUN apk add jq
 RUN pip install safety==1.10.3

--- a/internal/services/formatters/ruby/brakeman/formatter.go
+++ b/internal/services/formatters/ruby/brakeman/formatter.go
@@ -49,19 +49,20 @@ func (f *Formatter) StartAnalysis(projectSubPath string) {
 		return
 	}
 
-	f.SetAnalysisError(f.startBrakeman(projectSubPath), tools.Brakeman, projectSubPath)
+	output, err := f.startBrakeman(projectSubPath)
+	f.SetAnalysisError(err, tools.Brakeman, output, projectSubPath)
 	f.LogDebugWithReplace(messages.MsgDebugToolFinishAnalysis, tools.Brakeman, languages.Ruby)
 }
 
-func (f *Formatter) startBrakeman(projectSubPath string) error {
+func (f *Formatter) startBrakeman(projectSubPath string) (string, error) {
 	f.LogDebugWithReplace(messages.MsgDebugToolStartAnalysis, tools.Brakeman, languages.Ruby)
 
 	output, err := f.ExecuteContainer(f.getDockerConfig(projectSubPath))
 	if err != nil {
-		return err
+		return output, err
 	}
 
-	return f.parseOutput(output, projectSubPath)
+	return output, f.parseOutput(output, projectSubPath)
 }
 
 func (f *Formatter) parseOutput(containerOutput, projectSubPath string) error {
@@ -88,7 +89,6 @@ func (f *Formatter) newContainerOutputFromString(containerOutput string) (output
 	}
 
 	err = json.Unmarshal([]byte(containerOutput), &output)
-	logger.LogErrorWithLevel(f.GetAnalysisIDErrorMessage(tools.Brakeman, containerOutput), err)
 	return output, err
 }
 

--- a/internal/services/formatters/ruby/bundler/formatter.go
+++ b/internal/services/formatters/ruby/bundler/formatter.go
@@ -54,24 +54,24 @@ func (f *Formatter) StartAnalysis(projectSubPath string) {
 		return
 	}
 
-	f.SetAnalysisError(f.startBundlerAudit(projectSubPath), tools.BundlerAudit, projectSubPath)
+	output, err := f.startBundlerAudit(projectSubPath)
+	f.SetAnalysisError(err, tools.BundlerAudit, output, projectSubPath)
 	f.LogDebugWithReplace(messages.MsgDebugToolFinishAnalysis, tools.BundlerAudit, languages.Ruby)
 }
 
-func (f *Formatter) startBundlerAudit(projectSubPath string) error {
+func (f *Formatter) startBundlerAudit(projectSubPath string) (string, error) {
 	f.LogDebugWithReplace(messages.MsgDebugToolStartAnalysis, tools.BundlerAudit, languages.Ruby)
 
 	output, err := f.ExecuteContainer(f.getDockerConfig(projectSubPath))
 	if err != nil {
-		return err
+		return output, err
 	}
 
 	if errGemLock := f.verifyGemLockError(output); errGemLock != nil {
-		return errGemLock
+		return output, errGemLock
 	}
-
 	f.parseOutput(f.removeOutputEsc(output), projectSubPath)
-	return nil
+	return "", nil
 }
 
 func (f *Formatter) getDockerConfig(projectSubPath string) *dockerEntities.AnalysisData {

--- a/internal/services/formatters/ruby/deployments/Dockerfile
+++ b/internal/services/formatters/ruby/deployments/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ruby:3.0.2-alpine
+FROM ruby:2.4.10-alpine
 
 RUN gem install brakeman -v 5.1.1
 RUN gem install bundler-audit -v 0.9.0

--- a/internal/services/formatters/service.go
+++ b/internal/services/formatters/service.go
@@ -113,12 +113,12 @@ func (s *Service) GetAnalysisID() string {
 	return s.analysis.GetIDString()
 }
 
-func (s *Service) SetAnalysisError(err error, tool tools.Tool, projectSubPath string) {
+func (s *Service) SetAnalysisError(err error, tool tools.Tool, output, projectSubPath string) {
 	if err != nil {
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 		s.addAnalysisError(err)
-		msg := s.GetAnalysisIDErrorMessage(tool, "")
+		msg := s.GetAnalysisIDErrorMessage(tool, output)
 		if projectSubPath != "" {
 			msg += " | ProjectSubPath -> " + projectSubPath
 		}

--- a/internal/services/formatters/service_test.go
+++ b/internal/services/formatters/service_test.go
@@ -128,7 +128,7 @@ func TestMock_AddWorkDirInCmd(t *testing.T) {
 		_ = mock.GetCommitAuthor("", "")
 		_ = mock.AddWorkDirInCmd("", "", "")
 		_ = mock.GetConfigProjectPath()
-		mock.SetAnalysisError(errors.New(""), "", "")
+		mock.SetAnalysisError(errors.New(""), "", "", "")
 		_ = mock.RemoveSrcFolderFromPath("")
 		_ = mock.GetCodeWithMaxCharacters("", 0)
 	})
@@ -279,10 +279,10 @@ func TestLogAnalysisError(t *testing.T) {
 		logger.LogSetOutput(stdOutMock)
 		logger.SetLogLevel("debug")
 		assert.NotPanics(t, func() {
-			monitorController.SetAnalysisError(errors.New("test"), tools.GoSec, "")
-			monitorController.SetAnalysisError(errors.New("test2"), tools.GitLeaks, "")
+			monitorController.SetAnalysisError(errors.New("test"), tools.GoSec, "container err", "")
+			monitorController.SetAnalysisError(errors.New("test2"), tools.GitLeaks, "container err", "")
 		})
-		assert.Contains(t, stdOutMock.String(), `{HORUSEC_CLI} Something error went wrong in GoSec tool | analysisID -> 00000000-0000-0000-0000-000000000000 | output -> `)
+		assert.Contains(t, stdOutMock.String(), `{HORUSEC_CLI} Something error went wrong in GoSec tool | analysisID -> 00000000-0000-0000-0000-000000000000 | output -> container err`)
 	})
 	t.Run("should not panic when logging error and exists projectSubPath", func(t *testing.T) {
 		monitorController := NewFormatterService(&analysis.Analysis{}, testutil.NewDockerMock(), &config.Config{})
@@ -290,10 +290,10 @@ func TestLogAnalysisError(t *testing.T) {
 		logger.LogSetOutput(stdOutMock)
 		logger.SetLogLevel("debug")
 		assert.NotPanics(t, func() {
-			monitorController.SetAnalysisError(errors.New("test"), tools.GoSec, "/tmp")
-			monitorController.SetAnalysisError(errors.New("test2"), tools.GitLeaks, "/tmp")
+			monitorController.SetAnalysisError(errors.New("test"), tools.GoSec, "container err", "/tmp")
+			monitorController.SetAnalysisError(errors.New("test2"), tools.GitLeaks, "container err", "/tmp")
 		})
-		assert.Contains(t, stdOutMock.String(), `{HORUSEC_CLI} Something error went wrong in GoSec tool | analysisID -> 00000000-0000-0000-0000-000000000000 | output ->  | ProjectSubPath -> /tmp - test"`)
+		assert.Contains(t, stdOutMock.String(), `{HORUSEC_CLI} Something error went wrong in GoSec tool | analysisID -> 00000000-0000-0000-0000-000000000000 | output -> container err | ProjectSubPath -> /tmp - test"`)
 	})
 }
 

--- a/internal/services/formatters/shell/shellcheck/formatter.go
+++ b/internal/services/formatters/shell/shellcheck/formatter.go
@@ -51,19 +51,20 @@ func (f *Formatter) StartAnalysis(projectSubPath string) {
 		return
 	}
 
-	f.SetAnalysisError(f.startShellCheck(projectSubPath), tools.ShellCheck, projectSubPath)
+	output, err := f.startShellCheck(projectSubPath)
+	f.SetAnalysisError(err, tools.ShellCheck, output, projectSubPath)
 	f.LogDebugWithReplace(messages.MsgDebugToolFinishAnalysis, tools.ShellCheck, languages.Shell)
 }
 
-func (f *Formatter) startShellCheck(projectSubPath string) error {
+func (f *Formatter) startShellCheck(projectSubPath string) (string, error) {
 	f.LogDebugWithReplace(messages.MsgDebugToolStartAnalysis, tools.ShellCheck, languages.Shell)
 
 	output, err := f.ExecuteContainer(f.getDockerConfig(projectSubPath))
 	if err != nil {
-		return err
+		return output, err
 	}
 
-	return f.parseOutput(output)
+	return output, f.parseOutput(output)
 }
 
 func (f *Formatter) parseOutput(containerOutput string) error {
@@ -90,7 +91,6 @@ func (f *Formatter) newContainerOutputFromString(containerOutput string) (output
 	containerOutput = strings.ReplaceAll(containerOutput, NotFoundFiles, "")
 
 	err = json.Unmarshal([]byte(containerOutput), &output)
-	logger.LogErrorWithLevel(f.GetAnalysisIDErrorMessage(tools.ShellCheck, containerOutput), err)
 	return output, err
 }
 

--- a/internal/utils/prompt/prompt_test.go
+++ b/internal/utils/prompt/prompt_test.go
@@ -17,8 +17,9 @@ package prompt
 import (
 	"testing"
 
-	"github.com/ZupIT/horusec/internal/utils/testutil"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ZupIT/horusec/internal/utils/testutil"
 )
 
 func TestPrompt_Ask(t *testing.T) {

--- a/internal/utils/testutil/examples.go
+++ b/internal/utils/testutil/examples.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	// AverageTimeoutAnalyzeForExamplesFolder Average timeout for analysis in the example directory
-	AverageTimeoutAnalyzeForExamplesFolder = time.Minute * 15
+	AverageTimeoutAnalyzeForExamplesFolder = time.Minute * 30
 )
 
 var (
@@ -33,6 +33,11 @@ var (
 
 	// ExamplesPath represents the entire examples directory.
 	ExamplesPath = filepath.Join(RootPath, "examples")
+
+	// nolint:golint
+	// C-Lang Example represents the entire c-lang examples directory.
+	CExample  = filepath.Join(ExamplesPath, "c")
+	CExample1 = filepath.Join(CExample, "example1")
 
 	// CsharpExample represents the entire C# examples directory.
 	CsharpExample  = filepath.Join(ExamplesPath, "csharp")

--- a/internal/utils/testutil/formatter_mock.go
+++ b/internal/utils/testutil/formatter_mock.go
@@ -68,7 +68,7 @@ func (m *FormatterMock) GetConfigProjectPath() string {
 	return args.Get(0).(string)
 }
 
-func (m *FormatterMock) SetAnalysisError(_ error, _ tools.Tool, _ string) {
+func (m *FormatterMock) SetAnalysisError(_ error, _ tools.Tool, _, _ string) {
 	_ = m.MethodCalled("SetAnalysisError")
 }
 


### PR DESCRIPTION
* In older version i found some errors:
  * The analysis is not effective in check tools runned, because not apply assert in all tools runned by language, then i fixed this;
  * Occurs when horusec not found files required in project how requirements.txt and others, not exist validation if analysis was been executed with success, then i fixed this;
* In older version when run analysis always download all tools from dockerhub, and this not validate if current version is OK for create new release, then was implemented this new test. Note the struct AnalysisTestCase is shared into both tests, then was moved to centralized file.
* Another error found was that the error logs presented by the tool were scattered, so we centralized the SetAnalysisError function where, in addition to adding the error in the analysis, it also performs the unified log among all the tools.
* An error was found in the language detect package, if the user is using a project with git submodule it was not possible to copy the git folder as it was only a reference so we fixed these problems.
* In HCL language it was necessary to change your docker file seen at issue bridgecrewio/checkov#1947 where we found a problem in checkov for alpine version
* Was Updated all dockerfiles with image from python fix in version python:3.10.0-alpine3.14
* Was Update dockerfile of Ruby language for usage ruby:2.4.10-alpine base image, because brakeman tool is not suport for newest version of ruby
* Was Updated DockerAPI for pass GITHUB_TOKEN env because nancy and others tools use the github api's and get error GitHub rate-limiting on unauthenticated requests

Signed-off-by: wilian <wilian.silva@zup.com.br>