### PR TITLE
e2e:chore - test for the information severity flag

### DIFF
--- a/e2e/commands/start/start_test.go
+++ b/e2e/commands/start/start_test.go
@@ -393,4 +393,18 @@ var _ = Describe("running binary Horusec with start parameter", func() {
 			Expect(session.Out.Contents()).To(ContainSubstring(`\"enable_shell_check\": true`))
 		})
 	})
+
+	When("--information-severity is passed", func() {
+		BeforeEach(func() {
+			flags = map[string]string{
+				testutil.StartFlagProjectPath:         testutil.JavaScriptExample1,
+				testutil.StartFlagInformationSeverity: "true",
+			}
+		})
+
+		It("Checks if the information severity property was set", func() {
+			Expect(session.Out.Contents()).To(ContainSubstring(`\"enable_information_severity\": true`))
+			Expect(session.Out.Contents()).NotTo(ContainSubstring("Horusec not show info vulnerabilities in this analysis"))
+		})
+	})
 })


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
E2e test for the `--information-severity`

**- How to verify it**
run `make test-e2e` and expected all tests passed.

**- Description for the changelog**
N/A

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Signed-off-by: lucas.bruno <lucas.bruno@zup.com.br>