### PR TITLE
engine:chore - rename the nodejs engine service to javascript

### DIFF
--- a/cmd/app/start/start.go
+++ b/cmd/app/start/start.go
@@ -274,7 +274,7 @@ func (s *Start) CreateStartCommand() *cobra.Command {
 			BoolP(
 				"disable-docker", "D",
 				s.configs.DisableDocker,
-				"Used to run horusec without docker if enabled it will only run the following tools: horusec-csharp, horusec-kotlin, horusec-java, horusec-kubernetes, horusec-leaks, horusec-nodejs, horusec-dart, horusec-nginx. Example: -D=\"true\"",
+				"Used to run horusec without docker if enabled it will only run the following tools: horusec-csharp, horusec-kotlin, horusec-java, horusec-kubernetes, horusec-leaks, horusec-javascript, horusec-dart, horusec-nginx. Example: -D=\"true\"",
 			)
 	}
 

--- a/internal/controllers/analyzer/analyzer.go
+++ b/internal/controllers/analyzer/analyzer.go
@@ -62,7 +62,7 @@ import (
 	"github.com/ZupIT/horusec/internal/services/formatters/hcl/checkov"
 	"github.com/ZupIT/horusec/internal/services/formatters/hcl/tfsec"
 	"github.com/ZupIT/horusec/internal/services/formatters/java/horusecjava"
-	"github.com/ZupIT/horusec/internal/services/formatters/javascript/horusecnodejs"
+	"github.com/ZupIT/horusec/internal/services/formatters/javascript/horusecjavascript"
 	"github.com/ZupIT/horusec/internal/services/formatters/javascript/npmaudit"
 	"github.com/ZupIT/horusec/internal/services/formatters/javascript/yarnaudit"
 	"github.com/ZupIT/horusec/internal/services/formatters/kotlin/horuseckotlin"
@@ -363,7 +363,7 @@ func (a *Analyzer) detectVulnerabilityNginx(_ *sync.WaitGroup, projectSubPath st
 }
 
 func (a *Analyzer) detectVulnerabilityJavascript(wg *sync.WaitGroup, projectSubPath string) error {
-	spawn(wg, horusecnodejs.NewFormatter(a.formatter), projectSubPath)
+	spawn(wg, horusecjavascript.NewFormatter(a.formatter), projectSubPath)
 
 	if err := a.docker.PullImage(a.getCustomOrDefaultImage(languages.Javascript)); err != nil {
 		return err

--- a/internal/entities/custom_rules/custom_rule.go
+++ b/internal/entities/custom_rules/custom_rule.go
@@ -33,11 +33,11 @@ import (
 	"github.com/ZupIT/horusec/internal/services/engines/csharp"
 	"github.com/ZupIT/horusec/internal/services/engines/dart"
 	"github.com/ZupIT/horusec/internal/services/engines/java"
+	"github.com/ZupIT/horusec/internal/services/engines/javascript"
 	"github.com/ZupIT/horusec/internal/services/engines/kotlin"
 	"github.com/ZupIT/horusec/internal/services/engines/kubernetes"
 	"github.com/ZupIT/horusec/internal/services/engines/leaks"
 	"github.com/ZupIT/horusec/internal/services/engines/nginx"
-	"github.com/ZupIT/horusec/internal/services/engines/nodejs"
 )
 
 type CustomRule struct {
@@ -141,7 +141,7 @@ func (r ruleIDValidator) Validate(value interface{}) error {
 	case languages.Leaks:
 		rules = leaks.Rules()
 	case languages.Javascript:
-		rules = nodejs.Rules()
+		rules = javascript.Rules()
 	case languages.Nginx:
 		rules = nginx.Rules()
 	default:

--- a/internal/services/engines/javascript/rule_manager.go
+++ b/internal/services/engines/javascript/rule_manager.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package nodejs
+package javascript
 
 import (
 	engine "github.com/ZupIT/horusec-engine"

--- a/internal/services/engines/javascript/rules.go
+++ b/internal/services/engines/javascript/rules.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package nodejs
+package javascript
 
 import (
 	"regexp"

--- a/internal/services/engines/javascript/rules_test.go
+++ b/internal/services/engines/javascript/rules_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package nodejs
+package javascript
 
 import (
 	"testing"

--- a/internal/services/engines/javascript/samples_test.go
+++ b/internal/services/engines/javascript/samples_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package nodejs
+package javascript
 
 const (
 	SampleVulnerableHSJAVASCRIPT1 = `

--- a/internal/services/engines/rules_test.go
+++ b/internal/services/engines/rules_test.go
@@ -25,11 +25,11 @@ import (
 	"github.com/ZupIT/horusec/internal/services/engines/csharp"
 	"github.com/ZupIT/horusec/internal/services/engines/dart"
 	"github.com/ZupIT/horusec/internal/services/engines/java"
+	"github.com/ZupIT/horusec/internal/services/engines/javascript"
 	"github.com/ZupIT/horusec/internal/services/engines/kotlin"
 	"github.com/ZupIT/horusec/internal/services/engines/kubernetes"
 	"github.com/ZupIT/horusec/internal/services/engines/leaks"
 	"github.com/ZupIT/horusec/internal/services/engines/nginx"
-	"github.com/ZupIT/horusec/internal/services/engines/nodejs"
 	"github.com/ZupIT/horusec/internal/services/engines/swift"
 )
 
@@ -40,8 +40,8 @@ func TestGetRules(t *testing.T) {
 		expectedTotalRules int
 	}{
 		{
-			engine:             "Nodejs",
-			manager:            nodejs.NewRules(),
+			engine:             "Javascript",
+			manager:            javascript.NewRules(),
 			expectedTotalRules: 53,
 		},
 		{

--- a/internal/services/formatters/default_engine_formatter_test.go
+++ b/internal/services/formatters/default_engine_formatter_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/ZupIT/horusec/internal/services/formatters"
 	"github.com/ZupIT/horusec/internal/services/formatters/csharp/horuseccsharp"
 	"github.com/ZupIT/horusec/internal/services/formatters/java/horusecjava"
-	"github.com/ZupIT/horusec/internal/services/formatters/javascript/horusecnodejs"
+	"github.com/ZupIT/horusec/internal/services/formatters/javascript/horusecjavascript"
 	"github.com/ZupIT/horusec/internal/services/formatters/kotlin/horuseckotlin"
 	"github.com/ZupIT/horusec/internal/services/formatters/leaks/horusecleaks"
 	"github.com/ZupIT/horusec/internal/services/formatters/nginx/horusecnginx"
@@ -52,8 +52,8 @@ func TestStartAnalysis(t *testing.T) {
 			formatter: horusecjava.NewFormatter,
 		},
 		{
-			engine:    "Nodejs",
-			formatter: horusecnodejs.NewFormatter,
+			engine:    "Javascript",
+			formatter: horusecjavascript.NewFormatter,
 		},
 		{
 			engine:    "Kotlin",

--- a/internal/services/formatters/javascript/horusecjavascript/formatter.go
+++ b/internal/services/formatters/javascript/horusecjavascript/formatter.go
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package horusecnodejs
+package horusecjavascript
 
 import (
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
-	"github.com/ZupIT/horusec/internal/services/engines/nodejs"
+	"github.com/ZupIT/horusec/internal/services/engines/javascript"
 	"github.com/ZupIT/horusec/internal/services/formatters"
 )
 
 func NewFormatter(service formatters.IService) formatters.IFormatter {
-	return formatters.NewDefaultFormatter(service, nodejs.NewRules(), languages.Javascript)
+	return formatters.NewDefaultFormatter(service, javascript.NewRules(), languages.Javascript)
 }


### PR DESCRIPTION
Rename the nodejs engine service to javascript
Signed-off-by: lucas.bruno <lucas.bruno@zup.com.br>
