### PR TITLE
flawfinder:chore - improve tests asserts and code cleaning

### DIFF
--- a/internal/services/formatters/c/flawfinder/formatter_test.go
+++ b/internal/services/formatters/c/flawfinder/formatter_test.go
@@ -18,110 +18,142 @@ import (
 	"bytes"
 	"encoding/csv"
 	"errors"
+	"path/filepath"
 	"testing"
 
-	entitiesAnalysis "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
+	"github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
+	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
+	"github.com/ZupIT/horusec-devkit/pkg/enums/severities"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
-	cliConfig "github.com/ZupIT/horusec/config"
+	"github.com/ZupIT/horusec/config"
 	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
-	"github.com/ZupIT/horusec/internal/entities/workdir"
 	"github.com/ZupIT/horusec/internal/services/formatters"
 	"github.com/ZupIT/horusec/internal/utils/testutil"
 )
 
-func getCsvString() string {
-	pairs := [][]string{
-		{"File", "./test.c"},
-		{"Line", "16"},
-		{"Column", "9"},
-		{"Level", "5"},
-		{"Category", "4"},
-		{"Name", "test"},
-		{"Warning", "test"},
-		{"Suggestion", "test"},
-		{"Note", "test"},
-		{"CWEs", "test"},
-		{"Context", "test"},
-		{"Fingerprint", "test"},
-	}
-
-	buffer := new(bytes.Buffer)
-	writer := csv.NewWriter(buffer)
-
-	_ = writer.WriteAll(pairs)
-	return buffer.String()
-}
-
 func TestStartCFlawfinder(t *testing.T) {
-	t.Run("should success execute container and process output", func(t *testing.T) {
+	t.Run("should run analysis successfully when output is empty", func(t *testing.T) {
+		analysis := new(analysis.Analysis)
+
+		cfg := config.New()
+
+		output := csvOutput(t, cfg.ProjectPath)
+
 		dockerAPIControllerMock := testutil.NewDockerMock()
-		analysis := &entitiesAnalysis.Analysis{}
-		config := &cliConfig.Config{}
-		config.WorkDir = &workdir.WorkDir{}
-
-		output := getCsvString()
-
 		dockerAPIControllerMock.On("CreateLanguageAnalysisContainer").Return(output, nil)
 
-		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, config)
+		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, cfg)
 		formatter := NewFormatter(service)
 
 		formatter.StartAnalysis("")
 
-		assert.NotEmpty(t, analysis)
-		assert.Len(t, analysis.AnalysisVulnerabilities, 11)
+		require.Len(t, analysis.AnalysisVulnerabilities, 1)
+
+		vuln := analysis.AnalysisVulnerabilities[0].Vulnerability
+
+		assert.Equal(t, tools.Flawfinder, vuln.SecurityTool, "Expected flawfinder as security tool")
+		assert.Equal(t, languages.C, vuln.Language, "Expected C as vulnerability language")
+		assert.Equal(t, severities.Critical, vuln.Severity, "Exected critial as vulnerability severity")
+		assert.Equal(t, "waring suggestion note", vuln.Details, "Exected equals vulnerability details")
+		assert.Equal(t, "16", vuln.Line, "Exected equals vulnerability line")
+		assert.Equal(t, "9", vuln.Column, "Exected equals vulnerability column")
+		assert.Equal(
+			t,
+			`char BOM[4] = {(char)0xEF, (char)0xBB, (char)0xBF, '\0'};`,
+			vuln.Code,
+			"Exected equals vulnerability code",
+		)
+		assert.Equal(t, filepath.Join(cfg.ProjectPath, "test.c"), vuln.File)
 	})
 
-	t.Run("should return error when invalid output", func(t *testing.T) {
+	t.Run("should add error on analysis when invalid output", func(t *testing.T) {
+		analysis := new(analysis.Analysis)
+
+		cfg := config.New()
+
 		dockerAPIControllerMock := testutil.NewDockerMock()
-		analysis := &entitiesAnalysis.Analysis{}
-		config := &cliConfig.Config{}
-		config.WorkDir = &workdir.WorkDir{}
+		dockerAPIControllerMock.On("CreateLanguageAnalysisContainer").Return("", nil)
 
-		output := ""
-
-		dockerAPIControllerMock.On("CreateLanguageAnalysisContainer").Return(output, nil)
-
-		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, config)
+		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, cfg)
 		formatter := NewFormatter(service)
 
-		assert.NotPanics(t, func() {
-			formatter.StartAnalysis("")
-		})
+		formatter.StartAnalysis("")
+
+		assert.True(t, analysis.HasErrors(), "Expected errors on analysis")
 	})
 
-	t.Run("should return error when executing container", func(t *testing.T) {
-		dockerAPIControllerMock := testutil.NewDockerMock()
-		analysis := &entitiesAnalysis.Analysis{}
-		config := &cliConfig.Config{}
-		config.WorkDir = &workdir.WorkDir{}
+	t.Run("should run analysis and add error from Docker on Analysis", func(t *testing.T) {
+		analysis := new(analysis.Analysis)
 
+		cfg := config.New()
+
+		dockerAPIControllerMock := testutil.NewDockerMock()
 		dockerAPIControllerMock.On("CreateLanguageAnalysisContainer").Return("", errors.New("test"))
 
-		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, config)
+		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, cfg)
 		formatter := NewFormatter(service)
 
-		assert.NotPanics(t, func() {
-			formatter.StartAnalysis("")
-		})
+		formatter.StartAnalysis("")
+
+		assert.True(t, analysis.HasErrors(), "Expected errors on analysis")
 	})
 
 	t.Run("Should not execute tool because it's ignored", func(t *testing.T) {
-		analysis := &entitiesAnalysis.Analysis{}
 		dockerAPIControllerMock := testutil.NewDockerMock()
-		config := &cliConfig.Config{}
-		config.WorkDir = &workdir.WorkDir{}
+
+		config := config.New()
 		config.ToolsConfig = toolsconfig.ToolsConfig{
 			tools.Flawfinder: toolsconfig.Config{
 				IsToIgnore: true,
 			},
 		}
 
-		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, config)
+		service := formatters.NewFormatterService(new(analysis.Analysis), dockerAPIControllerMock, config)
 		formatter := NewFormatter(service)
 
 		formatter.StartAnalysis("")
 	})
