### PR TITLE
engine:chore - improve the HS-JAVASCRIPT-02 rule

### DIFF
--- a/internal/services/engines/nodejs/rules.go
+++ b/internal/services/engines/nodejs/rules.go
@@ -50,7 +50,7 @@ func NewNoUseEval() text.TextRule {
 		},
 		Type: text.Regular,
 		Expressions: []*regexp.Regexp{
-			regexp.MustCompile(`(eval\(.+)(?:req\.|req\.query|req\.body|req\.param)`),
+			regexp.MustCompile(`eval\(((.*[\+,$].*\))|([a-zA-Z]*\)))`),
 		},
 	}
 }

--- a/internal/services/engines/nodejs/rules_test.go
+++ b/internal/services/engines/nodejs/rules_test.go
@@ -50,7 +50,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 			Src:  SampleVulnerableHSJAVASCRIPT2,
 			Findings: []engine.Finding{
 				{
-					CodeSample: `eval("bash -c" + req.body);`,
+					CodeSample: `eval(foo);`,
 					SourceLocation: engine.Location{
 						Line:   3,
 						Column: 1,

--- a/internal/services/engines/nodejs/samples_test.go
+++ b/internal/services/engines/nodejs/samples_test.go
@@ -22,7 +22,7 @@ console.debug("user password: ", pwd)
 
 	SampleVulnerableHSJAVASCRIPT2 = `
 function f(req) {
-	eval("bash -c" + req.body);
+	eval(foo);
 }
 `
 
@@ -146,10 +146,9 @@ navigator.geolocation.getCurrentPosition(success, error, {});
 const (
 	SampleSafeHSJAVASCRIPT2 = `
 function f() {
-	eval("echo foo");
+	window.eval("any string")
 }
 `
-
 	SampleSafeHSJAVASCRIPT9 = `
 function f(foo) {
 	Model.find({ where: { foo: foo}});

--- a/internal/utils/testutil/examples.go
+++ b/internal/utils/testutil/examples.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	// AverageTimeoutAnalyzeForExamplesFolder Average timeout for analysis in the example directory
-	AverageTimeoutAnalyzeForExamplesFolder = time.Minute * 5
+	AverageTimeoutAnalyzeForExamplesFolder = time.Minute * 15
 )
 
 var (


### PR DESCRIPTION
In issue #765 we have a scenario that our rule was not able to detect the vulnerability.

In order for it to be more assertive, I suggest a more assertive change in the rule matcher, however this implies confidentiality, that I needed to change it to LOW.

Signed-off-by: lucas.bruno <lucas.bruno@zup.com.br>


