### PR TITLE
usecases/cli:chore - remove unnecessary UseCases struct

### DIFF
--- a/cmd/app/start/start.go
+++ b/cmd/app/start/start.go
@@ -21,11 +21,11 @@ import (
 	"strings"
 
 	"github.com/ZupIT/horusec/internal/controllers/requirements"
+	usecases "github.com/ZupIT/horusec/internal/usecases/cli"
 
 	"github.com/ZupIT/horusec/config"
 	"github.com/ZupIT/horusec/config/dist"
 	"github.com/ZupIT/horusec/internal/helpers/messages"
-	"github.com/ZupIT/horusec/internal/usecases/cli"
 
 	"github.com/spf13/cobra"
 
@@ -48,11 +48,6 @@ type Prompt interface {
 	Ask(label, defaultValue string) (string, error)
 }
 
-// UseCase is the interface that validate the configurations
-type UseCase interface {
-	ValidateConfig(config *config.Config) error
-}
-
 // Requirements is the interface that validate Horusec dynamic
 // requirements to execute analysis
 type Requirements interface {
@@ -61,7 +56,6 @@ type Requirements interface {
 }
 
 type Start struct {
-	useCases     UseCase
 	configs      *config.Config
 	analyzer     Analyzer
 	prompt       Prompt
@@ -71,7 +65,6 @@ type Start struct {
 func NewStartCommand(configs *config.Config) *Start {
 	return &Start{
 		configs:      configs,
-		useCases:     cli.NewCLIUseCases(),
 		prompt:       prompt.NewPrompt(),
 		requirements: requirements.NewRequirements(),
 	}
@@ -308,7 +301,7 @@ func (s *Start) startAnalysis(cmd *cobra.Command) (totalVulns int, err error) {
 }
 
 func (s *Start) configsValidations(cmd *cobra.Command) error {
-	if err := s.useCases.ValidateConfig(s.configs); err != nil {
+	if err := usecases.ValidateConfig(s.configs); err != nil {
 		logger.LogErrorWithLevel(messages.MsgErrorInvalidConfigs, err)
 		_ = cmd.Help()
 		return err

--- a/cmd/app/start/start_test.go
+++ b/cmd/app/start/start_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/ZupIT/horusec/config"
 	"github.com/ZupIT/horusec/internal/controllers/analyzer"
 	"github.com/ZupIT/horusec/internal/entities/workdir"
-	"github.com/ZupIT/horusec/internal/usecases/cli"
 	"github.com/ZupIT/horusec/internal/utils/copy"
 	"github.com/ZupIT/horusec/internal/utils/prompt"
 )
@@ -69,7 +68,6 @@ func TestNewStartCommand(t *testing.T) {
 		analyzerMock.On("Analyze").Return(0, nil)
 		requirementsMock.On("ValidateDocker")
 		start := &Start{
-			useCases:     cli.NewCLIUseCases(),
 			configs:      cfg,
 			prompt:       promptMock,
 			analyzer:     analyzerMock,
@@ -570,7 +568,6 @@ func TestStartCommand_ExecuteIntegrationTest(t *testing.T) {
 		requirementsMock.On("ValidateDocker")
 
 		cmd := &Start{
-			useCases:     cli.NewCLIUseCases(),
 			configs:      cfg,
 			prompt:       promptMock,
 			analyzer:     nil,
@@ -629,7 +626,6 @@ func TestStartCommand_ExecuteIntegrationTest(t *testing.T) {
 		requirementsMock.On("ValidateDocker")
 
 		cmd := &Start{
-			useCases:     cli.NewCLIUseCases(),
 			configs:      cfg,
 			prompt:       promptMock,
 			analyzer:     nil,
@@ -676,7 +672,6 @@ func TestStartCommand_ExecuteIntegrationTest(t *testing.T) {
 		requirementsMock.On("ValidateDocker")
 
 		cmd := &Start{
-			useCases:     cli.NewCLIUseCases(),
 			configs:      cfg,
 			prompt:       promptMock,
 			analyzer:     nil,
@@ -722,7 +717,6 @@ func TestStartCommand_ExecuteIntegrationTest(t *testing.T) {
 		requirementsMock.On("ValidateDocker")
 
 		cmd := &Start{
-			useCases:     cli.NewCLIUseCases(),
 			configs:      cfg,
 			prompt:       promptMock,
 			analyzer:     nil,
@@ -783,7 +777,6 @@ func TestStartCommand_ExecuteIntegrationTest(t *testing.T) {
 		requirementsMock.On("ValidateDocker")
 
 		cmd := &Start{
-			useCases:     cli.NewCLIUseCases(),
 			configs:      cfg,
 			prompt:       promptMock,
 			analyzer:     nil,
@@ -838,7 +831,6 @@ func TestStartCommand_ExecuteIntegrationTest(t *testing.T) {
 		requirementMock.On("ValidateDocker")
 
 		cmd := &Start{
-			useCases:     cli.NewCLIUseCases(),
 			configs:      cfg,
 			prompt:       promptMock,
 			analyzer:     nil,
@@ -887,7 +879,6 @@ func getMocksAndStartStruct() (*prompt.Mock, *config.Config, *requirements.Mock,
 	analyzerMock := &analyzer.Mock{}
 
 	start := &Start{
-		useCases:     cli.NewCLIUseCases(),
 		configs:      cfg,
 		prompt:       promptMock,
 		analyzer:     analyzerMock,

--- a/internal/usecases/cli/cli.go
+++ b/internal/usecases/cli/cli.go
@@ -37,37 +37,32 @@ import (
 	"github.com/ZupIT/horusec/internal/services/git"
 )
 
-type UseCases struct{}
-
-func NewCLIUseCases() *UseCases {
-	return &UseCases{}
-}
-
-//nolint
-func (au *UseCases) ValidateConfig(cfg *config.Config) error {
+// ValidateConfig validate if the fields from config has valid values.
+//
+// nolint
+func ValidateConfig(cfg *config.Config) error {
 	return validation.ValidateStruct(cfg,
-		validation.Field(&cfg.HorusecAPIUri, validation.Required, validation.By(au.checkIfIsURL(cfg.HorusecAPIUri))),
+		validation.Field(&cfg.HorusecAPIUri, validation.Required, validation.By(checkIfIsURL(cfg.HorusecAPIUri))),
 		validation.Field(&cfg.TimeoutInSecondsRequest, validation.Required, validation.Min(10)),
 		validation.Field(&cfg.TimeoutInSecondsAnalysis, validation.Required, validation.Min(10)),
 		validation.Field(&cfg.MonitorRetryInSeconds, validation.Required, validation.Min(10)),
 		validation.Field(&cfg.RepositoryAuthorization, validation.Required, is.UUID),
-		validation.Field(&cfg.PrintOutputType, au.validationOutputTypes()),
-		validation.Field(&cfg.JSONOutputFilePath, validation.By(au.checkAndValidateJSONOutputFilePath(cfg))),
-		validation.Field(&cfg.SeveritiesToIgnore, validation.By(au.validationSeverities(cfg))),
-		validation.Field(&cfg.FilesOrPathsToIgnore),
+		validation.Field(&cfg.PrintOutputType, validation.In(outputtype.JSON, outputtype.SonarQube, outputtype.Text)),
+		validation.Field(&cfg.JSONOutputFilePath, validation.By(validateJSONOutputFilePath(cfg))),
+		validation.Field(&cfg.SeveritiesToIgnore, validation.By(validationSeverities(cfg))),
 		validation.Field(&cfg.ReturnErrorIfFoundVulnerability, validation.In(true, false)),
-		validation.Field(&cfg.ProjectPath, validation.By(au.validateIfIsValidPath(cfg.ProjectPath))),
-		validation.Field(&cfg.WorkDir, validation.By(au.validateWorkDir(cfg.WorkDir, cfg.ProjectPath))),
+		validation.Field(&cfg.ProjectPath, validation.By(validateIfIsValidPath(cfg.ProjectPath))),
+		validation.Field(&cfg.WorkDir, validation.By(validateWorkDir(cfg.WorkDir, cfg.ProjectPath))),
 		validation.Field(&cfg.CertInsecureSkipVerify, validation.In(true, false)),
-		validation.Field(&cfg.CertPath, validation.By(au.validateCertPath(cfg.CertPath))),
-		validation.Field(&cfg.FalsePositiveHashes, validation.By(au.checkIfExistsDuplicatedFalsePositiveHashes(cfg))),
-		validation.Field(&cfg.RiskAcceptHashes, validation.By(au.checkIfExistsDuplicatedRiskAcceptHashes(cfg))),
-		validation.Field(&cfg.ShowVulnerabilitiesTypes, validation.By(au.checkIfIsValidVulnerabilitiesTypes(cfg))),
-		validation.Field(&cfg.EnableCommitAuthor, validation.By(au.checkGitDepthClone(cfg))),
+		validation.Field(&cfg.CertPath, validation.By(validateCertPath(cfg.CertPath))),
+		validation.Field(&cfg.FalsePositiveHashes, validation.By(validateDuplicatedFalsePositiveHashes(cfg))),
+		validation.Field(&cfg.RiskAcceptHashes, validation.By(validateDuplicatedRiskAcceptHashes(cfg))),
+		validation.Field(&cfg.ShowVulnerabilitiesTypes, validation.By(validateVulnerabilitiesTypes(cfg))),
+		validation.Field(&cfg.EnableCommitAuthor, validation.By(validateGitDepthClone(cfg))),
 	)
 }
 
-func (au *UseCases) checkGitDepthClone(cfg *config.Config) validation.RuleFunc {
+func validateGitDepthClone(cfg *config.Config) validation.RuleFunc {
 	return func(_ interface{}) error {
 		if (cfg.EnableCommitAuthor || cfg.EnableGitHistoryAnalysis) && git.RepositoryIsShallow(cfg) {
 			logger.LogWarn(messages.MsgWarnGitRepositoryIsNotFullCloned)
@@ -76,7 +71,7 @@ func (au *UseCases) checkGitDepthClone(cfg *config.Config) validation.RuleFunc {
 	}
 }
 
-func (au *UseCases) checkIfExistsDuplicatedFalsePositiveHashes(cfg *config.Config) validation.RuleFunc {
+func validateDuplicatedFalsePositiveHashes(cfg *config.Config) validation.RuleFunc {
 	return func(value interface{}) error {
 		for _, falsePositive := range cfg.FalsePositiveHashes {
 			for _, riskAccept := range cfg.RiskAcceptHashes {
@@ -90,7 +85,7 @@ func (au *UseCases) checkIfExistsDuplicatedFalsePositiveHashes(cfg *config.Confi
 	}
 }
 
-func (au *UseCases) checkIfExistsDuplicatedRiskAcceptHashes(cfg *config.Config) validation.RuleFunc {
+func validateDuplicatedRiskAcceptHashes(cfg *config.Config) validation.RuleFunc {
 	return func(value interface{}) error {
 		for _, riskAccept := range cfg.RiskAcceptHashes {
 			for _, falsePositive := range cfg.FalsePositiveHashes {
@@ -104,55 +99,47 @@ func (au *UseCases) checkIfExistsDuplicatedRiskAcceptHashes(cfg *config.Config) 
 	}
 }
 
-func (au *UseCases) checkAndValidateJSONOutputFilePath(cfg *config.Config) validation.RuleFunc {
+func validateJSONOutputFilePath(cfg *config.Config) validation.RuleFunc {
 	return func(value interface{}) error {
 		switch cfg.PrintOutputType {
 		case outputtype.JSON, outputtype.SonarQube:
-			return au.validateFilePathAndExtension(cfg, ".json")
+			return validateFilePathAndExtension(cfg, ".json")
 		case outputtype.Text:
-			return au.validateTextOutputFilePath(cfg)
+			return validateTextOutputFilePath(cfg)
 		}
 		return nil
 	}
 }
 
-func (au *UseCases) validateTextOutputFilePath(cfg *config.Config) error {
+func validateTextOutputFilePath(cfg *config.Config) error {
 	if cfg.JSONOutputFilePath == "" {
 		return nil
 	}
-	return au.validateFilePathAndExtension(cfg, ".txt")
+	return validateFilePathAndExtension(cfg, ".txt")
 }
 
-func (au *UseCases) validateFilePathAndExtension(cfg *config.Config, extension string) error {
+func validateFilePathAndExtension(cfg *config.Config, extension string) error {
 	if filepath.Ext(cfg.JSONOutputFilePath) != extension {
 		return fmt.Errorf("%s %s", messages.MsgErrorJSONOutputFilePathNotValidExtension, extension)
 	}
 	return nil
 }
 
-func (au *UseCases) validationOutputTypes() validation.InRule {
-	return validation.In(
-		outputtype.JSON,
-		outputtype.SonarQube,
-		outputtype.Text,
-	)
-}
-
-func (au *UseCases) validationSeverities(cfg *config.Config) validation.RuleFunc {
+func validationSeverities(cfg *config.Config) validation.RuleFunc {
 	return func(value interface{}) error {
 		for idx := range cfg.SeveritiesToIgnore {
 			cfg.SeveritiesToIgnore[idx] = strings.TrimSpace(cfg.SeveritiesToIgnore[idx])
-			if !au.checkIfExistItemInSliceOfSeverity(cfg.SeveritiesToIgnore[idx]) {
+			if !checkIfExistItemInSliceOfSeverity(cfg.SeveritiesToIgnore[idx]) {
 				return fmt.Errorf("%s %s %v",
-					cfg.SeveritiesToIgnore[idx], messages.MsgErrorSeverityNotValid, au.sliceSeverityEnable())
+					cfg.SeveritiesToIgnore[idx], messages.MsgErrorSeverityNotValid, sliceSeverityEnable())
 			}
 		}
 		return nil
 	}
 }
 
-func (au *UseCases) checkIfExistItemInSliceOfSeverity(item string) bool {
-	for _, severityName := range au.sliceSeverityEnable() {
+func checkIfExistItemInSliceOfSeverity(item string) bool {
+	for _, severityName := range sliceSeverityEnable() {
 		if severityName.ToString() == item {
 			return true
 		}
@@ -160,7 +147,7 @@ func (au *UseCases) checkIfExistItemInSliceOfSeverity(item string) bool {
 	return false
 }
 
-func (au *UseCases) sliceSeverityEnable() []severities.Severity {
+func sliceSeverityEnable() []severities.Severity {
 	return []severities.Severity{
 		severities.Critical,
 		severities.High,
@@ -171,7 +158,7 @@ func (au *UseCases) sliceSeverityEnable() []severities.Severity {
 	}
 }
 
-func (au *UseCases) validateIfIsValidPath(dir string) validation.RuleFunc {
+func validateIfIsValidPath(dir string) validation.RuleFunc {
 	return func(value interface{}) error {
 		if _, errStat := os.Stat(dir); errStat != nil || dir == "" {
 			return fmt.Errorf("%s %s", messages.MsgErrorPathNotValid, dir)
@@ -180,24 +167,24 @@ func (au *UseCases) validateIfIsValidPath(dir string) validation.RuleFunc {
 	}
 }
 
-func (au *UseCases) validateCertPath(dir string) validation.RuleFunc {
+func validateCertPath(dir string) validation.RuleFunc {
 	if dir == "" {
 		return func(value interface{}) error {
 			return nil
 		}
 	}
 
-	return au.validateIfIsValidPath(dir)
+	return validateIfIsValidPath(dir)
 }
 
-func (au *UseCases) validateWorkDir(workDir *workdir.WorkDir, projectPath string) validation.RuleFunc {
+func validateWorkDir(workDir *workdir.WorkDir, projectPath string) validation.RuleFunc {
 	return func(value interface{}) error {
 		if workDir == nil {
 			return errors.New(messages.MsgErrorInvalidWorkDir)
 		}
 		for _, pathsByLanguage := range workDir.LanguagePaths() {
 			for _, projectSubPath := range pathsByLanguage {
-				err := au.validateIfExistPathInProjectToWorkDir(projectPath, projectSubPath)
+				err := validateIfExistPathInProjectToWorkDir(projectPath, projectSubPath)
 				if err != nil {
 					return err
 				}
@@ -207,7 +194,7 @@ func (au *UseCases) validateWorkDir(workDir *workdir.WorkDir, projectPath string
 	}
 }
 
-func (au *UseCases) validateIfExistPathInProjectToWorkDir(projectPath, internalPath string) error {
+func validateIfExistPathInProjectToWorkDir(projectPath, internalPath string) error {
 	projectPathAbs, _ := filepath.Abs(projectPath)
 	if internalPath != "" {
 		if _, err := os.Stat(path.Join(projectPathAbs, internalPath)); err != nil {
@@ -219,10 +206,10 @@ func (au *UseCases) validateIfExistPathInProjectToWorkDir(projectPath, internalP
 	return nil
 }
 
-func (au *UseCases) checkIfIsValidVulnerabilitiesTypes(cfg *config.Config) validation.RuleFunc {
+func validateVulnerabilitiesTypes(cfg *config.Config) validation.RuleFunc {
 	return func(value interface{}) error {
 		for _, vulnType := range cfg.ShowVulnerabilitiesTypes {
-			if !au.isVulnerabilityValid(strings.TrimSpace(vulnType)) {
+			if !isVulnerabilityValid(strings.TrimSpace(vulnType)) {
 				return fmt.Errorf("%s %s", messages.MsgVulnerabilityTypeToShowInvalid, vulnType)
 			}
 		}
@@ -230,7 +217,7 @@ func (au *UseCases) checkIfIsValidVulnerabilitiesTypes(cfg *config.Config) valid
 	}
 }
 
-func (au *UseCases) isVulnerabilityValid(vulnType string) bool {
+func isVulnerabilityValid(vulnType string) bool {
 	for _, valid := range vulnerability.Values() {
 		if strings.EqualFold(valid.ToString(), vulnType) {
 			return true
@@ -238,7 +225,7 @@ func (au *UseCases) isVulnerabilityValid(vulnType string) bool {
 	}
 	return false
 }
-func (au *UseCases) checkIfIsURL(rawURL string) validation.RuleFunc {
+func checkIfIsURL(rawURL string) validation.RuleFunc {
 	return func(value interface{}) error {
 		_, err := url.ParseRequestURI(rawURL)
 		if err != nil {

--- a/internal/usecases/cli/cli_test.go
+++ b/internal/usecases/cli/cli_test.go
@@ -33,13 +33,11 @@ import (
 )
 
 func TestValidateConfigs(t *testing.T) {
-	useCases := NewCLIUseCases()
-
 	t.Run("Should return no errors when valid", func(t *testing.T) {
 		cfg := config.New()
 		cfg.WorkDir = &workdir.WorkDir{}
 
-		err := useCases.ValidateConfig(cfg)
+		err := ValidateConfig(cfg)
 		assert.NoError(t, err)
 	})
 	t.Run("Should return no errors when is not valid path", func(t *testing.T) {
@@ -47,7 +45,7 @@ func TestValidateConfigs(t *testing.T) {
 		cfg.WorkDir = &workdir.WorkDir{}
 		cfg.ProjectPath = "./not-exist-path"
 
-		err := useCases.ValidateConfig(cfg)
+		err := ValidateConfig(cfg)
 		assert.Error(t, err)
 		assert.Equal(t, "project_path: invalid path: ./not-exist-path.", err.Error())
 	})
@@ -56,7 +54,7 @@ func TestValidateConfigs(t *testing.T) {
 		cfg.WorkDir = &workdir.WorkDir{}
 		cfg.SeveritiesToIgnore = []string{"LOW"}
 
-		err := useCases.ValidateConfig(cfg)
+		err := ValidateConfig(cfg)
 		assert.NoError(t, err)
 	})
 	t.Run("Should return error when invalid ignore value", func(t *testing.T) {
@@ -64,7 +62,7 @@ func TestValidateConfigs(t *testing.T) {
 		cfg.WorkDir = &workdir.WorkDir{}
 		cfg.SeveritiesToIgnore = []string{"test"}
 
-		err := useCases.ValidateConfig(cfg)
+		err := ValidateConfig(cfg)
 		assert.Error(t, err)
 		expected := "severities_to_ignore: test Type of severity not valid. See severities enable: [CRITICAL HIGH MEDIUM LOW UNKNOWN INFO]."
 		assert.Equal(t, expected, err.Error())
@@ -75,7 +73,7 @@ func TestValidateConfigs(t *testing.T) {
 		cfg.PrintOutputType = outputtype.JSON
 		cfg.JSONOutputFilePath = ""
 
-		err := useCases.ValidateConfig(cfg)
+		err := ValidateConfig(cfg)
 		assert.Error(t, err)
 		assert.Equal(t, "json_output_file_path: Output File path not valid file of type: .json.",
 			err.Error())
@@ -86,7 +84,7 @@ func TestValidateConfigs(t *testing.T) {
 		cfg.PrintOutputType = outputtype.JSON
 		cfg.JSONOutputFilePath = "test.test"
 
-		err := useCases.ValidateConfig(cfg)
+		err := ValidateConfig(cfg)
 		assert.Error(t, err)
 		assert.Equal(t, "json_output_file_path: Output File path not valid file of type: .json.",
 			err.Error())
@@ -98,7 +96,7 @@ func TestValidateConfigs(t *testing.T) {
 		cfg.PrintOutputType = outputtype.Text
 		cfg.JSONOutputFilePath = "test.test"
 
-		err := useCases.ValidateConfig(cfg)
+		err := ValidateConfig(cfg)
 		assert.Error(t, err)
 		assert.EqualError(t, err, "json_output_file_path: Output File path not valid file of type: .txt.")
 	})
@@ -113,13 +111,13 @@ func TestValidateConfigs(t *testing.T) {
 		cfg.PrintOutputType = (outputtype.Text)
 		cfg.JSONOutputFilePath = pathValid
 
-		err = useCases.ValidateConfig(cfg)
+		err = ValidateConfig(cfg)
 		assert.NoError(t, err)
 	})
 	t.Run("Should return error when invalid workdir", func(t *testing.T) {
 		cfg := &config.Config{}
 
-		err := useCases.ValidateConfig(cfg)
+		err := ValidateConfig(cfg)
 		assert.Error(t, err)
 	})
 	t.Run("Should return success because exists path in workdir", func(t *testing.T) {
@@ -136,7 +134,7 @@ func TestValidateConfigs(t *testing.T) {
 			HCL:        []string{},
 		}
 
-		err := useCases.ValidateConfig(cfg)
+		err := ValidateConfig(cfg)
 		assert.NoError(t, err)
 	})
 	t.Run("Should return error because not exists path in workdir", func(t *testing.T) {
@@ -156,7 +154,7 @@ func TestValidateConfigs(t *testing.T) {
 			},
 		}
 
-		err := useCases.ValidateConfig(cfg)
+		err := ValidateConfig(cfg)
 		assert.Error(t, err)
 
 		var vErrors validation.Errors
@@ -171,7 +169,7 @@ func TestValidateConfigs(t *testing.T) {
 		cfg := config.New()
 		cfg.CertPath = "INVALID PATH"
 
-		err := useCases.ValidateConfig(cfg)
+		err := ValidateConfig(cfg)
 		assert.Error(t, err)
 		assert.Equal(t, "cert_path: invalid path: INVALID PATH.", err.Error())
 	})
@@ -181,7 +179,7 @@ func TestValidateConfigs(t *testing.T) {
 		cfg.FalsePositiveHashes = []string{hash}
 		cfg.RiskAcceptHashes = []string{hash}
 
-		err := useCases.ValidateConfig(cfg)
+		err := ValidateConfig(cfg)
 		expected := "false_positive_hashes: False positive is not valid because is duplicated in risk accept:1e836029-4e90-4151-bb4a-d86ef47f96b6; risk_accept_hashes: Risk Accept is not valid because is duplicated in false positive: 1e836029-4e90-4151-bb4a-d86ef47f96b6."
 		assert.Equal(t, expected, err.Error())
 	})
@@ -190,7 +188,7 @@ func TestValidateConfigs(t *testing.T) {
 		cfg.FalsePositiveHashes = []string{"1e836029-4e90-4151-bb4a-d86ef47f96b6"}
 		cfg.RiskAcceptHashes = []string{"c0d0c85c-8597-49c4-b4fa-b92ecad2a991"}
 
-		err := useCases.ValidateConfig(cfg)
+		err := ValidateConfig(cfg)
 		assert.NoError(t, err)
 	})
 }


### PR DESCRIPTION
This commit remove an unnecessary empty `UseCases` struct and change
their methods to functions and change the references to this struct to
call the public function directly.

Some private functions from this package was renamed to have consistency
between all of them.

Removing this struct we also remove an unnecessary heap allocation since
the `NewCLIUseCases()` function return a pointer to this struct.

The heap allocation was noticed using the
github.com/jordanlewis/gcassert using the `gcassert:noescape` directive
on cmd/app/start/start.go:68:

```
gcassert ./cmd/app/start/
cmd/app/start/start.go:75:useCases: cli.NewCLIUseCases(): &cli.UseCases{} escapes to heap:
```

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