+}
+
+func csvOutput(t *testing.T, basePath string) string {
+	pairs := [][]string{
+		{
+			"File",
+			"Line",
+			"Column",
+			"Level",
+			"Category",
+			"Name",
+			"Warning",
+			"Suggestion",
+			"Note",
+			"CWEs",
+			"Context",
+			"Fingerprint",
+		},
+		{
+			filepath.Join(basePath, "test.c"), // File
+			"16",                              // Line
+			"9",                               // Column
+			"5",                               // Level
+			"4",                               // Category
+			"char",                            // Name
+			"waring",                          // Warning
+			"suggestion",                      // Suggestion
+			"note",                            // Note
+			"CWE-123",                         // CWEs
+			`char BOM[4] = {(char)0xEF, (char)0xBB, (char)0xBF, '\0'};`, // Context
+			"fingerprint", // Fingerprint
+		},
+	}
+
+	buffer := bytes.NewBufferString("")
+	writer := csv.NewWriter(buffer)
+
+	require.NoError(t, writer.WriteAll(pairs), "Expected no errors to create csv mock")
+
+	return buffer.String()
 }

--- a/internal/services/formatters/c/flawfinder/result.go
+++ b/internal/services/formatters/c/flawfinder/result.go
@@ -12,17 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package entities
+package flawfinder
 
 import (
 	"fmt"
+	"path/filepath"
 	"strconv"
-	"strings"
 
 	"github.com/ZupIT/horusec-devkit/pkg/enums/severities"
 )
 
