### PR TITLE
utils/copy:chore - skip symlink files and improve tests assertiveness

### DIFF
--- a/internal/utils/copy/copy_test.go
+++ b/internal/utils/copy/copy_test.go
@@ -12,31 +12,55 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package copy
+package copy_test
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/ZupIT/horusec/internal/utils/copy"
+	"github.com/ZupIT/horusec/internal/utils/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCopy(t *testing.T) {
-	t.Run("Should success copy dir", func(t *testing.T) {
-		srcPath, err := filepath.Abs("../../../config")
-		assert.NoError(t, err)
+	src := testutil.GoExample1
+	dst := filepath.Join(t.TempDir(), t.Name())
 
-		dstPath, err := filepath.Abs(".")
-		assert.NoError(t, err)
+	tmpFile, err := os.CreateTemp(t.TempDir(), "test-symlink")
+	require.Nil(t, err, "Expected nil error to create temp file")
 
-		dstPath = fmt.Sprintf(dstPath+"%s", "/tmp-test")
+	symlinkFile := filepath.Join(src, "symlink")
+	err = os.Symlink(tmpFile.Name(), symlinkFile)
+	require.NoError(t, err, "Expected nil error to create symlink file: %v", err)
 
-		err = Copy(srcPath, dstPath, func(src string) bool { return false })
-		assert.NoError(t, err)
+	t.Cleanup(func() {
+		err := tmpFile.Close()
+		assert.NoError(t, err, "Expected nil error to close temp file: %v", err)
 
-		err = os.RemoveAll(dstPath)
-		assert.NoError(t, err)
+		err = os.Remove(symlinkFile)
+		assert.NoError(t, err, "Expected nil error to clean up symlink file: %v", err)
 	})
+
+	err = copy.Copy(src, dst, func(src string) bool {
+		ext := filepath.Ext(src)
+		return ext == ".mod" || ext == ".sum"
+	})
+
+	assert.NoError(t, err)
+
+	assert.DirExists(t, dst)
+	assert.DirExists(t, filepath.Join(dst, "api", "routes"))
+	assert.DirExists(t, filepath.Join(dst, "api", "util"))
+
+	assert.NoFileExists(t, filepath.Join(dst, "symlink"))
+	assert.FileExists(t, filepath.Join(dst, "api", "server.go"))
+	assert.FileExists(t, filepath.Join(dst, "api", "routes", "healthcheck.go"))
+	assert.FileExists(t, filepath.Join(dst, "api", "util", "util.go"))
+
+	assert.NoFileExists(t, filepath.Join(dst, "go.mod"))
+	assert.NoFileExists(t, filepath.Join(dst, "go.sum"))
+
 }


### PR DESCRIPTION
Previously if some symlink exists on project path during the copy we was
creating a directory instead evaluating the sysmlink.

Evaluating the symlink makes us need to deal with several scenarios,
such as, how should we copy a file to the .horuse folder when it is not
in the project path? Another scenario would be how do we handle symlinks
from files that don't exist on the user's machine?

With that in mind, this commit changes the behavior of the `Copy` function
to ignore symlinks by default and only copy directories and files. Since
previously we were no longer analyzing sysmlinks, this change will not be
noticed by the user.

This commit also change the assertiveness of tests to check if all files
and directories was copied correctly.

Updates #718

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
