### PR TITLE
printresults: fix wrong filepath when using --container-bind-project-path

### DIFF
--- a/internal/controllers/printresults/print_results.go
+++ b/internal/controllers/printresults/print_results.go
@@ -293,7 +293,7 @@ func (pr *PrintResults) printTextOutputVulnerabilityData(vulnerability *vulnerab
 	pr.printlnf("Column: %s", vulnerability.Column)
 	pr.printlnf("SecurityTool: %s", vulnerability.SecurityTool)
 	pr.printlnf("Confidence: %s", vulnerability.Confidence)
-	pr.printlnf("File: %s", pr.getProjectPath(vulnerability.File))
+	pr.printlnf("File: %s", pr.getFilePath(vulnerability.File))
 	pr.printlnf("Code: %s", vulnerability.Code)
 	if vulnerability.RuleID != "" {
 		pr.printlnf("RuleID: %s", vulnerability.RuleID)
@@ -375,16 +375,16 @@ func (pr *PrintResults) logSeparator(isToShow bool) {
 	}
 }
 
-func (pr *PrintResults) getProjectPath(path string) string {
+func (pr *PrintResults) getFilePath(path string) string {
 	if strings.Contains(path, pr.config.ProjectPath) {
 		return path
 	}
 
 	if pr.config.ContainerBindProjectPath != "" {
-		return fmt.Sprintf("%s/%s", pr.config.ContainerBindProjectPath, path)
+		return filepath.Join(pr.config.ContainerBindProjectPath, path)
 	}
 
-	return fmt.Sprintf("%s/%s", pr.config.ProjectPath, path)
+	return filepath.Join(pr.config.ProjectPath, path)
 }
 
 func (pr *PrintResults) printlnf(text string, args ...interface{}) {

--- a/internal/controllers/printresults/print_results_test.go
+++ b/internal/controllers/printresults/print_results_test.go
@@ -16,6 +16,7 @@ package printresults
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -35,6 +36,7 @@ import (
 	"github.com/ZupIT/horusec/internal/enums/outputtype"
 	"github.com/ZupIT/horusec/internal/helpers/messages"
 	"github.com/ZupIT/horusec/internal/utils/mock"
+	"github.com/ZupIT/horusec/internal/utils/testutil"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -207,6 +209,20 @@ func TestPrintResultsStartPrintResults(t *testing.T) {
 				for _, line := range strings.Split(expectedTextResult, "\n") {
 					assert.Contains(t, output, line)
 				}
+			},
+		},
+		{
+			name: "Should print correct path when using ContainerBindProjectPath",
+			cfg: config.Config{
+				StartOptions: config.StartOptions{
+					ContainerBindProjectPath: os.TempDir(),
+					ProjectPath:              testutil.JavaScriptExample1,
+				},
+			},
+			analysis:        *mock.CreateAnalysisMock(),
+			vulnerabilities: 11,
+			outputs: []string{
+				fmt.Sprintf("File: %s", filepath.Join(os.TempDir(), "cert.pem")),
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
