### PR TITLE
toolsconfig:chore: create tests and rename public objects

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -114,7 +114,7 @@ type StartOptions struct {
 	FalsePositiveHashes             []string                  `json:"false_positive_hashes"`
 	RiskAcceptHashes                []string                  `json:"risk_accept_hashes"`
 	ShowVulnerabilitiesTypes        []string                  `json:"show_vulnerabilities_types"`
-	ToolsConfig                     toolsconfig.MapToolConfig `json:"tools_config"`
+	ToolsConfig                     toolsconfig.ToolsConfig   `json:"tools_config"`
 	Headers                         map[string]string         `json:"headers"`
 	WorkDir                         *workdir.WorkDir          `json:"work_dir"`
 	CustomImages                    customimages.CustomImages `json:"custom_images"`
@@ -167,7 +167,7 @@ func New() *Config {
 			FalsePositiveHashes:             make([]string, 0),
 			Headers:                         make(map[string]string),
 			ContainerBindProjectPath:        "",
-			ToolsConfig:                     toolsconfig.ParseInterfaceToMapToolsConfig(toolsconfig.ToolConfig{}),
+			ToolsConfig:                     toolsconfig.Default(),
 			ShowVulnerabilitiesTypes:        []string{vulnerability.Vulnerability.ToString()},
 			CustomImages:                    customimages.NewCustomImages(),
 			DisableDocker:                   dist.IsStandAlone(),
@@ -296,8 +296,8 @@ func (c *Config) LoadFromConfigFile() *Config {
 		viper.GetString(c.toLowerCamel(EnvContainerBindProjectPath)), c.ContainerBindProjectPath,
 	)
 
-	if cfg := viper.Get(c.toLowerCamel(EnvToolsConfig)); cfg != nil {
-		c.ToolsConfig = toolsconfig.ParseInterfaceToMapToolsConfig(cfg)
+	if cfg := viper.GetStringMap(c.toLowerCamel(EnvToolsConfig)); cfg != nil {
+		c.ToolsConfig = toolsconfig.MustParseToolsConfig(cfg)
 	}
 
 	c.DisableDocker = viper.GetBool(c.toLowerCamel(EnvDisableDocker))

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -117,7 +117,7 @@ func TestNewHorusecConfig(t *testing.T) {
 		assert.Equal(t, true, configs.EnableOwaspDependencyCheck)
 		assert.Equal(t, true, configs.EnableShellCheck)
 		assert.Equal(t, []string{vulnerability.Vulnerability.ToString(), vulnerability.FalsePositive.ToString()}, configs.ShowVulnerabilitiesTypes)
-		assert.Equal(t, toolsconfig.ToolConfig{
+		assert.Equal(t, toolsconfig.Config{
 			IsToIgnore: true,
 		}, configs.ToolsConfig[tools.GoSec])
 		assert.Equal(t, "docker.io/company/go:latest", configs.CustomImages["go"])
@@ -157,7 +157,7 @@ func TestNewHorusecConfig(t *testing.T) {
 		assert.Equal(t, true, configs.EnableInformationSeverity)
 		assert.Equal(t, true, configs.EnableOwaspDependencyCheck)
 		assert.Equal(t, true, configs.EnableShellCheck)
-		assert.Equal(t, toolsconfig.ToolConfig{
+		assert.Equal(t, toolsconfig.Config{
 			IsToIgnore: true,
 		}, configs.ToolsConfig[tools.GoSec])
 		assert.Equal(t, "docker.io/company/go:latest", configs.CustomImages["go"])
@@ -260,7 +260,7 @@ func TestNewHorusecConfig(t *testing.T) {
 		assert.Equal(t, true, configs.EnableInformationSeverity)
 		assert.Equal(t, true, configs.EnableOwaspDependencyCheck)
 		assert.Equal(t, true, configs.EnableShellCheck)
-		assert.Equal(t, toolsconfig.ToolConfig{
+		assert.Equal(t, toolsconfig.Config{
 			IsToIgnore: true,
 		}, configs.ToolsConfig[tools.GoSec])
 		assert.Equal(t, "docker.io/company/go:latest", configs.CustomImages["go"])

--- a/internal/entities/toolsconfig/tools_config_test.go
+++ b/internal/entities/toolsconfig/tools_config_test.go
@@ -1,0 +1,142 @@
+// Copyright 2021 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package toolsconfig_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
+	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
+	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
+	"github.com/ZupIT/horusec/internal/helpers/messages"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultValues(t *testing.T) {
+	cfg := toolsconfig.Default()
+
+	tools := tools.Values()
+
+	assert.Len(t, cfg, len(tools), "Expected all tools on default values")
+
+	for tool, cfg := range cfg {
+		assert.Contains(t, tools, tool, "Tool %s is invalid", tool)
+		assert.False(t, cfg.IsToIgnore, "Expected default value as false to IsToIgnore")
+	}
+}
+
+func TestParseToolsConfig(t *testing.T) {
+	testcases := []struct {
+		name     string
+		input    map[string]interface{}
+		expected toolsconfig.ToolsConfig
+		output   string
+	}{
+		{
+			name: "Should parse values incomplete correctly and return all tools",
+			input: map[string]interface{}{
+				"bandit": map[string]bool{
+					"istoignore": false,
+				},
+				"gosec": map[string]bool{
+					"istoignore": true,
+				},
+			},
+			expected: toolsconfig.ToolsConfig{
+				tools.Bandit:               toolsconfig.Config{false},
+				tools.BundlerAudit:         toolsconfig.Config{false},
+				tools.Brakeman:             toolsconfig.Config{false},
+				tools.Checkov:              toolsconfig.Config{false},
+				tools.Flawfinder:           toolsconfig.Config{false},
+				tools.GitLeaks:             toolsconfig.Config{false},
+				tools.GoSec:                toolsconfig.Config{true},
+				tools.HorusecEngine:        toolsconfig.Config{false},
+				tools.MixAudit:             toolsconfig.Config{false},
+				tools.NpmAudit:             toolsconfig.Config{false},
+				tools.PhpCS:                toolsconfig.Config{false},
+				tools.Safety:               toolsconfig.Config{false},
+				tools.SecurityCodeScan:     toolsconfig.Config{false},
+				tools.Semgrep:              toolsconfig.Config{false},
+				tools.ShellCheck:           toolsconfig.Config{false},
+				tools.Sobelow:              toolsconfig.Config{false},
+				tools.TfSec:                toolsconfig.Config{false},
+				tools.YarnAudit:            toolsconfig.Config{false},
+				tools.OwaspDependencyCheck: toolsconfig.Config{false},
+				tools.DotnetCli:            toolsconfig.Config{false},
+				tools.Nancy:                toolsconfig.Config{false},
+				tools.Trivy:                toolsconfig.Config{false},
+			},
+		},
+		{
+			name: "Should error on invalid configuration and use default values",
+			input: map[string]interface{}{
+				"gosec": map[string]string{
+					"istoigore": "invalid data type",
+				},
+				"bandit": "invalid type",
+			},
+			expected: toolsconfig.Default(),
+			output:   messages.MsgErrorParseStringToToolsConfig,
+		},
+		{
+			name: "Should parse using lower and upper case",
+			input: map[string]interface{}{
+				"trivy": map[string]bool{
+					"istoignore": true,
+				},
+				"HorusecEngine": map[string]bool{
+					"istoignore": true,
+				},
+			},
+			expected: toolsconfig.ToolsConfig{
+				tools.Bandit:               toolsconfig.Config{false},
+				tools.BundlerAudit:         toolsconfig.Config{false},
+				tools.Brakeman:             toolsconfig.Config{false},
+				tools.Checkov:              toolsconfig.Config{false},
+				tools.Flawfinder:           toolsconfig.Config{false},
+				tools.GitLeaks:             toolsconfig.Config{false},
+				tools.GoSec:                toolsconfig.Config{false},
+				tools.HorusecEngine:        toolsconfig.Config{true},
+				tools.MixAudit:             toolsconfig.Config{false},
+				tools.NpmAudit:             toolsconfig.Config{false},
+				tools.PhpCS:                toolsconfig.Config{false},
+				tools.Safety:               toolsconfig.Config{false},
+				tools.SecurityCodeScan:     toolsconfig.Config{false},
+				tools.Semgrep:              toolsconfig.Config{false},
+				tools.ShellCheck:           toolsconfig.Config{false},
+				tools.Sobelow:              toolsconfig.Config{false},
+				tools.TfSec:                toolsconfig.Config{false},
+				tools.YarnAudit:            toolsconfig.Config{false},
+				tools.OwaspDependencyCheck: toolsconfig.Config{false},
+				tools.DotnetCli:            toolsconfig.Config{false},
+				tools.Nancy:                toolsconfig.Config{false},
+				tools.Trivy:                toolsconfig.Config{true},
+			},
+		},
+	}
+
+	output := bytes.NewBufferString("")
+	logger.LogSetOutput(output)
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			config := toolsconfig.MustParseToolsConfig(tt.input)
+
+			assert.Equal(t, tt.expected, config)
+			assert.Contains(t, output.String(), tt.output)
+		})
+	}
+}

--- a/internal/services/formatters/c/flawfinder/formatter_test.go
+++ b/internal/services/formatters/c/flawfinder/formatter_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
 
 	entitiesAnalysis "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
@@ -114,11 +115,11 @@ func TestStartCFlawfinder(t *testing.T) {
 		dockerAPIControllerMock := &docker.Mock{}
 		config := &cliConfig.Config{}
 		config.WorkDir = &workdir.WorkDir{}
-		config.ToolsConfig = toolsconfig.ParseInterfaceToMapToolsConfig(toolsconfig.ToolsConfigsStruct{
-			Flawfinder: toolsconfig.ToolConfig{
+		config.ToolsConfig = toolsconfig.ToolsConfig{
+			tools.Flawfinder: toolsconfig.Config{
 				IsToIgnore: true,
 			},
-		})
+		}
 
 		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, config)
 		formatter := NewFormatter(service)

--- a/internal/services/formatters/csharp/dotnet_cli/formatter_test.go
+++ b/internal/services/formatters/csharp/dotnet_cli/formatter_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	analysisEntities "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
+	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 
 	cliConfig "github.com/ZupIT/horusec/config"
 	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
@@ -115,9 +116,11 @@ func TestParseOutput(t *testing.T) {
 		dockerAPIControllerMock := &docker.Mock{}
 		config := &cliConfig.Config{}
 		config.WorkDir = &workdir.WorkDir{}
-		config.ToolsConfig = toolsconfig.ParseInterfaceToMapToolsConfig(
-			toolsconfig.ToolsConfigsStruct{DotnetCli: toolsconfig.ToolConfig{IsToIgnore: true}},
-		)
+		config.ToolsConfig = toolsconfig.ToolsConfig{
+			tools.DotnetCli: toolsconfig.Config{
+				IsToIgnore: true,
+			},
+		}
 
 		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, config)
 		formatter := NewFormatter(service)

--- a/internal/services/formatters/csharp/scs/formatter_test.go
+++ b/internal/services/formatters/csharp/scs/formatter_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	analysisEntities "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
+	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 
 	cliConfig "github.com/ZupIT/horusec/config"
 	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
@@ -190,9 +191,11 @@ func TestParseOutput(t *testing.T) {
 		dockerAPIControllerMock := &docker.Mock{}
 		config := &cliConfig.Config{}
 		config.WorkDir = &workdir.WorkDir{}
-		config.ToolsConfig = toolsconfig.ParseInterfaceToMapToolsConfig(
-			toolsconfig.ToolsConfigsStruct{SecurityCodeScan: toolsconfig.ToolConfig{IsToIgnore: true}},
-		)
+		config.ToolsConfig = toolsconfig.ToolsConfig{
+			tools.SecurityCodeScan: toolsconfig.Config{
+				IsToIgnore: true,
+			},
+		}
 
 		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, config)
 		formatter := NewFormatter(service)

--- a/internal/services/formatters/elixir/mixaudit/formatter_test.go
+++ b/internal/services/formatters/elixir/mixaudit/formatter_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
+	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 	cliConfig "github.com/ZupIT/horusec/config"
 	"github.com/ZupIT/horusec/internal/entities/workdir"
 	"github.com/ZupIT/horusec/internal/services/docker"
@@ -92,9 +93,11 @@ func TestStartCFlawfinder(t *testing.T) {
 		dockerAPIControllerMock := &docker.Mock{}
 		config := &cliConfig.Config{}
 		config.WorkDir = &workdir.WorkDir{}
-		config.ToolsConfig = toolsconfig.ParseInterfaceToMapToolsConfig(
-			toolsconfig.ToolsConfigsStruct{MixAudit: toolsconfig.ToolConfig{IsToIgnore: true}},
-		)
+		config.ToolsConfig = toolsconfig.ToolsConfig{
+			tools.MixAudit: toolsconfig.Config{
+				IsToIgnore: true,
+			},
+		}
 
 		service := formatters.NewFormatterService(entity, dockerAPIControllerMock, config)
 		formatter := NewFormatter(service)

--- a/internal/services/formatters/elixir/sobelow/formatter_test.go
+++ b/internal/services/formatters/elixir/sobelow/formatter_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
+	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 	cliConfig "github.com/ZupIT/horusec/config"
 	"github.com/ZupIT/horusec/internal/entities/workdir"
 	"github.com/ZupIT/horusec/internal/services/docker"
@@ -101,9 +102,11 @@ func TestStartCFlawfinder(t *testing.T) {
 		dockerAPIControllerMock := &docker.Mock{}
 		config := &cliConfig.Config{}
 		config.WorkDir = &workdir.WorkDir{}
-		config.ToolsConfig = toolsconfig.ParseInterfaceToMapToolsConfig(
-			toolsconfig.ToolsConfigsStruct{Sobelow: toolsconfig.ToolConfig{IsToIgnore: true}},
-		)
+		config.ToolsConfig = toolsconfig.ToolsConfig{
+			tools.Sobelow: toolsconfig.Config{
+				IsToIgnore: true,
+			},
+		}
 
 		service := formatters.NewFormatterService(entity, dockerAPIControllerMock, config)
 		formatter := NewFormatter(service)

--- a/internal/services/formatters/generic/dependency_check/formatter_test.go
+++ b/internal/services/formatters/generic/dependency_check/formatter_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	entitiesAnalysis "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
+	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 
 	cliConfig "github.com/ZupIT/horusec/config"
 	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
@@ -133,9 +134,11 @@ func TestStartGenericOwaspDependencyCheck(t *testing.T) {
 		dockerAPIControllerMock := &docker.Mock{}
 		config := &cliConfig.Config{}
 		config.WorkDir = &workdir.WorkDir{}
-		config.ToolsConfig = toolsconfig.ParseInterfaceToMapToolsConfig(
-			toolsconfig.ToolsConfigsStruct{OwaspDependencyCheck: toolsconfig.ToolConfig{IsToIgnore: true}},
-		)
+		config.ToolsConfig = toolsconfig.ToolsConfig{
+			tools.OwaspDependencyCheck: toolsconfig.Config{
+				IsToIgnore: true,
+			},
+		}
 
 		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, config)
 		formatter := NewFormatter(service)

--- a/internal/services/formatters/generic/semgrep/formatter_test.go
+++ b/internal/services/formatters/generic/semgrep/formatter_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
 
 	entitiesAnalysis "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
+	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 
 	"github.com/stretchr/testify/assert"
 
@@ -139,9 +140,11 @@ func TestParseOutput(t *testing.T) {
 		dockerAPIControllerMock := &docker.Mock{}
 		config := &cliConfig.Config{}
 		config.WorkDir = &workdir.WorkDir{}
-		config.ToolsConfig = toolsconfig.ParseInterfaceToMapToolsConfig(
-			toolsconfig.ToolsConfigsStruct{Semgrep: toolsconfig.ToolConfig{IsToIgnore: true}},
-		)
+		config.ToolsConfig = toolsconfig.ToolsConfig{
+			tools.Semgrep: toolsconfig.Config{
+				IsToIgnore: true,
+			},
+		}
 
 		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, config)
 		formatter := NewFormatter(service)

--- a/internal/services/formatters/generic/trivy/formatter_test.go
+++ b/internal/services/formatters/generic/trivy/formatter_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	entitiesAnalysis "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
+	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 	"github.com/ZupIT/horusec/config"
 	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
 	"github.com/ZupIT/horusec/internal/entities/workdir"
@@ -69,9 +70,11 @@ func TestParseOutput(t *testing.T) {
 		dockerAPIControllerMock := &docker.Mock{}
 		c := &config.Config{}
 		c.WorkDir = &workdir.WorkDir{}
-		c.ToolsConfig = toolsconfig.ParseInterfaceToMapToolsConfig(
-			toolsconfig.ToolsConfigsStruct{Trivy: toolsconfig.ToolConfig{IsToIgnore: true}},
-		)
+		c.ToolsConfig = toolsconfig.ToolsConfig{
+			tools.Trivy: toolsconfig.Config{
+				IsToIgnore: true,
+			},
+		}
 
 		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, c)
 		formatter := NewFormatter(service)

--- a/internal/services/formatters/go/gosec/formatter_test.go
+++ b/internal/services/formatters/go/gosec/formatter_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
+	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 	cliConfig "github.com/ZupIT/horusec/config"
 	"github.com/ZupIT/horusec/internal/entities/workdir"
 	"github.com/ZupIT/horusec/internal/services/docker"
@@ -120,9 +121,11 @@ func TestGoLang_StartAnalysis(t *testing.T) {
 		dockerAPIControllerMock := &docker.Mock{}
 		config := &cliConfig.Config{}
 		config.WorkDir = &workdir.WorkDir{}
-		config.ToolsConfig = toolsconfig.ParseInterfaceToMapToolsConfig(
-			toolsconfig.ToolsConfigsStruct{GoSec: toolsconfig.ToolConfig{IsToIgnore: true}},
-		)
+		config.ToolsConfig = toolsconfig.ToolsConfig{
+			tools.GoSec: toolsconfig.Config{
+				IsToIgnore: true,
+			},
+		}
 
 		service := formatters.NewFormatterService(entity, dockerAPIControllerMock, config)
 		formatter := NewFormatter(service)

--- a/internal/services/formatters/go/nancy/formatter_test.go
+++ b/internal/services/formatters/go/nancy/formatter_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	entitiesAnalysis "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
+	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 
 	cliConfig "github.com/ZupIT/horusec/config"
 	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
@@ -145,9 +146,11 @@ func TestParseOutput(t *testing.T) {
 		analysis := &entitiesAnalysis.Analysis{}
 		dockerAPIControllerMock := &docker.Mock{}
 		config := &cliConfig.Config{}
-		config.ToolsConfig = toolsconfig.ParseInterfaceToMapToolsConfig(
-			toolsconfig.ToolsConfigsStruct{Nancy: toolsconfig.ToolConfig{IsToIgnore: true}},
-		)
+		config.ToolsConfig = toolsconfig.ToolsConfig{
+			tools.Nancy: toolsconfig.Config{
+				IsToIgnore: true,
+			},
+		}
 
 		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, config)
 		formatter := NewFormatter(service)

--- a/internal/services/formatters/hcl/checkov/formatter_test.go
+++ b/internal/services/formatters/hcl/checkov/formatter_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	entitiesAnalysis "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
+	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 
 	"github.com/stretchr/testify/assert"
 
@@ -88,9 +89,11 @@ func TestStartHCLCheckov(t *testing.T) {
 		analysis := &entitiesAnalysis.Analysis{}
 		config := &cliConfig.Config{}
 		config.WorkDir = &workdir.WorkDir{}
-		config.ToolsConfig = toolsconfig.ParseInterfaceToMapToolsConfig(
-			toolsconfig.ToolsConfigsStruct{Checkov: toolsconfig.ToolConfig{IsToIgnore: true}},
-		)
+		config.ToolsConfig = toolsconfig.ToolsConfig{
+			tools.Checkov: toolsconfig.Config{
+				IsToIgnore: true,
+			},
+		}
 
 		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, config)
 		formatter := NewFormatter(service)

--- a/internal/services/formatters/hcl/tfsec/formatter_test.go
+++ b/internal/services/formatters/hcl/tfsec/formatter_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
 
 	entitiesAnalysis "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
+	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 
 	"github.com/stretchr/testify/assert"
 
@@ -88,9 +89,11 @@ func TestStartHCLTfSec(t *testing.T) {
 		dockerAPIControllerMock := &docker.Mock{}
 		config := &cliConfig.Config{}
 		config.WorkDir = &workdir.WorkDir{}
-		config.ToolsConfig = toolsconfig.ParseInterfaceToMapToolsConfig(
-			toolsconfig.ToolsConfigsStruct{TfSec: toolsconfig.ToolConfig{IsToIgnore: true}},
-		)
+		config.ToolsConfig = toolsconfig.ToolsConfig{
+			tools.TfSec: toolsconfig.Config{
+				IsToIgnore: true,
+			},
+		}
 		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, config)
 		formatter := NewFormatter(service)
 

--- a/internal/services/formatters/javascript/npmaudit/formatter_test.go
+++ b/internal/services/formatters/javascript/npmaudit/formatter_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
 
 	entitiesAnalysis "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
+	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 
 	"github.com/stretchr/testify/assert"
 
@@ -129,9 +130,11 @@ func TestStartNpmAudit(t *testing.T) {
 		analysis := &entitiesAnalysis.Analysis{}
 		dockerAPIControllerMock := &docker.Mock{}
 		config := &cliConfig.Config{}
-		config.ToolsConfig = toolsconfig.ParseInterfaceToMapToolsConfig(
-			toolsconfig.ToolsConfigsStruct{NpmAudit: toolsconfig.ToolConfig{IsToIgnore: true}},
-		)
+		config.ToolsConfig = toolsconfig.ToolsConfig{
+			tools.NpmAudit: toolsconfig.Config{
+				IsToIgnore: true,
+			},
+		}
 		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, config)
 		formatter := NewFormatter(service)
 

--- a/internal/services/formatters/javascript/yarnaudit/formatter_test.go
+++ b/internal/services/formatters/javascript/yarnaudit/formatter_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
 
 	entitiesAnalysis "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
+	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 
 	"github.com/stretchr/testify/assert"
 
@@ -132,9 +133,11 @@ func TestParseOutputYarn(t *testing.T) {
 		dockerAPIControllerMock := &docker.Mock{}
 
 		config := &cliConfig.Config{}
-		config.ToolsConfig = toolsconfig.ParseInterfaceToMapToolsConfig(
-			toolsconfig.ToolsConfigsStruct{YarnAudit: toolsconfig.ToolConfig{IsToIgnore: true}},
-		)
+		config.ToolsConfig = toolsconfig.ToolsConfig{
+			tools.YarnAudit: toolsconfig.Config{
+				IsToIgnore: true,
+			},
+		}
 		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, config)
 		formatter := NewFormatter(service)
 

--- a/internal/services/formatters/leaks/gitleaks/formatter_test.go
+++ b/internal/services/formatters/leaks/gitleaks/formatter_test.go
@@ -23,6 +23,7 @@ import (
 
 	entitiesAnalysis "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
 	enumsAnalysis "github.com/ZupIT/horusec-devkit/pkg/enums/analysis"
+	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -137,9 +138,11 @@ func TestLeaks_StartAnalysis(t *testing.T) {
 		analysis := &entitiesAnalysis.Analysis{}
 		dockerAPIControllerMock := &docker.Mock{}
 		config := &cliConfig.Config{}
-		config.ToolsConfig = toolsconfig.ParseInterfaceToMapToolsConfig(
-			toolsconfig.ToolsConfigsStruct{GitLeaks: toolsconfig.ToolConfig{IsToIgnore: true}},
-		)
+		config.ToolsConfig = toolsconfig.ToolsConfig{
+			tools.GitLeaks: toolsconfig.Config{
+				IsToIgnore: true,
+			},
+		}
 
 		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, config)
 		formatter := NewFormatter(service)

--- a/internal/services/formatters/php/phpcs/formatter_test.go
+++ b/internal/services/formatters/php/phpcs/formatter_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	entitiesAnalysis "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
+	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 	cliConfig "github.com/ZupIT/horusec/config"
 	"github.com/ZupIT/horusec/internal/entities/workdir"
 	"github.com/ZupIT/horusec/internal/services/docker"
@@ -86,9 +87,11 @@ func TestStartCFlawfinder(t *testing.T) {
 		analysis := &entitiesAnalysis.Analysis{}
 		dockerAPIControllerMock := &docker.Mock{}
 		config := &cliConfig.Config{}
-		config.ToolsConfig = toolsconfig.ParseInterfaceToMapToolsConfig(
-			toolsconfig.ToolsConfigsStruct{PhpCS: toolsconfig.ToolConfig{IsToIgnore: true}},
-		)
+		config.ToolsConfig = toolsconfig.ToolsConfig{
+			tools.PhpCS: toolsconfig.Config{
+				IsToIgnore: true,
+			},
+		}
 
 		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, config)
 		formatter := NewFormatter(service)

--- a/internal/services/formatters/python/bandit/formatter_test.go
+++ b/internal/services/formatters/python/bandit/formatter_test.go
@@ -23,6 +23,7 @@ import (
 
 	entitiesAnalysis "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
 	enumHorusec "github.com/ZupIT/horusec-devkit/pkg/enums/analysis"
+	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -156,9 +157,11 @@ func TestFormatter_StartSafety(t *testing.T) {
 		analysis := &entitiesAnalysis.Analysis{}
 		dockerAPIControllerMock := &docker.Mock{}
 		config := &cliConfig.Config{}
-		config.ToolsConfig = toolsconfig.ParseInterfaceToMapToolsConfig(
-			toolsconfig.ToolsConfigsStruct{Bandit: toolsconfig.ToolConfig{IsToIgnore: true}},
-		)
+		config.ToolsConfig = toolsconfig.ToolsConfig{
+			tools.Bandit: toolsconfig.Config{
+				IsToIgnore: true,
+			},
+		}
 
 		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, config)
 		formatter := NewFormatter(service)

--- a/internal/services/formatters/python/safety/formatter_test.go
+++ b/internal/services/formatters/python/safety/formatter_test.go
@@ -23,6 +23,7 @@ import (
 
 	entitiesAnalysis "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
 	enumHorusec "github.com/ZupIT/horusec-devkit/pkg/enums/analysis"
+	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -134,9 +135,11 @@ func TestFormatter_StartSafety(t *testing.T) {
 		analysis := &entitiesAnalysis.Analysis{}
 		dockerAPIControllerMock := &docker.Mock{}
 		config := &cliConfig.Config{}
-		config.ToolsConfig = toolsconfig.ParseInterfaceToMapToolsConfig(
-			toolsconfig.ToolsConfigsStruct{Safety: toolsconfig.ToolConfig{IsToIgnore: true}},
-		)
+		config.ToolsConfig = toolsconfig.ToolsConfig{
+			tools.Safety: toolsconfig.Config{
+				IsToIgnore: true,
+			},
+		}
 
 		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, config)
 		formatter := NewFormatter(service)

--- a/internal/services/formatters/ruby/brakeman/formatter_test.go
+++ b/internal/services/formatters/ruby/brakeman/formatter_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
 
 	entitiesAnalysis "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
+	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 
 	"github.com/stretchr/testify/assert"
 
@@ -140,9 +141,11 @@ func TestParseOutput(t *testing.T) {
 		analysis := &entitiesAnalysis.Analysis{}
 		dockerAPIControllerMock := &docker.Mock{}
 		config := &cliConfig.Config{}
-		config.ToolsConfig = toolsconfig.ParseInterfaceToMapToolsConfig(
-			toolsconfig.ToolsConfigsStruct{Brakeman: toolsconfig.ToolConfig{IsToIgnore: true}},
-		)
+		config.ToolsConfig = toolsconfig.ToolsConfig{
+			tools.Brakeman: toolsconfig.Config{
+				IsToIgnore: true,
+			},
+		}
 
 		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, config)
 		formatter := NewFormatter(service)

--- a/internal/services/formatters/ruby/bundler/formatter_test.go
+++ b/internal/services/formatters/ruby/bundler/formatter_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
 
 	entitiesAnalysis "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
+	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 
 	"github.com/stretchr/testify/assert"
 
@@ -128,9 +129,11 @@ func TestParseOutput(t *testing.T) {
 		analysis := &entitiesAnalysis.Analysis{}
 		dockerAPIControllerMock := &docker.Mock{}
 		config := &cliConfig.Config{}
-		config.ToolsConfig = toolsconfig.ParseInterfaceToMapToolsConfig(
-			toolsconfig.ToolsConfigsStruct{BundlerAudit: toolsconfig.ToolConfig{IsToIgnore: true}},
-		)
+		config.ToolsConfig = toolsconfig.ToolsConfig{
+			tools.BundlerAudit: toolsconfig.Config{
+				IsToIgnore: true,
+			},
+		}
 
 		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, config)
 		formatter := NewFormatter(service)

--- a/internal/services/formatters/service_test.go
+++ b/internal/services/formatters/service_test.go
@@ -298,9 +298,11 @@ func TestLogAnalysisError(t *testing.T) {
 func TestToolIsToIgnore(t *testing.T) {
 	t.Run("should return true when language is match", func(t *testing.T) {
 		configs := &config.Config{}
-		configs.ToolsConfig = toolsconfig.ParseInterfaceToMapToolsConfig(
-			toolsconfig.ToolsConfigsStruct{GoSec: toolsconfig.ToolConfig{IsToIgnore: true}},
-		)
+		configs.ToolsConfig = toolsconfig.ToolsConfig{
+			tools.GoSec: toolsconfig.Config{
+				IsToIgnore: true,
+			},
+		}
 
 		monitorController := NewFormatterService(&analysis.Analysis{}, &docker.Mock{}, configs)
 
@@ -308,9 +310,11 @@ func TestToolIsToIgnore(t *testing.T) {
 	})
 	t.Run("should return true when language is match uppercase", func(t *testing.T) {
 		configs := &config.Config{}
-		configs.ToolsConfig = toolsconfig.ParseInterfaceToMapToolsConfig(
-			toolsconfig.ToolsConfigsStruct{GoSec: toolsconfig.ToolConfig{IsToIgnore: true}},
-		)
+		configs.ToolsConfig = toolsconfig.ToolsConfig{
+			tools.GoSec: toolsconfig.Config{
+				IsToIgnore: true,
+			},
+		}
 
 		monitorController := NewFormatterService(&analysis.Analysis{}, &docker.Mock{}, configs)
 
@@ -318,12 +322,10 @@ func TestToolIsToIgnore(t *testing.T) {
 	})
 	t.Run("should return true when language is match lowercase and multi tools", func(t *testing.T) {
 		configs := &config.Config{}
-		configs.ToolsConfig = toolsconfig.ParseInterfaceToMapToolsConfig(
-			toolsconfig.ToolsConfigsStruct{
-				GoSec:            toolsconfig.ToolConfig{IsToIgnore: true},
-				SecurityCodeScan: toolsconfig.ToolConfig{IsToIgnore: true},
-			},
-		)
+		configs.ToolsConfig = toolsconfig.ToolsConfig{
+			tools.GoSec:            toolsconfig.Config{IsToIgnore: true},
+			tools.SecurityCodeScan: toolsconfig.Config{IsToIgnore: true},
+		}
 
 		monitorController := NewFormatterService(&analysis.Analysis{}, &docker.Mock{}, configs)
 
@@ -331,9 +333,11 @@ func TestToolIsToIgnore(t *testing.T) {
 	})
 	t.Run("should return false when language is not match", func(t *testing.T) {
 		configs := &config.Config{}
-		configs.ToolsConfig = toolsconfig.ParseInterfaceToMapToolsConfig(
-			toolsconfig.ToolsConfigsStruct{SecurityCodeScan: toolsconfig.ToolConfig{IsToIgnore: true}},
-		)
+		configs.ToolsConfig = toolsconfig.ToolsConfig{
+			tools.SecurityCodeScan: toolsconfig.Config{
+				IsToIgnore: true,
+			},
+		}
 
 		monitorController := NewFormatterService(&analysis.Analysis{}, &docker.Mock{}, configs)
 

--- a/internal/services/formatters/shell/shellcheck/formatter_test.go
+++ b/internal/services/formatters/shell/shellcheck/formatter_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
 
 	entitiesAnalysis "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
+	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 
 	"github.com/stretchr/testify/assert"
 
@@ -141,9 +142,11 @@ func TestParseOutput(t *testing.T) {
 		dockerAPIControllerMock := &docker.Mock{}
 		config := &cliConfig.Config{}
 		config.EnableShellCheck = true
-		config.ToolsConfig = toolsconfig.ParseInterfaceToMapToolsConfig(
-			toolsconfig.ToolsConfigsStruct{ShellCheck: toolsconfig.ToolConfig{IsToIgnore: true}},
-		)
+		config.ToolsConfig = toolsconfig.ToolsConfig{
+			tools.ShellCheck: toolsconfig.Config{
+				IsToIgnore: true,
+			},
+		}
 
 		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, config)
 		formatter := NewFormatter(service)


### PR DESCRIPTION
Previously the toolsconfig package does not have any unit tests and the
public functions and types was a bit confused, since two types was
exported to represents the same "thing".

This commit implements the tests to cover scenarios of toolsconfig
parsing.

This commit also rename ToolsConfigStruct to toolsConfig and also made
private, since this struct is only used as schema to parse the values
and only the Map type is used by other packages. The Map and Config
struct was also renamed to don't be repetitive on names.

The function ParseInterfaceToMapToolsConfig was also renamed to
MustParseToolsConfig to follow the Go standards of functions that can
cause errors that will be not returned. The signature was also changed
to avoid bugs when accepting an empty interface{}, since the viper will
always return a map[string]interface{} when we get the tools config from
config file, this function does not need to accept an empty interface.

A new function Default was also created to return the default values
from tools config.

Updates #718

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
