### PR TITLE
formatters:hotfix - fix random vulnerability hash on Windows

### DIFF
--- a/internal/helpers/messages/error.go
+++ b/internal/helpers/messages/error.go
@@ -73,4 +73,5 @@ const (
 	MsgErrorFailedToPullImage        = "{HORUSEC_CLI} Failed to pull docker image"
 	MsgErrorWhileParsingCustomImages = "{HORUSEC_CLI} Error when parsing custom images config. Using default values"
 	MsgErrorSettingLogFile           = "{HORUSEC_CLI} Error when setting log file"
+	MsgErrorGetRelativePathFromFile  = "{HORUSEC_CLI} Error when get relative path of file"
 )

--- a/internal/services/formatters/service.go
+++ b/internal/services/formatters/service.go
@@ -236,8 +236,17 @@ func (s *Service) newVulnerabilityFromFinding(finding *engine.Finding, tool tool
 }
 
 func (s *Service) removeHorusecFolder(path string) string {
-	toRemove := fmt.Sprintf("%s/", s.GetConfigProjectPath())
-	return strings.ReplaceAll(path, toRemove, "")
+	rel, err := filepath.Rel(s.GetConfigProjectPath(), path)
+	if err != nil {
+		logger.LogError(messages.MsgErrorGetRelativePathFromFile, err, map[string]interface{}{
+			"basepath": s.GetConfigProjectPath(),
+			"path":     path,
+		})
+		// Since all files will be analyzed from GetConfigProjectPath path
+		// this error should never happen.
+		return path
+	}
+	return rel
 }
 
 func (s *Service) GetConfigCMDByFileExtension(projectSubPath, imageCmd, ext string, tool tools.Tool) string {

--- a/internal/services/formatters/service_test.go
+++ b/internal/services/formatters/service_test.go
@@ -51,8 +51,11 @@ import (
 )
 
 func TestParseFindingsToVulnerabilities(t *testing.T) {
-	analysis := new(analysis.Analysis)
-	svc := NewFormatterService(analysis, &docker.Mock{}, config.New())
+	analysis := &analysis.Analysis{
+		ID: uuid.New(),
+	}
+	cfg := config.New()
+	svc := NewFormatterService(analysis, &docker.Mock{}, cfg)
 
 	rule := java.NewAWSQueryInjection()
 	findings := []engine.Finding{
@@ -64,7 +67,7 @@ func TestParseFindingsToVulnerabilities(t *testing.T) {
 			Confidence:  rule.Confidence,
 			Description: rule.Description,
 			SourceLocation: engine.Location{
-				Filename: "Test.java",
+				Filename: filepath.Join(cfg.ProjectPath, ".horusec", analysis.ID.String(), "Test.java"),
 				Line:     10,
 				Column:   20,
 			},


### PR DESCRIPTION
Previously when running the Horusec on Windows we was getting a
different vulnerability hash for each analysis, this problem was
happening because we weren't removing the .horusec folder from
the file path before generating the hash, and since the .horusec folder
contains a uuid, on every analysis we was getting a new uuid and
consequently a new vulnerability hash.

The commit fix this issue using a better approach to remove the .horusec
folder from filepath, using the relative path from file using the
.horusec folder as base path.

This commit also change the testcase to catch this bug.

This bug was founded on #777

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