-type Result struct {
+type flawFinderResult struct {
 	File       string `json:"file"`
 	Line       string `json:"line"`
 	Column     string `json:"column"`
@@ -33,16 +33,16 @@ type Result struct {
 	Context    string `json:"context"`
 }
 
-func (r *Result) GetDetails() string {
+func (r *flawFinderResult) getDetails() string {
 	return fmt.Sprintf("%s %s %s", r.Warning, r.Suggestion, r.Note)
 }
 
-func (r *Result) GetSeverity() severities.Severity {
+func (r *flawFinderResult) getSeverity() severities.Severity {
 	level, _ := strconv.Atoi(r.Level)
 	return r.mapSeverityByLevels()[level]
 }
 
-func (r *Result) mapSeverityByLevels() map[int]severities.Severity {
+func (r *flawFinderResult) mapSeverityByLevels() map[int]severities.Severity {
 	return map[int]severities.Severity{
 		5: severities.Critical,
 		4: severities.High,
@@ -53,6 +53,6 @@ func (r *Result) mapSeverityByLevels() map[int]severities.Severity {
 	}
 }
 
-func (r *Result) GetFilename() string {
-	return strings.ReplaceAll(r.File, "./", "")
+func (r *flawFinderResult) getFilename() string {
+	return filepath.Clean(r.File)
 }

--- a/internal/services/formatters/c/flawfinder/result_test.go
+++ b/internal/services/formatters/c/flawfinder/result_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package entities
+package flawfinder
 
 import (
 	"testing"
@@ -22,14 +22,14 @@ import (
 )
 
 func TestGetDetails(t *testing.T) {
-	result := &Result{
+	result := &flawFinderResult{
 		Warning:    "test",
 		Suggestion: "test",
 		Note:       "test",
 	}
 
 	t.Run("should success get details", func(t *testing.T) {
-		details := result.GetDetails()
+		details := result.getDetails()
 
 		assert.NotEmpty(t, details)
 		assert.Equal(t, "test test test", details)
@@ -37,46 +37,46 @@ func TestGetDetails(t *testing.T) {
 }
 
 func TestGetSeverity(t *testing.T) {
-	result := &Result{
+	result := &flawFinderResult{
 		Level: "0",
 	}
 
 	t.Run("should get severities low", func(t *testing.T) {
-		assert.Equal(t, severities.Low, result.GetSeverity())
+		assert.Equal(t, severities.Low, result.getSeverity())
 
 		result.Level = "0"
-		assert.Equal(t, severities.Low, result.GetSeverity())
+		assert.Equal(t, severities.Low, result.getSeverity())
 
 		result.Level = "1"
-		assert.Equal(t, severities.Low, result.GetSeverity())
+		assert.Equal(t, severities.Low, result.getSeverity())
 	})
 
 	t.Run("should get severities medium", func(t *testing.T) {
 		result.Level = "2"
-		assert.Equal(t, severities.Medium, result.GetSeverity())
+		assert.Equal(t, severities.Medium, result.getSeverity())
 
 		result.Level = "3"
-		assert.Equal(t, severities.Medium, result.GetSeverity())
+		assert.Equal(t, severities.Medium, result.getSeverity())
 	})
 
 	t.Run("should get severities high", func(t *testing.T) {
 		result.Level = "4"
-		assert.Equal(t, severities.High, result.GetSeverity())
+		assert.Equal(t, severities.High, result.getSeverity())
 	})
 
 	t.Run("should get severities critical", func(t *testing.T) {
 		result.Level = "5"
-		assert.Equal(t, severities.Critical, result.GetSeverity())
+		assert.Equal(t, severities.Critical, result.getSeverity())
 	})
 }
 
 func TestGetFilename(t *testing.T) {
-	result := &Result{
+	result := &flawFinderResult{
 		File: "./test.c",
 	}
 
 	t.Run("should success get filename", func(t *testing.T) {
-		filename := result.GetFilename()
+		filename := result.getFilename()
 
 		assert.NotEmpty(t, filename)
 		assert.NotContains(t, filename, "./")


### PR DESCRIPTION
Improves the test cases of errors to verify that errors were actually
added to the analysis. Some asserts was also added on success tests to
verify that the parsing is correctly and all fields is filled.

This commit also move schema definition of flawfinder results from
flawfinder/entities to flawfinder package and make them private.

Finally some code organization was made and redundant code was removed.

Updates #718

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
