### PR TITLE
auto-format/chore - running auto format makefile command

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,7 +23,7 @@ linters-settings:
     lines: 15
     statements: 10
   gci:
-    local-prefixes: github.com/ZupIT/horusec
+    local-prefixes: github.com/ZupIT/horusec/
   goconst:
     min-len: 2
     min-occurrences: 2
@@ -44,7 +44,7 @@ linters-settings:
   gocyclo:
     min-complexity: 5
   goimports:
-    local-prefixes: github.com/ZupIT/horusec
+    local-prefixes: github.com/ZupIT/horusec/
   golint:
     min-confidence: 0
   gomnd:

--- a/cmd/app/generate/generate.go
+++ b/cmd/app/generate/generate.go
@@ -18,9 +18,9 @@ import (
 	"encoding/json"
 	"os"
 
+	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
 	"github.com/spf13/cobra"
 
-	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
 	"github.com/ZupIT/horusec/config"
 	"github.com/ZupIT/horusec/internal/helpers/messages"
 )
@@ -75,7 +75,7 @@ func (g *Generate) createAndOpenFile() (outputFile *os.File, err error) {
 	if _, err = os.Create(g.configs.ConfigFilePath); err != nil {
 		return nil, err
 	}
-	outputFile, err = os.OpenFile(g.configs.ConfigFilePath, os.O_CREATE|os.O_WRONLY, 0600)
+	outputFile, err = os.OpenFile(g.configs.ConfigFilePath, os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +91,7 @@ func (g *Generate) writeConfigOnFile(outputFile *os.File) error {
 
 //nolint:gomnd // magic number
 func (g *Generate) readFileAndCreateNewKeys() error {
-	configFile, err := os.OpenFile(g.configs.ConfigFilePath, os.O_CREATE|os.O_WRONLY, 0600)
+	configFile, err := os.OpenFile(g.configs.ConfigFilePath, os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
 		logger.LogError(messages.MsgErrorErrorOnReadConfigFile+g.configs.ConfigFilePath, err)
 		return err

--- a/cmd/app/generate/generate_test.go
+++ b/cmd/app/generate/generate_test.go
@@ -31,7 +31,7 @@ import (
 
 func TestMain(m *testing.M) {
 	_ = os.RemoveAll("./tmp")
-	_ = os.MkdirAll("./tmp", 0750)
+	_ = os.MkdirAll("./tmp", 0o750)
 	code := m.Run()
 	_ = os.RemoveAll("./tmp")
 	os.Exit(code)
@@ -67,7 +67,7 @@ func TestGenerate_CreateCobraCmd(t *testing.T) {
 		// Create existing file and write empry object
 		_, err := os.Create(configs.ConfigFilePath)
 		assert.NoError(t, err)
-		fileExisting, err := os.OpenFile(configs.ConfigFilePath, os.O_CREATE|os.O_WRONLY, 0600)
+		fileExisting, err := os.OpenFile(configs.ConfigFilePath, os.O_CREATE|os.O_WRONLY, 0o600)
 		assert.NoError(t, err)
 		_, err = fileExisting.Write([]byte("{}"))
 		assert.NoError(t, err)

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -17,10 +17,10 @@ package main
 import (
 	"os"
 
-	"github.com/spf13/cobra"
-
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
 	engine "github.com/ZupIT/horusec-engine"
+	"github.com/spf13/cobra"
+
 	"github.com/ZupIT/horusec/cmd/app/generate"
 	"github.com/ZupIT/horusec/cmd/app/start"
 	"github.com/ZupIT/horusec/cmd/app/version"

--- a/cmd/app/start/start.go
+++ b/cmd/app/start/start.go
@@ -20,17 +20,15 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ZupIT/horusec/internal/controllers/requirements"
-	usecases "github.com/ZupIT/horusec/internal/usecases/cli"
+	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
+	"github.com/spf13/cobra"
 
 	"github.com/ZupIT/horusec/config"
 	"github.com/ZupIT/horusec/config/dist"
-	"github.com/ZupIT/horusec/internal/helpers/messages"
-
-	"github.com/spf13/cobra"
-
-	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
 	"github.com/ZupIT/horusec/internal/controllers/analyzer"
+	"github.com/ZupIT/horusec/internal/controllers/requirements"
+	"github.com/ZupIT/horusec/internal/helpers/messages"
+	usecases "github.com/ZupIT/horusec/internal/usecases/cli"
 	"github.com/ZupIT/horusec/internal/utils/prompt"
 )
 

--- a/cmd/app/start/start_test.go
+++ b/cmd/app/start/start_test.go
@@ -22,17 +22,14 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/spf13/pflag"
-
-	"github.com/ZupIT/horusec/internal/utils/testutil"
-
 	"github.com/google/uuid"
-
+	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/ZupIT/horusec/config"
 	"github.com/ZupIT/horusec/internal/entities/workdir"
 	"github.com/ZupIT/horusec/internal/utils/copy"
+	"github.com/ZupIT/horusec/internal/utils/testutil"
 )
 
 var tmpPath, _ = filepath.Abs("tmp")
@@ -174,7 +171,6 @@ func TestStartCommand_ExecuteUnitTests(t *testing.T) {
 				analyzer.On("Analyze").Return(0, nil)
 				requirements.On("ValidateDocker")
 				requirements.On("ValidateGit")
-
 			},
 			assertFn: func(t *testing.T, prompt *testutil.PromptMock, requirements *testutil.RequirementsMock, analyzer *testutil.AnalyzerMock, cfg *config.Config) {
 				assert.True(t, cfg.ReturnErrorIfFoundVulnerability)
@@ -376,7 +372,6 @@ func TestStartCommand_ExecuteUnitTests(t *testing.T) {
 			args: []string{testutil.StartFlagProjectPath, testutil.RootPath, testutil.StartFlagIgnoreSeverity, "CRITICAL, LOW"},
 			err:  false,
 			onFn: func(prompt *testutil.PromptMock, requirements *testutil.RequirementsMock, analyzer *testutil.AnalyzerMock) {
-
 				analyzer.On("Analyze").Return(0, nil)
 				prompt.On("Ask").Return("Y", nil)
 				requirements.On("ValidateDocker")
@@ -549,6 +544,7 @@ func TestStartCommand_ExecuteUnitTests(t *testing.T) {
 		})
 	}
 }
+
 func TestStartCommand_ExecuteIntegrationTest(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
@@ -586,7 +582,8 @@ func TestStartCommand_ExecuteIntegrationTest(t *testing.T) {
 		cobraCmd.SetArgs([]string{
 			testutil.StartFlagProjectPath, ".",
 			testutil.StartFlagOutputFormat, "json",
-			testutil.StartFlagJSONOutputFilePath, outputPathJSON})
+			testutil.StartFlagJSONOutputFilePath, outputPathJSON,
+		})
 
 		assert.NoError(t, cobraCmd.Execute())
 		err := w.Close()
@@ -864,6 +861,7 @@ func TestStartCommand_ExecuteIntegrationTest(t *testing.T) {
 		assert.NoError(t, os.RemoveAll(dstProject))
 	})
 }
+
 func getMocksAndStartStruct() (*testutil.PromptMock, *config.Config, *testutil.RequirementsMock, *testutil.AnalyzerMock, *Start) {
 	promptMock := testutil.NewPromptMock()
 

--- a/cmd/app/version/version.go
+++ b/cmd/app/version/version.go
@@ -15,9 +15,8 @@
 package version
 
 import (
-	"github.com/spf13/cobra"
-
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
+	"github.com/spf13/cobra"
 
 	"github.com/ZupIT/horusec/config/dist"
 )

--- a/config/config.go
+++ b/config/config.go
@@ -22,23 +22,21 @@ import (
 	"strings"
 	"time"
 
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-
 	"github.com/ZupIT/horusec-devkit/pkg/enums/vulnerability"
 	"github.com/ZupIT/horusec-devkit/pkg/utils/env"
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
-	customimages "github.com/ZupIT/horusec/internal/entities/custom_images"
-	"github.com/ZupIT/horusec/internal/helpers/messages"
-
 	"github.com/google/uuid"
 	"github.com/iancoleman/strcase"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/ZupIT/horusec/cmd/app/version"
 	"github.com/ZupIT/horusec/config/dist"
+	customimages "github.com/ZupIT/horusec/internal/entities/custom_images"
 	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
 	"github.com/ZupIT/horusec/internal/entities/workdir"
+	"github.com/ZupIT/horusec/internal/helpers/messages"
 	jsonutils "github.com/ZupIT/horusec/internal/utils/json"
 	"github.com/ZupIT/horusec/internal/utils/valueordefault"
 )

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -24,14 +24,13 @@ import (
 	"testing"
 
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
+	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/vulnerability"
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
-
 	"github.com/google/uuid"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 	"github.com/ZupIT/horusec/cmd/app/start"
 	"github.com/ZupIT/horusec/config"
 	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
@@ -40,7 +39,7 @@ import (
 
 func TestMain(m *testing.M) {
 	_ = os.RemoveAll("./tmp")
-	_ = os.MkdirAll("./tmp", 0750)
+	_ = os.MkdirAll("./tmp", 0o750)
 	code := m.Run()
 	_ = os.RemoveAll("./tmp")
 	os.Exit(code)
@@ -384,7 +383,6 @@ func TestNewHorusecConfig(t *testing.T) {
 		assert.Equal(t, "repository-name-test", configs.RepositoryName)
 		assert.Equal(t, int64(123), configs.TimeoutInSecondsRequest)
 		assert.Equal(t, true, configs.ReturnErrorIfFoundVulnerability)
-
 	})
 }
 

--- a/config/dist/dist.go
+++ b/config/dist/dist.go
@@ -16,9 +16,7 @@ package dist
 
 const False = "false"
 
-var (
-	standAlone string = False
-)
+var standAlone string = False
 
 func IsStandAlone() bool {
 	return standAlone != False

--- a/e2e/analysis/analysis_suite_test.go
+++ b/e2e/analysis/analysis_suite_test.go
@@ -17,9 +17,8 @@ package analysis_test
 import (
 	"testing"
 
-	ginkgoconfig "github.com/onsi/ginkgo/config"
-
 	. "github.com/onsi/ginkgo"
+	ginkgoconfig "github.com/onsi/ginkgo/config"
 	. "github.com/onsi/gomega"
 )
 

--- a/e2e/analysis/analysis_test.go
+++ b/e2e/analysis/analysis_test.go
@@ -24,21 +24,22 @@ import (
 	"time"
 
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
-
+	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
 	"github.com/ZupIT/horusec/config"
 	"github.com/ZupIT/horusec/e2e/analysis"
 	customimages "github.com/ZupIT/horusec/internal/entities/custom_images"
 	"github.com/ZupIT/horusec/internal/utils/testutil"
 )
 
-const isWindows = runtime.GOOS == "windows"
-const isDarwin = runtime.GOOS == "darwin"
-const horusecConfigName = "horusec-config.json"
+const (
+	isWindows         = runtime.GOOS == "windows"
+	isDarwin          = runtime.GOOS == "darwin"
+	horusecConfigName = "horusec-config.json"
+)
 
 var _ = Describe("Run a complete horusec analysis when build tools locally", func() {
 	tmpDir := CreateHorusecConfigAndReturnTMPDirectory()

--- a/e2e/analysis/test_case.go
+++ b/e2e/analysis/test_case.go
@@ -19,15 +19,13 @@ import (
 	"runtime"
 
 	"github.com/ZupIT/horusec-devkit/pkg/enums/analysis"
-	"github.com/ZupIT/horusec/internal/helpers/messages"
-
-	"github.com/onsi/gomega/gexec"
-
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
-	"github.com/ZupIT/horusec/internal/utils/testutil"
-
 	. "github.com/onsi/ginkgo"
+	"github.com/onsi/gomega/gexec"
+
+	"github.com/ZupIT/horusec/internal/helpers/messages"
+	"github.com/ZupIT/horusec/internal/utils/testutil"
 )
 
 // Expected struct represents the validations that will be expected when comparing the final results of the analysis
@@ -101,7 +99,7 @@ func NewTestCase() []*TestCase {
 					fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.NpmAudit),
 					fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.YarnAudit),
 					// TODO: This log show only if pass --enable-git-history, we can see if this tool was runned or not without this flag
-					//fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.GitLeaks),
+					// fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.GitLeaks),
 					fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.TfSec),
 					fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.Checkov),
 					fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.Semgrep),
@@ -110,10 +108,10 @@ func NewTestCase() []*TestCase {
 					fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.MixAudit),
 					fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.Sobelow),
 					// TODO: This log show only if pass --enable-shellcheck, we can see if this tool was runned or not without this flag
-					//fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.ShellCheck),
+					// fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.ShellCheck),
 					fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.BundlerAudit),
 					// TODO: This log show only if pass --enable-owasp-dependency-check, we can see if this tool was runned or not without this flag
-					//fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.OwaspDependencyCheck),
+					// fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.OwaspDependencyCheck),
 					fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.DotnetCli),
 					fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.Nancy),
 					fmt.Sprintf("{HORUSEC_CLI} The tool was ignored for run in this analysis: %s", tools.Trivy),

--- a/e2e/commands/generate/generate_suite_test.go
+++ b/e2e/commands/generate/generate_suite_test.go
@@ -24,5 +24,4 @@ import (
 func TestGenerate(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Command generate suite")
-
 }

--- a/e2e/commands/start/start_test.go
+++ b/e2e/commands/start/start_test.go
@@ -19,16 +19,15 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/ZupIT/horusec-devkit/pkg/enums/severities"
+	"github.com/ZupIT/horusec-devkit/pkg/enums/vulnerability"
+	"github.com/ZupIT/horusec-devkit/pkg/utils/logger/enums"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
 
-	"github.com/ZupIT/horusec-devkit/pkg/enums/vulnerability"
-	"github.com/ZupIT/horusec-devkit/pkg/utils/logger/enums"
 	"github.com/ZupIT/horusec/internal/enums/outputtype"
-
-	"github.com/ZupIT/horusec-devkit/pkg/enums/severities"
 	"github.com/ZupIT/horusec/internal/utils/testutil"
 )
 
@@ -84,7 +83,7 @@ var _ = Describe("running binary Horusec with start parameter", func() {
 	})
 
 	When("global flag --log-file-path is passed", func() {
-		var logFilePathToTest = filepath.Join(os.TempDir(), fmt.Sprintf("%s-test.txt", uuid.New()))
+		logFilePathToTest := filepath.Join(os.TempDir(), fmt.Sprintf("%s-test.txt", uuid.New()))
 
 		BeforeEach(func() {
 			flags = map[string]string{
@@ -354,7 +353,6 @@ var _ = Describe("running binary Horusec with start parameter", func() {
 
 		It("Checks if the monitor retry count property was set.", func() {
 			Expect(session.Out.Contents()).To(ContainSubstring(fmt.Sprintf(`"monitor_retry_in_seconds\": %s`, monitorRetryCount)))
-
 		})
 	})
 

--- a/e2e/commands/version/version_suite_test.go
+++ b/e2e/commands/version/version_suite_test.go
@@ -24,5 +24,4 @@ import (
 func TestVersion(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Command version suite")
-
 }

--- a/internal/controllers/analyzer/analyzer.go
+++ b/internal/controllers/analyzer/analyzer.go
@@ -17,18 +17,13 @@ package analyzer
 import (
 	"fmt"
 	"io"
-	"path/filepath"
-
 	"log"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/briandowns/spinner"
-	"github.com/google/uuid"
-	"github.com/sirupsen/logrus"
 
 	"github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
 	"github.com/ZupIT/horusec-devkit/pkg/entities/vulnerability"
@@ -38,6 +33,9 @@ import (
 	"github.com/ZupIT/horusec-devkit/pkg/enums/severities"
 	enumsVulnerability "github.com/ZupIT/horusec-devkit/pkg/enums/vulnerability"
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
+	"github.com/briandowns/spinner"
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
 
 	"github.com/ZupIT/horusec/config"
 	languagedetect "github.com/ZupIT/horusec/internal/controllers/language_detect"
@@ -183,6 +181,7 @@ func (a *Analyzer) runAnalysis() (totalVulns int, err error) {
 	}
 	return a.startPrintResults()
 }
+
 func (a *Analyzer) startPrintResults() (int, error) {
 	a.formatAnalysisToPrint()
 	a.printController.SetAnalysis(a.analysis)

--- a/internal/controllers/analyzer/analyzer_test.go
+++ b/internal/controllers/analyzer/analyzer_test.go
@@ -25,29 +25,24 @@ import (
 	"os"
 	"testing"
 
-	"github.com/ZupIT/horusec/internal/utils/testutil"
-
-	"github.com/ZupIT/horusec-devkit/pkg/entities/cli"
-
-	"github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
 	entitiesAnalysis "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
+	"github.com/ZupIT/horusec-devkit/pkg/entities/cli"
 	"github.com/ZupIT/horusec-devkit/pkg/entities/vulnerability"
+	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
 	vulnerabilityenum "github.com/ZupIT/horusec-devkit/pkg/enums/vulnerability"
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
-	vulnhash "github.com/ZupIT/horusec/internal/utils/vuln_hash"
-
-	"github.com/ZupIT/horusec/internal/entities/workdir"
-
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
 	"github.com/ZupIT/horusec/config"
+	"github.com/ZupIT/horusec/internal/entities/workdir"
 	"github.com/ZupIT/horusec/internal/services/docker"
 	"github.com/ZupIT/horusec/internal/services/formatters"
+	"github.com/ZupIT/horusec/internal/utils/testutil"
+	vulnhash "github.com/ZupIT/horusec/internal/utils/vuln_hash"
 )
 
 func BenchmarkAnalyzerAnalyze(b *testing.B) {
@@ -117,7 +112,7 @@ func TestAnalyzerSetFalsePositivesAndRiskAcceptInVulnerabilities(t *testing.T) {
 			analyzer := NewAnalyzer(config.New())
 
 			analyzer.analysis.AnalysisVulnerabilities = append(
-				analyzer.analysis.AnalysisVulnerabilities, analysis.AnalysisVulnerabilities{
+				analyzer.analysis.AnalysisVulnerabilities, entitiesAnalysis.AnalysisVulnerabilities{
 					AnalysisID:    uuid.New(),
 					Vulnerability: tt.vulnerability,
 				},
@@ -142,7 +137,6 @@ func TestAnalyzerSetFalsePositivesAndRiskAcceptInVulnerabilities(t *testing.T) {
 			for _, vuln := range analyzer.analysis.AnalysisVulnerabilities {
 				assert.Equal(t, tt.expectedType, vuln.Vulnerability.Type)
 			}
-
 		})
 	}
 }

--- a/internal/controllers/language_detect/language_detect.go
+++ b/internal/controllers/language_detect/language_detect.go
@@ -22,12 +22,12 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
+	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
 	doubleStar "github.com/bmatcuk/doublestar/v4"
 	"github.com/go-enry/go-enry/v2"
 	"github.com/google/uuid"
 
-	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
-	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
 	"github.com/ZupIT/horusec/config"
 	"github.com/ZupIT/horusec/internal/enums/toignore"
 	"github.com/ZupIT/horusec/internal/helpers/messages"

--- a/internal/controllers/language_detect/language_detect_test.go
+++ b/internal/controllers/language_detect/language_detect_test.go
@@ -22,20 +22,16 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
-	"github.com/ZupIT/horusec/internal/enums/toignore"
-	"github.com/ZupIT/horusec/internal/helpers/messages"
-
 	"github.com/google/uuid"
-
-	"github.com/ZupIT/horusec/internal/utils/testutil"
-
-	"github.com/ZupIT/horusec/internal/utils/copy"
-
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
 	"github.com/ZupIT/horusec/config"
+	"github.com/ZupIT/horusec/internal/enums/toignore"
+	"github.com/ZupIT/horusec/internal/helpers/messages"
+	"github.com/ZupIT/horusec/internal/utils/copy"
+	"github.com/ZupIT/horusec/internal/utils/testutil"
 )
 
 var tmpPath, _ = filepath.Abs("tmp")
@@ -253,7 +249,7 @@ func TestNewLanguageDetect(t *testing.T) {
 			}
 			assert.Contains(t, langs, lang)
 		}
-		//TODO: We don't have examples of TypeScript language and Unknown language on examples folder, this will fail when we add them
+		// TODO: We don't have examples of TypeScript language and Unknown language on examples folder, this will fail when we add them
 		assert.Len(t, langs, len(languages.Values())-2)
 	})
 	t.Run("Should ignore folders present in toignore.GetDefaultFoldersToIgnore()", func(t *testing.T) {
@@ -264,7 +260,7 @@ func TestNewLanguageDetect(t *testing.T) {
 		stdOutMock := bytes.NewBufferString("")
 		logger.LogSetOutput(stdOutMock)
 		for _, folderName := range toignore.GetDefaultFoldersToIgnore() {
-			err = os.MkdirAll(filepath.Join(wd, folderName), 0700)
+			err = os.MkdirAll(filepath.Join(wd, folderName), 0o700)
 			assert.NoError(t, err)
 		}
 		langs, err := controller.Detect(wd)

--- a/internal/controllers/printresults/print_results.go
+++ b/internal/controllers/printresults/print_results.go
@@ -37,9 +37,7 @@ import (
 	"github.com/ZupIT/horusec/internal/utils/file"
 )
 
-var (
-	ErrOutputJSON = errors.New("{HORUSEC_CLI} error creating and/or writing to the specified file")
-)
+var ErrOutputJSON = errors.New("{HORUSEC_CLI} error creating and/or writing to the specified file")
 
 type SonarQubeConverter interface {
 	ConvertVulnerabilityToSonarQube() sq.Report
@@ -318,7 +316,6 @@ func (pr *PrintResults) printCommitAuthor(vulnerability *vulnerability.Vulnerabi
 	pr.printlnf("Commit Email: %s", vulnerability.CommitEmail)
 	pr.printlnf("Commit CommitHash: %s", vulnerability.CommitHash)
 	pr.printlnf("Commit Message: %s", vulnerability.CommitMessage)
-
 }
 
 func (pr *PrintResults) verifyRepositoryAuthorizationToken() {

--- a/internal/controllers/printresults/print_results_test.go
+++ b/internal/controllers/printresults/print_results_test.go
@@ -22,9 +22,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/uuid"
-
-	"github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
 	entitiesAnalysis "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
 	"github.com/ZupIT/horusec-devkit/pkg/entities/vulnerability"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/confidence"
@@ -33,14 +30,14 @@ import (
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 	vulnerabilityenum "github.com/ZupIT/horusec-devkit/pkg/enums/vulnerability"
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
-	"github.com/ZupIT/horusec/internal/enums/outputtype"
-	"github.com/ZupIT/horusec/internal/helpers/messages"
-	"github.com/ZupIT/horusec/internal/utils/testutil"
-
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ZupIT/horusec/config"
+	"github.com/ZupIT/horusec/internal/enums/outputtype"
+	"github.com/ZupIT/horusec/internal/helpers/messages"
+	"github.com/ZupIT/horusec/internal/utils/testutil"
 )
 
 type validateFn func(t *testing.T, tt testcase)
@@ -48,7 +45,7 @@ type validateFn func(t *testing.T, tt testcase)
 type testcase struct {
 	name            string
 	cfg             config.Config
-	analysis        analysis.Analysis
+	analysis        entitiesAnalysis.Analysis
 	vulnerabilities int
 	outputs         []string
 	err             bool
@@ -89,7 +86,6 @@ func TestPrintResultsStartPrintResults(t *testing.T) {
 						VulnerabilityID: uuid.MustParse("57bf7b03-b504-42ed-a026-ea89c81b7f4a"),
 						AnalysisID:      uuid.MustParse("16c70059-aa76-4b00-87d6-ad9941f8603e"),
 						Vulnerability: vulnerability.Vulnerability{
-
 							VulnerabilityID: uuid.MustParse("54a7a2a9-d68e-4139-ba53-6bff3bc84863"),
 							Line:            "1",
 							Column:          "0",
@@ -253,7 +249,7 @@ func TestPrintResultsStartPrintResults(t *testing.T) {
 
 // newPrintResultsTest creates a new PrintResults using the bytes.Buffer
 // from return as a print results writer and logger output.
-func newPrintResultsTest(entity *analysis.Analysis, cfg *config.Config) (*PrintResults, *bytes.Buffer) {
+func newPrintResultsTest(entity *entitiesAnalysis.Analysis, cfg *config.Config) (*PrintResults, *bytes.Buffer) {
 	output := bytes.NewBufferString("")
 	pr := NewPrintResults(entity, cfg)
 	pr.writer = output

--- a/internal/controllers/requirements/docker/docker.go
+++ b/internal/controllers/requirements/docker/docker.go
@@ -22,16 +22,17 @@ import (
 	"strings"
 
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
+
 	errorsEnums "github.com/ZupIT/horusec/internal/enums/errors"
 	"github.com/ZupIT/horusec/internal/helpers/messages"
 )
 
-const MinVersionDockerAccept = 19
-const MinSubVersionDockerAccept = 03
-
-var (
-	ErrMinVersion = fmt.Errorf("%v.%v", MinVersionDockerAccept, MinSubVersionDockerAccept)
+const (
+	MinVersionDockerAccept    = 19
+	MinSubVersionDockerAccept = 0o3
 )
+
+var ErrMinVersion = fmt.Errorf("%v.%v", MinVersionDockerAccept, MinSubVersionDockerAccept)
 
 type RequirementDocker struct{}
 

--- a/internal/controllers/requirements/git/git.go
+++ b/internal/controllers/requirements/git/git.go
@@ -21,16 +21,17 @@ import (
 	"strings"
 
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
+
 	errorsEnums "github.com/ZupIT/horusec/internal/enums/errors"
 	"github.com/ZupIT/horusec/internal/helpers/messages"
 )
 
-const MinVersionGitAccept = 2
-const MinSubVersionGitAccept = 01
-
-var (
-	ErrMinVersion = fmt.Errorf("%v.%v", MinVersionGitAccept, MinSubVersionGitAccept)
+const (
+	MinVersionGitAccept    = 2
+	MinSubVersionGitAccept = 0o1
 )
+
+var ErrMinVersion = fmt.Errorf("%v.%v", MinVersionGitAccept, MinSubVersionGitAccept)
 
 type RequirementGit struct{}
 

--- a/internal/controllers/requirements/requirements.go
+++ b/internal/controllers/requirements/requirements.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
+
 	"github.com/ZupIT/horusec/internal/controllers/requirements/docker"
 	"github.com/ZupIT/horusec/internal/controllers/requirements/git"
 	"github.com/ZupIT/horusec/internal/helpers/messages"

--- a/internal/entities/custom_images/custom_images.go
+++ b/internal/entities/custom_images/custom_images.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
+
 	"github.com/ZupIT/horusec/internal/enums/images"
 	"github.com/ZupIT/horusec/internal/helpers/messages"
 )

--- a/internal/entities/custom_images/custom_images_test.go
+++ b/internal/entities/custom_images/custom_images_test.go
@@ -18,10 +18,10 @@ import (
 	"io"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
+	"github.com/stretchr/testify/assert"
+
 	customimages "github.com/ZupIT/horusec/internal/entities/custom_images"
 )
 

--- a/internal/entities/custom_rules/custom_rule.go
+++ b/internal/entities/custom_rules/custom_rule.go
@@ -20,15 +20,14 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
-	engine "github.com/ZupIT/horusec-engine"
-
-	validation "github.com/go-ozzo/ozzo-validation/v4"
-
 	"github.com/ZupIT/horusec-devkit/pkg/enums/confidence"
+	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/severities"
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
+	engine "github.com/ZupIT/horusec-engine"
 	"github.com/ZupIT/horusec-engine/text"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+
 	customrules "github.com/ZupIT/horusec/internal/enums/custom_rules"
 	"github.com/ZupIT/horusec/internal/services/engines/csharp"
 	"github.com/ZupIT/horusec/internal/services/engines/dart"

--- a/internal/entities/custom_rules/custom_rule_test.go
+++ b/internal/entities/custom_rules/custom_rule_test.go
@@ -17,13 +17,12 @@ package customrules
 import (
 	"testing"
 
-	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
-
-	"github.com/stretchr/testify/assert"
-
 	"github.com/ZupIT/horusec-devkit/pkg/enums/confidence"
+	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/severities"
 	"github.com/ZupIT/horusec-engine/text"
+	"github.com/stretchr/testify/assert"
+
 	customrulesenum "github.com/ZupIT/horusec/internal/enums/custom_rules"
 )
 

--- a/internal/entities/docker/analysis_data.go
+++ b/internal/entities/docker/analysis_data.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
+
 	"github.com/ZupIT/horusec/internal/enums/images"
 )
 

--- a/internal/entities/docker/analysis_data_test.go
+++ b/internal/entities/docker/analysis_data_test.go
@@ -46,7 +46,6 @@ func TestSetData(t *testing.T) {
 		assert.Equal(t, "other-host.io/t/test:latest", newData.CustomImage)
 		assert.Equal(t, "docker.io/test:v1.0.0", newData.DefaultImage)
 	})
-
 }
 
 func TestGetCustomOrDefaultImage(t *testing.T) {

--- a/internal/entities/toolsconfig/tools_config.go
+++ b/internal/entities/toolsconfig/tools_config.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
+
 	"github.com/ZupIT/horusec/internal/helpers/messages"
 )
 

--- a/internal/entities/toolsconfig/tools_config_test.go
+++ b/internal/entities/toolsconfig/tools_config_test.go
@@ -18,10 +18,10 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
 	"github.com/ZupIT/horusec/internal/helpers/messages"
 )

--- a/internal/entities/workdir/workdir.go
+++ b/internal/entities/workdir/workdir.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
+
 	"github.com/ZupIT/horusec/internal/helpers/messages"
 )
 

--- a/internal/entities/workdir/workdir_test.go
+++ b/internal/entities/workdir/workdir_test.go
@@ -17,9 +17,9 @@ package workdir_test
 import (
 	"testing"
 
+	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
 	"github.com/ZupIT/horusec/internal/entities/workdir"
 )
 

--- a/internal/services/custom_rules/service.go
+++ b/internal/services/custom_rules/service.go
@@ -21,10 +21,10 @@ import (
 	"os"
 
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
-
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
 	engine "github.com/ZupIT/horusec-engine"
 	"github.com/ZupIT/horusec-engine/text"
+
 	"github.com/ZupIT/horusec/config"
 	customRulesEntities "github.com/ZupIT/horusec/internal/entities/custom_rules"
 )

--- a/internal/services/custom_rules/service_test.go
+++ b/internal/services/custom_rules/service_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
-
 	"github.com/stretchr/testify/assert"
 
 	cliConfig "github.com/ZupIT/horusec/config"

--- a/internal/services/docker/client/docker_config.go
+++ b/internal/services/docker/client/docker_config.go
@@ -15,9 +15,9 @@
 package client
 
 import (
+	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
 	docker "github.com/docker/docker/client"
 
-	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
 	"github.com/ZupIT/horusec/internal/helpers/messages"
 )
 

--- a/internal/services/docker/docker_api.go
+++ b/internal/services/docker/docker_api.go
@@ -26,23 +26,21 @@ import (
 	"strings"
 	"sync"
 
-	enumErrors "github.com/ZupIT/horusec/internal/enums/errors"
-
-	"github.com/docker/docker/api/types"
-	dockerTypesFilters "github.com/docker/docker/api/types/filters"
-	"github.com/docker/docker/api/types/mount"
-	"github.com/google/uuid"
-
 	"github.com/ZupIT/horusec-devkit/pkg/utils/env"
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	dockerTypesFilters "github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/mount"
+	"github.com/docker/docker/api/types/network"
+	"github.com/google/uuid"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/ZupIT/horusec/config"
 	"github.com/ZupIT/horusec/internal/entities/docker"
+	enumErrors "github.com/ZupIT/horusec/internal/enums/errors"
 	"github.com/ZupIT/horusec/internal/enums/images"
 	"github.com/ZupIT/horusec/internal/helpers/messages"
-
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/network"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // Docker is the interface that abstract the Docker API.
@@ -57,22 +55,14 @@ type Client interface {
 	ContainerCreate(ctx context.Context, cfg *container.Config, hostCfg *container.HostConfig,
 		netCfg *network.NetworkingConfig, plataform *specs.Platform, name string,
 	) (container.ContainerCreateCreatedBody, error)
-
 	ContainerStart(ctx context.Context, containerID string, options types.ContainerStartOptions) error
-
 	ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error)
-
 	ContainerWait(ctx context.Context, containerID string, condition container.WaitCondition) (
 		<-chan container.ContainerWaitOKBody, <-chan error)
-
 	ContainerLogs(ctx context.Context, containerID string, options types.ContainerLogsOptions) (io.ReadCloser, error)
-
 	ContainerRemove(ctx context.Context, containerID string, options types.ContainerRemoveOptions) error
-
 	ImageList(ctx context.Context, options types.ImageListOptions) ([]types.ImageSummary, error)
-
 	ImagePull(ctx context.Context, ref string, options types.ImagePullOptions) (io.ReadCloser, error)
-
 	Ping(ctx context.Context) (types.Ping, error)
 }
 

--- a/internal/services/docker/docker_api_test.go
+++ b/internal/services/docker/docker_api_test.go
@@ -28,12 +28,11 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 
-	errorsenum "github.com/ZupIT/horusec/internal/enums/errors"
-	"github.com/ZupIT/horusec/internal/utils/testutil"
-
 	cliConfig "github.com/ZupIT/horusec/config"
 	dockerEntities "github.com/ZupIT/horusec/internal/entities/docker"
+	errorsenum "github.com/ZupIT/horusec/internal/enums/errors"
 	"github.com/ZupIT/horusec/internal/services/docker/client"
+	"github.com/ZupIT/horusec/internal/utils/testutil"
 )
 
 var ErrGeneric = errors.New("some error generic")

--- a/internal/services/engines/csharp/rule_manager.go
+++ b/internal/services/engines/csharp/rule_manager.go
@@ -16,6 +16,7 @@ package csharp
 
 import (
 	engine "github.com/ZupIT/horusec-engine"
+
 	"github.com/ZupIT/horusec/internal/services/engines"
 )
 

--- a/internal/services/engines/csharp/rules_test.go
+++ b/internal/services/engines/csharp/rules_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	engine "github.com/ZupIT/horusec-engine"
+
 	"github.com/ZupIT/horusec/internal/utils/testutil"
 )
 

--- a/internal/services/engines/dart/rule_manager.go
+++ b/internal/services/engines/dart/rule_manager.go
@@ -16,6 +16,7 @@ package dart
 
 import (
 	engine "github.com/ZupIT/horusec-engine"
+
 	"github.com/ZupIT/horusec/internal/services/engines"
 )
 

--- a/internal/services/engines/dart/rules_test.go
+++ b/internal/services/engines/dart/rules_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	engine "github.com/ZupIT/horusec-engine"
+
 	"github.com/ZupIT/horusec/internal/utils/testutil"
 )
 

--- a/internal/services/engines/java/rule_manager.go
+++ b/internal/services/engines/java/rule_manager.go
@@ -16,6 +16,7 @@ package java
 
 import (
 	engine "github.com/ZupIT/horusec-engine"
+
 	"github.com/ZupIT/horusec/internal/services/engines"
 	"github.com/ZupIT/horusec/internal/services/engines/jvm"
 )
@@ -36,8 +37,8 @@ func Rules() []engine.Rule {
 		NewInsecureImplementationOfSSL(),
 		NewWebViewLoadFilesFromExternalStorage(),
 		NewInsecureWebViewImplementation(),
-		//NewNoUseSQLCipherAndMatch(),
-		//NewNoUseRealmDatabaseWithEncryptionKey(),
+		// NewNoUseSQLCipherAndMatch(),
+		// NewNoUseRealmDatabaseWithEncryptionKey(),
 		NewNoUseWebviewDebuggingEnable(),
 		NewNoListenToClipboard(),
 		NewNoCopyContentToClipboard(),
@@ -78,8 +79,8 @@ func Rules() []engine.Rule {
 		NewAnonymousLDAPBind(),
 		NewLDAPEntryPoisoning(),
 		NewTrustManagerThatAcceptAnyCertificatesClient(),
-		//NewTrustManagerThatAcceptAnyCertificatesServer(),
-		//NewTrustManagerThatAcceptAnyCertificatesIssuers(),
+		// NewTrustManagerThatAcceptAnyCertificatesServer(),
+		// NewTrustManagerThatAcceptAnyCertificatesIssuers(),
 		NewXMLParsingVulnerableToXXE(),
 		NewIgnoringXMLCommentsInSAML(),
 		NewInformationExposureThroughAnErrorMessage(),
@@ -109,17 +110,17 @@ func Rules() []engine.Rule {
 		NewXMLParsingVulnerableToXXEWithXMLInputFactory(),
 		NewXMLParsingVulnerableToXXEWithSAXParserFactory(),
 		NewXMLParsingVulnerableToXXEWithTransformerFactory(),
-		//NewXMLParsingVulnerableToXXEWithSchemaFactory(),
+		// NewXMLParsingVulnerableToXXEWithSchemaFactory(),
 		NewXMLParsingVulnerableToXXEWithDom4j(),
 		NewXMLParsingVulnerableToXXEWithJdom2(),
 		NewClassesShouldNotBeLoadedDynamically(),
-		//NewHostnameVerifierVerifyShouldNotAlwaysReturnTrue(),
+		// NewHostnameVerifierVerifyShouldNotAlwaysReturnTrue(),
 		NewXPathExpressionsShouldNotBeVulnerableToInjectionAttacks(),
 		NewServerHostnamesShouldBeVerifiedDuringSSLTLSConnections(),
 		NewServerHostnamesShouldBeVerifiedDuringSSLTLSConnectionsWithSimpleEmail(),
 		NewFunctionCallsShouldNotBeVulnerableToPathInjectionAttacks(),
 		NewServerHostnamesShouldBeVerifiedDuringSSLTLSConnectionsWithMail(),
-		//NewServerHostnamesShouldBeVerifiedDuringSSLTLSConnectionsWithJakartaMail(),
+		// NewServerHostnamesShouldBeVerifiedDuringSSLTLSConnectionsWithJakartaMail(),
 		NewHTTPResponseHeadersShouldNotBeVulnerableToInjectionAttacks(),
 		NewLDAPAuthenticatedAnalyzeYourCode(),
 		NewSecureRandomSeedsShouldNotBePredictable(),
@@ -138,8 +139,8 @@ func Rules() []engine.Rule {
 		NewNoUseIVsWeak(),
 		NewRootDetectionCapabilities(),
 		NewJARURLConnection(),
-		//NewSetOrReadClipboardData(),
-		//NewMessageDigest(),
+		// NewSetOrReadClipboardData(),
+		// NewMessageDigest(),
 		NewOverlyPermissiveFilePermission(),
 		NewCipherGetInstanceInsecure(),
 

--- a/internal/services/engines/java/rules.go
+++ b/internal/services/engines/java/rules.go
@@ -954,7 +954,7 @@ func NewQueryDatabaseOfSMSContacts() text.TextRule {
 	}
 }
 
-//Deprecated: the javax package is deprecated in the Jakarta EE newest version. We'll use jakarta package.
+// Deprecated: the javax package is deprecated in the Jakarta EE newest version. We'll use jakarta package.
 func NewPotentialPathTraversal() text.TextRule {
 	return text.TextRule{
 		Metadata: engine.Metadata{
@@ -1638,7 +1638,7 @@ func NewOpenSAML2ShouldBeConfiguredToPreventAuthenticationBypass() text.TextRule
 	}
 }
 
-//Deprecated: the javax package is deprecated in the Jakarta EE newest version. We'll use jakarta package.
+// Deprecated: the javax package is deprecated in the Jakarta EE newest version. We'll use jakarta package.
 func NewHttpServletRequestGetRequestedSessionIdShouldNotBeUsed() text.TextRule {
 	return text.TextRule{
 		Metadata: engine.Metadata{
@@ -1690,7 +1690,7 @@ func NewLDAPAuthenticatedAnalyzeYourCode() text.TextRule {
 	}
 }
 
-//Deprecated: the javax package is deprecated in the Jakarta EE newest version. We'll use jakarta package.
+// Deprecated: the javax package is deprecated in the Jakarta EE newest version. We'll use jakarta package.
 func NewWebApplicationsShouldHotHaveAMainMethod() text.TextRule {
 	return text.TextRule{
 		Metadata: engine.Metadata{

--- a/internal/services/engines/javascript/rule_manager.go
+++ b/internal/services/engines/javascript/rule_manager.go
@@ -16,6 +16,7 @@ package javascript
 
 import (
 	engine "github.com/ZupIT/horusec-engine"
+
 	"github.com/ZupIT/horusec/internal/services/engines"
 )
 

--- a/internal/services/engines/javascript/rules_test.go
+++ b/internal/services/engines/javascript/rules_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	engine "github.com/ZupIT/horusec-engine"
+
 	"github.com/ZupIT/horusec/internal/utils/testutil"
 )
 

--- a/internal/services/engines/jvm/rules.go
+++ b/internal/services/engines/jvm/rules.go
@@ -15,12 +15,11 @@
 package jvm
 
 import (
-	engine "github.com/ZupIT/horusec-engine"
-
 	"regexp"
 
 	"github.com/ZupIT/horusec-devkit/pkg/enums/confidence"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/severities"
+	engine "github.com/ZupIT/horusec-engine"
 	"github.com/ZupIT/horusec-engine/text"
 )
 

--- a/internal/services/engines/jvm/samples_test.go
+++ b/internal/services/engines/jvm/samples_test.go
@@ -13,5 +13,3 @@
 // limitations under the License.
 
 package jvm
-
-const ()

--- a/internal/services/engines/kotlin/rules.go
+++ b/internal/services/engines/kotlin/rules.go
@@ -16,6 +16,7 @@ package kotlin
 
 import (
 	engine "github.com/ZupIT/horusec-engine"
+
 	"github.com/ZupIT/horusec/internal/services/engines"
 	"github.com/ZupIT/horusec/internal/services/engines/jvm"
 )

--- a/internal/services/engines/kubernetes/rule_manager.go
+++ b/internal/services/engines/kubernetes/rule_manager.go
@@ -16,6 +16,7 @@ package kubernetes
 
 import (
 	engine "github.com/ZupIT/horusec-engine"
+
 	"github.com/ZupIT/horusec/internal/services/engines"
 )
 

--- a/internal/services/engines/kubernetes/rules_test.go
+++ b/internal/services/engines/kubernetes/rules_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	engine "github.com/ZupIT/horusec-engine"
+
 	"github.com/ZupIT/horusec/internal/utils/testutil"
 )
 

--- a/internal/services/engines/leaks/rule_manager.go
+++ b/internal/services/engines/leaks/rule_manager.go
@@ -16,6 +16,7 @@ package leaks
 
 import (
 	engine "github.com/ZupIT/horusec-engine"
+
 	"github.com/ZupIT/horusec/internal/services/engines"
 )
 

--- a/internal/services/engines/leaks/rules_test.go
+++ b/internal/services/engines/leaks/rules_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	engine "github.com/ZupIT/horusec-engine"
+
 	"github.com/ZupIT/horusec/internal/utils/testutil"
 )
 
@@ -381,7 +382,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 				{
 					CodeSample: `DB_PASSWORD="gorm"`,
 					SourceLocation: engine.Location{
-						Line:   12,
+						Line:   13,
 						Column: 4,
 					},
 				},
@@ -426,6 +427,7 @@ func TestRulesVulnerableCode(t *testing.T) {
 
 	testutil.TestVulnerableCode(t, testcases)
 }
+
 func TestRulesSafeCode(t *testing.T) {
 	testcases := []*testutil.RuleTestCase{
 		{

--- a/internal/services/engines/leaks/samples_test.go
+++ b/internal/services/engines/leaks/samples_test.go
@@ -243,9 +243,10 @@ services:
 package main
 
 import (
-  "fmt"
-  "gorm.io/gorm"
-  "gorm.io/driver/postgres"
+	"fmt"
+
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
 )
 
 func main() {

--- a/internal/services/engines/nginx/rule_manager.go
+++ b/internal/services/engines/nginx/rule_manager.go
@@ -16,6 +16,7 @@ package nginx
 
 import (
 	engine "github.com/ZupIT/horusec-engine"
+
 	"github.com/ZupIT/horusec/internal/services/engines"
 )
 

--- a/internal/services/engines/nginx/rules_test.go
+++ b/internal/services/engines/nginx/rules_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	engine "github.com/ZupIT/horusec-engine"
+
 	"github.com/ZupIT/horusec/internal/utils/testutil"
 )
 

--- a/internal/services/engines/rules_test.go
+++ b/internal/services/engines/rules_test.go
@@ -17,10 +17,10 @@ package engines_test
 import (
 	"testing"
 
+	"github.com/ZupIT/horusec-engine/text"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ZupIT/horusec-engine/text"
 	"github.com/ZupIT/horusec/internal/services/engines"
 	"github.com/ZupIT/horusec/internal/services/engines/csharp"
 	"github.com/ZupIT/horusec/internal/services/engines/dart"

--- a/internal/services/engines/swift/rule_manager.go
+++ b/internal/services/engines/swift/rule_manager.go
@@ -16,6 +16,7 @@ package swift
 
 import (
 	engine "github.com/ZupIT/horusec-engine"
+
 	"github.com/ZupIT/horusec/internal/services/engines"
 )
 

--- a/internal/services/engines/swift/rules_test.go
+++ b/internal/services/engines/swift/rules_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	engine "github.com/ZupIT/horusec-engine"
+
 	"github.com/ZupIT/horusec/internal/utils/testutil"
 )
 

--- a/internal/services/formatters/c/flawfinder/entities/result_test.go
+++ b/internal/services/formatters/c/flawfinder/entities/result_test.go
@@ -17,9 +17,8 @@ package entities
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/ZupIT/horusec-devkit/pkg/enums/severities"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetDetails(t *testing.T) {
@@ -35,7 +34,6 @@ func TestGetDetails(t *testing.T) {
 		assert.NotEmpty(t, details)
 		assert.Equal(t, "test test test", details)
 	})
-
 }
 
 func TestGetSeverity(t *testing.T) {
@@ -84,5 +82,4 @@ func TestGetFilename(t *testing.T) {
 		assert.NotContains(t, filename, "./")
 		assert.Equal(t, "test.c", filename)
 	})
-
 }

--- a/internal/services/formatters/c/flawfinder/formatter.go
+++ b/internal/services/formatters/c/flawfinder/formatter.go
@@ -15,12 +15,12 @@
 package flawfinder
 
 import (
-	"github.com/gocarina/gocsv"
-
 	"github.com/ZupIT/horusec-devkit/pkg/entities/vulnerability"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
+	"github.com/gocarina/gocsv"
+
 	dockerEntities "github.com/ZupIT/horusec/internal/entities/docker"
 	"github.com/ZupIT/horusec/internal/enums/images"
 	"github.com/ZupIT/horusec/internal/helpers/messages"

--- a/internal/services/formatters/c/flawfinder/formatter_test.go
+++ b/internal/services/formatters/c/flawfinder/formatter_test.go
@@ -20,17 +20,15 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
-	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
-	"github.com/ZupIT/horusec/internal/utils/testutil"
-
 	entitiesAnalysis "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
-
+	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 	"github.com/stretchr/testify/assert"
 
 	cliConfig "github.com/ZupIT/horusec/config"
+	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
 	"github.com/ZupIT/horusec/internal/entities/workdir"
 	"github.com/ZupIT/horusec/internal/services/formatters"
+	"github.com/ZupIT/horusec/internal/utils/testutil"
 )
 
 func getCsvString() string {

--- a/internal/services/formatters/csharp/dotnet_cli/entities/dependency_test.go
+++ b/internal/services/formatters/csharp/dotnet_cli/entities/dependency_test.go
@@ -17,9 +17,8 @@ package entities
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/ZupIT/horusec-devkit/pkg/enums/severities"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSetName(t *testing.T) {

--- a/internal/services/formatters/csharp/dotnet_cli/formatter_test.go
+++ b/internal/services/formatters/csharp/dotnet_cli/formatter_test.go
@@ -18,10 +18,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	analysisEntities "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
+	"github.com/stretchr/testify/assert"
 
 	cliConfig "github.com/ZupIT/horusec/config"
 	"github.com/ZupIT/horusec/internal/entities/toolsconfig"

--- a/internal/services/formatters/csharp/horuseccsharp/formatter.go
+++ b/internal/services/formatters/csharp/horuseccsharp/formatter.go
@@ -16,6 +16,7 @@ package horuseccsharp
 
 import (
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
+
 	"github.com/ZupIT/horusec/internal/services/engines/csharp"
 	"github.com/ZupIT/horusec/internal/services/formatters"
 )

--- a/internal/services/formatters/csharp/scs/formatter_test.go
+++ b/internal/services/formatters/csharp/scs/formatter_test.go
@@ -20,11 +20,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	analysisEntities "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	cliConfig "github.com/ZupIT/horusec/config"
 	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
@@ -38,7 +37,7 @@ func createSlnFile(t *testing.T) {
 	wd, _ := os.Getwd()
 
 	dir := filepath.Join(wd, ".horusec", "00000000-0000-0000-0000-000000000000")
-	err := os.MkdirAll(dir, 0755)
+	err := os.MkdirAll(dir, 0o755)
 	require.Nil(t, err, "Expected nil error to create sln directory: %v", err)
 
 	f, err := os.Create(filepath.Join(dir, "test.sln"))
@@ -48,7 +47,6 @@ func createSlnFile(t *testing.T) {
 		assert.NoError(t, f.Close(), "Expected nil error to close sln file")
 		assert.NoError(t, os.RemoveAll(dir), "Expected nil error to remove sln directory")
 	})
-
 }
 
 func TestParseOutput(t *testing.T) {
@@ -106,7 +104,6 @@ func TestParseOutput(t *testing.T) {
 
 		formatter.StartAnalysis("")
 		assert.Len(t, analysis.AnalysisVulnerabilities, 4)
-
 	})
 
 	t.Run("should return error when unmarshalling output", func(t *testing.T) {
@@ -127,7 +124,6 @@ func TestParseOutput(t *testing.T) {
 
 		formatter.StartAnalysis("")
 		assert.NotEmpty(t, analysis.Errors)
-
 	})
 
 	t.Run("should return build error", func(t *testing.T) {
@@ -148,7 +144,6 @@ func TestParseOutput(t *testing.T) {
 
 		formatter.StartAnalysis("")
 		assert.NotEmpty(t, analysis.Errors)
-
 	})
 
 	t.Run("should return error not found solution file", func(t *testing.T) {

--- a/internal/services/formatters/dart/horusecdart/formatter.go
+++ b/internal/services/formatters/dart/horusecdart/formatter.go
@@ -16,6 +16,7 @@ package horusecdart
 
 import (
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
+
 	"github.com/ZupIT/horusec/internal/services/engines/dart"
 	"github.com/ZupIT/horusec/internal/services/formatters"
 )

--- a/internal/services/formatters/default_engine_formatter.go
+++ b/internal/services/formatters/default_engine_formatter.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
 	engine "github.com/ZupIT/horusec-engine"
+
 	"github.com/ZupIT/horusec/internal/enums/engines"
 	"github.com/ZupIT/horusec/internal/helpers/messages"
 )

--- a/internal/services/formatters/default_engine_formatter_test.go
+++ b/internal/services/formatters/default_engine_formatter_test.go
@@ -19,8 +19,11 @@ import (
 
 	"github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
 	engine "github.com/ZupIT/horusec-engine"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/ZupIT/horusec/internal/services/formatters"
 	"github.com/ZupIT/horusec/internal/services/formatters/csharp/horuseccsharp"
+	"github.com/ZupIT/horusec/internal/services/formatters/dart/horusecdart"
 	"github.com/ZupIT/horusec/internal/services/formatters/java/horusecjava"
 	"github.com/ZupIT/horusec/internal/services/formatters/javascript/horusecjavascript"
 	"github.com/ZupIT/horusec/internal/services/formatters/kotlin/horuseckotlin"
@@ -29,10 +32,6 @@ import (
 	"github.com/ZupIT/horusec/internal/services/formatters/swift/horusecswift"
 	"github.com/ZupIT/horusec/internal/services/formatters/yaml/horuseckubernetes"
 	"github.com/ZupIT/horusec/internal/utils/testutil"
-
-	"github.com/stretchr/testify/assert"
-
-	"github.com/ZupIT/horusec/internal/services/formatters/dart/horusecdart"
 )
 
 func TestStartAnalysis(t *testing.T) {
@@ -80,7 +79,6 @@ func TestStartAnalysis(t *testing.T) {
 
 	for _, tt := range testcases {
 		t.Run(tt.engine, func(t *testing.T) {
-
 			t.Run("should success execute analysis without errors", func(t *testing.T) {
 				analysis := &analysis.Analysis{}
 				service := testutil.NewFormatterMock()
@@ -125,7 +123,6 @@ func TestStartAnalysis(t *testing.T) {
 					tt.formatter(service).StartAnalysis("")
 				})
 			})
-
 		})
 	}
 }

--- a/internal/services/formatters/elixir/mixaudit/formatter.go
+++ b/internal/services/formatters/elixir/mixaudit/formatter.go
@@ -17,19 +17,18 @@ package mixaudit
 import (
 	"encoding/json"
 
-	vulnhash "github.com/ZupIT/horusec/internal/utils/vuln_hash"
-
-	"github.com/ZupIT/horusec/internal/enums/images"
-
 	"github.com/ZupIT/horusec-devkit/pkg/entities/vulnerability"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/severities"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
+
 	dockerEntities "github.com/ZupIT/horusec/internal/entities/docker"
+	"github.com/ZupIT/horusec/internal/enums/images"
 	"github.com/ZupIT/horusec/internal/helpers/messages"
 	"github.com/ZupIT/horusec/internal/services/formatters"
 	"github.com/ZupIT/horusec/internal/services/formatters/elixir/mixaudit/entities"
+	vulnhash "github.com/ZupIT/horusec/internal/utils/vuln_hash"
 )
 
 type Formatter struct {

--- a/internal/services/formatters/elixir/mixaudit/formatter_test.go
+++ b/internal/services/formatters/elixir/mixaudit/formatter_test.go
@@ -18,16 +18,15 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
-	"github.com/ZupIT/horusec/internal/utils/testutil"
-
-	"github.com/stretchr/testify/assert"
-
 	"github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
+	"github.com/stretchr/testify/assert"
+
 	cliConfig "github.com/ZupIT/horusec/config"
+	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
 	"github.com/ZupIT/horusec/internal/entities/workdir"
 	"github.com/ZupIT/horusec/internal/services/formatters"
+	"github.com/ZupIT/horusec/internal/utils/testutil"
 )
 
 func getOutputString() string {

--- a/internal/services/formatters/elixir/sobelow/formatter.go
+++ b/internal/services/formatters/elixir/sobelow/formatter.go
@@ -18,18 +18,18 @@ import (
 	"errors"
 	"strings"
 
-	vulnhash "github.com/ZupIT/horusec/internal/utils/vuln_hash"
-
 	"github.com/ZupIT/horusec-devkit/pkg/entities/vulnerability"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/severities"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
+
 	dockerEntities "github.com/ZupIT/horusec/internal/entities/docker"
 	"github.com/ZupIT/horusec/internal/enums/images"
 	"github.com/ZupIT/horusec/internal/helpers/messages"
 	"github.com/ZupIT/horusec/internal/services/formatters"
 	"github.com/ZupIT/horusec/internal/services/formatters/elixir/sobelow/entities"
+	vulnhash "github.com/ZupIT/horusec/internal/utils/vuln_hash"
 )
 
 type Formatter struct {

--- a/internal/services/formatters/elixir/sobelow/formatter_test.go
+++ b/internal/services/formatters/elixir/sobelow/formatter_test.go
@@ -18,16 +18,15 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
-	"github.com/ZupIT/horusec/internal/utils/testutil"
-
-	"github.com/stretchr/testify/assert"
-
 	"github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
+	"github.com/stretchr/testify/assert"
+
 	cliConfig "github.com/ZupIT/horusec/config"
+	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
 	"github.com/ZupIT/horusec/internal/entities/workdir"
 	"github.com/ZupIT/horusec/internal/services/formatters"
+	"github.com/ZupIT/horusec/internal/utils/testutil"
 )
 
 func getOutputString() string {

--- a/internal/services/formatters/generic/dependency_check/entities/vulnerability_test.go
+++ b/internal/services/formatters/generic/dependency_check/entities/vulnerability_test.go
@@ -17,9 +17,8 @@ package entities
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/ZupIT/horusec-devkit/pkg/enums/severities"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetSeverity(t *testing.T) {

--- a/internal/services/formatters/generic/dependency_check/formatter_test.go
+++ b/internal/services/formatters/generic/dependency_check/formatter_test.go
@@ -18,10 +18,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	entitiesAnalysis "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
+	"github.com/stretchr/testify/assert"
 
 	cliConfig "github.com/ZupIT/horusec/config"
 	"github.com/ZupIT/horusec/internal/entities/toolsconfig"

--- a/internal/services/formatters/generic/semgrep/formatter.go
+++ b/internal/services/formatters/generic/semgrep/formatter.go
@@ -19,18 +19,17 @@ import (
 	"path/filepath"
 	"strconv"
 
-	vulnhash "github.com/ZupIT/horusec/internal/utils/vuln_hash"
-
-	"github.com/ZupIT/horusec/internal/enums/images"
-
 	"github.com/ZupIT/horusec-devkit/pkg/entities/vulnerability"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/severities"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
+
 	"github.com/ZupIT/horusec/internal/entities/docker"
+	"github.com/ZupIT/horusec/internal/enums/images"
 	"github.com/ZupIT/horusec/internal/helpers/messages"
 	"github.com/ZupIT/horusec/internal/services/formatters"
+	vulnhash "github.com/ZupIT/horusec/internal/utils/vuln_hash"
 )
 
 type Formatter struct {

--- a/internal/services/formatters/generic/semgrep/formatter_test.go
+++ b/internal/services/formatters/generic/semgrep/formatter_test.go
@@ -18,16 +18,14 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
-	"github.com/ZupIT/horusec/internal/utils/testutil"
-
 	"github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
-
 	"github.com/stretchr/testify/assert"
 
 	"github.com/ZupIT/horusec/config"
 	"github.com/ZupIT/horusec/internal/services/formatters"
+	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
+	"github.com/ZupIT/horusec/internal/utils/testutil"
 )
 
 func TestParseOutput(t *testing.T) {

--- a/internal/services/formatters/generic/trivy/formatter.go
+++ b/internal/services/formatters/generic/trivy/formatter.go
@@ -20,8 +20,6 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/google/uuid"
-
 	"github.com/ZupIT/horusec-devkit/pkg/entities/vulnerability"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/confidence"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
@@ -29,6 +27,7 @@ import (
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 	enumsVulnerability "github.com/ZupIT/horusec-devkit/pkg/enums/vulnerability"
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
+	"github.com/google/uuid"
 
 	dockerEntities "github.com/ZupIT/horusec/internal/entities/docker"
 	"github.com/ZupIT/horusec/internal/enums/images"

--- a/internal/services/formatters/generic/trivy/formatter_test.go
+++ b/internal/services/formatters/generic/trivy/formatter_test.go
@@ -17,10 +17,10 @@ package trivy
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	entitiesAnalysis "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/ZupIT/horusec/config"
 	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
 	"github.com/ZupIT/horusec/internal/entities/workdir"

--- a/internal/services/formatters/go/gosec/formatter.go
+++ b/internal/services/formatters/go/gosec/formatter.go
@@ -18,17 +18,16 @@ import (
 	"encoding/json"
 	"strconv"
 
-	vulnhash "github.com/ZupIT/horusec/internal/utils/vuln_hash"
-
-	"github.com/ZupIT/horusec/internal/enums/images"
-
 	"github.com/ZupIT/horusec-devkit/pkg/entities/vulnerability"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
+
 	"github.com/ZupIT/horusec/internal/entities/docker"
+	"github.com/ZupIT/horusec/internal/enums/images"
 	"github.com/ZupIT/horusec/internal/helpers/messages"
 	"github.com/ZupIT/horusec/internal/services/formatters"
+	vulnhash "github.com/ZupIT/horusec/internal/utils/vuln_hash"
 )
 
 // Formatter represents the Gosec formatter.

--- a/internal/services/formatters/go/gosec/formatter_test.go
+++ b/internal/services/formatters/go/gosec/formatter_test.go
@@ -18,15 +18,14 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
-	"github.com/ZupIT/horusec/internal/utils/testutil"
-
-	"github.com/stretchr/testify/assert"
-
 	"github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/ZupIT/horusec/config"
+	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
 	"github.com/ZupIT/horusec/internal/services/formatters"
+	"github.com/ZupIT/horusec/internal/utils/testutil"
 )
 
 func TestGosecStartAnalysis(t *testing.T) {

--- a/internal/services/formatters/go/nancy/formatter_test.go
+++ b/internal/services/formatters/go/nancy/formatter_test.go
@@ -21,13 +21,12 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/confidence"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ZupIT/horusec/config"
 	"github.com/ZupIT/horusec/internal/entities/toolsconfig"

--- a/internal/services/formatters/go/nancy/vulnerability_test.go
+++ b/internal/services/formatters/go/nancy/vulnerability_test.go
@@ -17,9 +17,8 @@ package nancy
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/ZupIT/horusec-devkit/pkg/enums/severities"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetDescription(t *testing.T) {

--- a/internal/services/formatters/hcl/checkov/entities/check_test.go
+++ b/internal/services/formatters/hcl/checkov/entities/check_test.go
@@ -29,7 +29,6 @@ func checkMock() *Check {
 		FileAbsPath:   "test",
 		FileLineRange: [2]int{1, 1},
 	}
-
 }
 
 func TestGetDetails(t *testing.T) {

--- a/internal/services/formatters/hcl/checkov/formatter.go
+++ b/internal/services/formatters/hcl/checkov/formatter.go
@@ -18,20 +18,18 @@ import (
 	"bytes"
 	"encoding/json"
 
-	"github.com/pborman/ansi"
-
-	vulnhash "github.com/ZupIT/horusec/internal/utils/vuln_hash"
-
-	"github.com/ZupIT/horusec/internal/enums/images"
-
 	"github.com/ZupIT/horusec-devkit/pkg/entities/vulnerability"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
+	"github.com/pborman/ansi"
+
 	dockerEntities "github.com/ZupIT/horusec/internal/entities/docker"
+	"github.com/ZupIT/horusec/internal/enums/images"
 	"github.com/ZupIT/horusec/internal/helpers/messages"
 	"github.com/ZupIT/horusec/internal/services/formatters"
 	"github.com/ZupIT/horusec/internal/services/formatters/hcl/checkov/entities"
+	vulnhash "github.com/ZupIT/horusec/internal/utils/vuln_hash"
 )
 
 type Formatter struct {

--- a/internal/services/formatters/hcl/checkov/formatter_test.go
+++ b/internal/services/formatters/hcl/checkov/formatter_test.go
@@ -20,7 +20,6 @@ import (
 
 	entitiesAnalysis "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
-
 	"github.com/stretchr/testify/assert"
 
 	cliConfig "github.com/ZupIT/horusec/config"

--- a/internal/services/formatters/hcl/tfsec/entities/result_test.go
+++ b/internal/services/formatters/hcl/tfsec/entities/result_test.go
@@ -32,7 +32,6 @@ func resultMock() *Result {
 		Description: "test",
 		Severity:    "test",
 	}
-
 }
 
 func TestGetDetails(t *testing.T) {

--- a/internal/services/formatters/hcl/tfsec/formatter.go
+++ b/internal/services/formatters/hcl/tfsec/formatter.go
@@ -19,18 +19,17 @@ import (
 	"fmt"
 	"strings"
 
-	vulnhash "github.com/ZupIT/horusec/internal/utils/vuln_hash"
-
-	"github.com/ZupIT/horusec/internal/enums/images"
-
 	"github.com/ZupIT/horusec-devkit/pkg/entities/vulnerability"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
+
 	dockerEntities "github.com/ZupIT/horusec/internal/entities/docker"
+	"github.com/ZupIT/horusec/internal/enums/images"
 	"github.com/ZupIT/horusec/internal/helpers/messages"
 	"github.com/ZupIT/horusec/internal/services/formatters"
 	"github.com/ZupIT/horusec/internal/services/formatters/hcl/tfsec/entities"
+	vulnhash "github.com/ZupIT/horusec/internal/utils/vuln_hash"
 )
 
 type Formatter struct {

--- a/internal/services/formatters/hcl/tfsec/formatter_test.go
+++ b/internal/services/formatters/hcl/tfsec/formatter_test.go
@@ -18,17 +18,15 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
-	"github.com/ZupIT/horusec/internal/utils/testutil"
-
 	entitiesAnalysis "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
-
 	"github.com/stretchr/testify/assert"
 
 	cliConfig "github.com/ZupIT/horusec/config"
+	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
 	"github.com/ZupIT/horusec/internal/entities/workdir"
 	"github.com/ZupIT/horusec/internal/services/formatters"
+	"github.com/ZupIT/horusec/internal/utils/testutil"
 )
 
 func TestStartHCLTfSec(t *testing.T) {

--- a/internal/services/formatters/interface.go
+++ b/internal/services/formatters/interface.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 	engine "github.com/ZupIT/horusec-engine"
+
 	commitauthor "github.com/ZupIT/horusec/internal/entities/commit_author"
 	"github.com/ZupIT/horusec/internal/entities/docker"
 )

--- a/internal/services/formatters/java/horusecjava/formatter.go
+++ b/internal/services/formatters/java/horusecjava/formatter.go
@@ -16,6 +16,7 @@ package horusecjava
 
 import (
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
+
 	"github.com/ZupIT/horusec/internal/services/engines/java"
 	"github.com/ZupIT/horusec/internal/services/formatters"
 )

--- a/internal/services/formatters/javascript/horusecjavascript/formatter.go
+++ b/internal/services/formatters/javascript/horusecjavascript/formatter.go
@@ -16,6 +16,7 @@ package horusecjavascript
 
 import (
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
+
 	"github.com/ZupIT/horusec/internal/services/engines/javascript"
 	"github.com/ZupIT/horusec/internal/services/formatters"
 )

--- a/internal/services/formatters/javascript/npmaudit/entities/issue_test.go
+++ b/internal/services/formatters/javascript/npmaudit/entities/issue_test.go
@@ -17,9 +17,8 @@ package entities
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/ZupIT/horusec-devkit/pkg/enums/severities"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetVersion(t *testing.T) {

--- a/internal/services/formatters/javascript/npmaudit/formatter.go
+++ b/internal/services/formatters/javascript/npmaudit/formatter.go
@@ -24,16 +24,16 @@ import (
 	"strings"
 
 	"github.com/ZupIT/horusec-devkit/pkg/entities/vulnerability"
-	vulnhash "github.com/ZupIT/horusec/internal/utils/vuln_hash"
-
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
+
 	dockerEntities "github.com/ZupIT/horusec/internal/entities/docker"
 	"github.com/ZupIT/horusec/internal/enums/images"
 	"github.com/ZupIT/horusec/internal/helpers/messages"
 	"github.com/ZupIT/horusec/internal/services/formatters"
 	"github.com/ZupIT/horusec/internal/services/formatters/javascript/npmaudit/entities"
+	vulnhash "github.com/ZupIT/horusec/internal/utils/vuln_hash"
 )
 
 type Formatter struct {

--- a/internal/services/formatters/javascript/npmaudit/formatter_test.go
+++ b/internal/services/formatters/javascript/npmaudit/formatter_test.go
@@ -18,17 +18,15 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
-	"github.com/ZupIT/horusec/internal/utils/testutil"
-
 	entitiesAnalysis "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
-
 	"github.com/stretchr/testify/assert"
 
 	cliConfig "github.com/ZupIT/horusec/config"
+	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
 	"github.com/ZupIT/horusec/internal/entities/workdir"
 	"github.com/ZupIT/horusec/internal/services/formatters"
+	"github.com/ZupIT/horusec/internal/utils/testutil"
 )
 
 func TestStartNpmAudit(t *testing.T) {

--- a/internal/services/formatters/javascript/yarnaudit/entities/issue_test.go
+++ b/internal/services/formatters/javascript/yarnaudit/entities/issue_test.go
@@ -17,9 +17,8 @@ package entities
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/ZupIT/horusec-devkit/pkg/enums/severities"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetVersion(t *testing.T) {

--- a/internal/services/formatters/javascript/yarnaudit/formatter_test.go
+++ b/internal/services/formatters/javascript/yarnaudit/formatter_test.go
@@ -18,17 +18,15 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
-	"github.com/ZupIT/horusec/internal/utils/testutil"
-
 	entitiesAnalysis "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
-
 	"github.com/stretchr/testify/assert"
 
 	cliConfig "github.com/ZupIT/horusec/config"
+	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
 	"github.com/ZupIT/horusec/internal/entities/workdir"
 	"github.com/ZupIT/horusec/internal/services/formatters"
+	"github.com/ZupIT/horusec/internal/utils/testutil"
 )
 
 func TestParseOutputYarn(t *testing.T) {

--- a/internal/services/formatters/kotlin/horuseckotlin/formatter.go
+++ b/internal/services/formatters/kotlin/horuseckotlin/formatter.go
@@ -16,6 +16,7 @@ package horuseckotlin
 
 import (
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
+
 	"github.com/ZupIT/horusec/internal/services/engines/kotlin"
 	"github.com/ZupIT/horusec/internal/services/formatters"
 )

--- a/internal/services/formatters/leaks/gitleaks/formatter.go
+++ b/internal/services/formatters/leaks/gitleaks/formatter.go
@@ -19,20 +19,18 @@ import (
 	"errors"
 	"strings"
 
-	vulnhash "github.com/ZupIT/horusec/internal/utils/vuln_hash"
-
-	"github.com/ZupIT/horusec/internal/enums/images"
-
-	"github.com/ZupIT/horusec/internal/services/formatters/leaks/gitleaks/entities"
-
 	"github.com/ZupIT/horusec-devkit/pkg/entities/vulnerability"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/severities"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
+
 	dockerEntities "github.com/ZupIT/horusec/internal/entities/docker"
+	"github.com/ZupIT/horusec/internal/enums/images"
 	"github.com/ZupIT/horusec/internal/helpers/messages"
 	"github.com/ZupIT/horusec/internal/services/formatters"
+	"github.com/ZupIT/horusec/internal/services/formatters/leaks/gitleaks/entities"
+	vulnhash "github.com/ZupIT/horusec/internal/utils/vuln_hash"
 )
 
 type Formatter struct {

--- a/internal/services/formatters/leaks/gitleaks/formatter_test.go
+++ b/internal/services/formatters/leaks/gitleaks/formatter_test.go
@@ -19,19 +19,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
-	"github.com/ZupIT/horusec/internal/utils/testutil"
-
 	entitiesAnalysis "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
 	enumsAnalysis "github.com/ZupIT/horusec-devkit/pkg/enums/analysis"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
-
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 
 	cliConfig "github.com/ZupIT/horusec/config"
+	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
 	"github.com/ZupIT/horusec/internal/entities/workdir"
 	"github.com/ZupIT/horusec/internal/services/formatters"
+	"github.com/ZupIT/horusec/internal/utils/testutil"
 )
 
 func AnalysisMock() *entitiesAnalysis.Analysis {

--- a/internal/services/formatters/leaks/horusecleaks/formatter.go
+++ b/internal/services/formatters/leaks/horusecleaks/formatter.go
@@ -16,6 +16,7 @@ package horusecleaks
 
 import (
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
+
 	"github.com/ZupIT/horusec/internal/services/engines/leaks"
 	"github.com/ZupIT/horusec/internal/services/formatters"
 )

--- a/internal/services/formatters/nginx/horusecnginx/formatter.go
+++ b/internal/services/formatters/nginx/horusecnginx/formatter.go
@@ -16,6 +16,7 @@ package horusecnginx
 
 import (
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
+
 	"github.com/ZupIT/horusec/internal/services/engines/nginx"
 	"github.com/ZupIT/horusec/internal/services/formatters"
 )

--- a/internal/services/formatters/php/phpcs/formatter.go
+++ b/internal/services/formatters/php/phpcs/formatter.go
@@ -18,19 +18,17 @@ import (
 	"encoding/json"
 
 	"github.com/ZupIT/horusec-devkit/pkg/entities/vulnerability"
-	vulnhash "github.com/ZupIT/horusec/internal/utils/vuln_hash"
-
-	"github.com/ZupIT/horusec/internal/enums/images"
-
-	"github.com/ZupIT/horusec/internal/services/formatters/php/phpcs/entities"
-
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/severities"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
+
 	dockerEntities "github.com/ZupIT/horusec/internal/entities/docker"
+	"github.com/ZupIT/horusec/internal/enums/images"
 	"github.com/ZupIT/horusec/internal/helpers/messages"
 	"github.com/ZupIT/horusec/internal/services/formatters"
+	"github.com/ZupIT/horusec/internal/services/formatters/php/phpcs/entities"
+	vulnhash "github.com/ZupIT/horusec/internal/utils/vuln_hash"
 )
 
 type Formatter struct {

--- a/internal/services/formatters/php/phpcs/formatter_test.go
+++ b/internal/services/formatters/php/phpcs/formatter_test.go
@@ -18,16 +18,15 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
-	"github.com/ZupIT/horusec/internal/utils/testutil"
-
-	"github.com/stretchr/testify/assert"
-
 	entitiesAnalysis "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
+	"github.com/stretchr/testify/assert"
+
 	cliConfig "github.com/ZupIT/horusec/config"
+	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
 	"github.com/ZupIT/horusec/internal/entities/workdir"
 	"github.com/ZupIT/horusec/internal/services/formatters"
+	"github.com/ZupIT/horusec/internal/utils/testutil"
 )
 
 func TestStartCFlawfinder(t *testing.T) {

--- a/internal/services/formatters/python/bandit/formatter.go
+++ b/internal/services/formatters/python/bandit/formatter.go
@@ -20,17 +20,16 @@ import (
 	"strings"
 
 	"github.com/ZupIT/horusec-devkit/pkg/entities/vulnerability"
-	vulnhash "github.com/ZupIT/horusec/internal/utils/vuln_hash"
-
-	"github.com/ZupIT/horusec/internal/enums/images"
-
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
+
 	dockerEntities "github.com/ZupIT/horusec/internal/entities/docker"
+	"github.com/ZupIT/horusec/internal/enums/images"
 	"github.com/ZupIT/horusec/internal/helpers/messages"
 	"github.com/ZupIT/horusec/internal/services/formatters"
 	"github.com/ZupIT/horusec/internal/services/formatters/python/bandit/entities"
+	vulnhash "github.com/ZupIT/horusec/internal/utils/vuln_hash"
 )
 
 type Formatter struct {

--- a/internal/services/formatters/python/bandit/formatter_test.go
+++ b/internal/services/formatters/python/bandit/formatter_test.go
@@ -19,19 +19,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
-	"github.com/ZupIT/horusec/internal/utils/testutil"
-
 	entitiesAnalysis "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
 	enumHorusec "github.com/ZupIT/horusec-devkit/pkg/enums/analysis"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
-
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 
 	cliConfig "github.com/ZupIT/horusec/config"
+	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
 	"github.com/ZupIT/horusec/internal/entities/workdir"
 	"github.com/ZupIT/horusec/internal/services/formatters"
+	"github.com/ZupIT/horusec/internal/utils/testutil"
 )
 
 func getAnalysis() *entitiesAnalysis.Analysis {

--- a/internal/services/formatters/python/safety/formatter.go
+++ b/internal/services/formatters/python/safety/formatter.go
@@ -25,19 +25,18 @@ import (
 	"strings"
 
 	"github.com/ZupIT/horusec-devkit/pkg/entities/vulnerability"
-	"github.com/ZupIT/horusec/internal/utils/file"
-	vulnhash "github.com/ZupIT/horusec/internal/utils/vuln_hash"
-
-	"github.com/ZupIT/horusec/internal/enums/images"
-
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/severities"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
+
 	dockerEntities "github.com/ZupIT/horusec/internal/entities/docker"
+	"github.com/ZupIT/horusec/internal/enums/images"
 	"github.com/ZupIT/horusec/internal/helpers/messages"
 	"github.com/ZupIT/horusec/internal/services/formatters"
 	"github.com/ZupIT/horusec/internal/services/formatters/python/safety/entities"
+	"github.com/ZupIT/horusec/internal/utils/file"
+	vulnhash "github.com/ZupIT/horusec/internal/utils/vuln_hash"
 )
 
 type Formatter struct {

--- a/internal/services/formatters/python/safety/formatter_test.go
+++ b/internal/services/formatters/python/safety/formatter_test.go
@@ -19,19 +19,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
-	"github.com/ZupIT/horusec/internal/utils/testutil"
-
 	entitiesAnalysis "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
 	enumHorusec "github.com/ZupIT/horusec-devkit/pkg/enums/analysis"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
-
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 
 	cliConfig "github.com/ZupIT/horusec/config"
+	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
 	"github.com/ZupIT/horusec/internal/entities/workdir"
 	"github.com/ZupIT/horusec/internal/services/formatters"
+	"github.com/ZupIT/horusec/internal/utils/testutil"
 )
 
 func getAnalysis() *entitiesAnalysis.Analysis {

--- a/internal/services/formatters/ruby/brakeman/entities/warning.go
+++ b/internal/services/formatters/ruby/brakeman/entities/warning.go
@@ -19,7 +19,6 @@ import (
 	"strconv"
 
 	"github.com/ZupIT/horusec-devkit/pkg/enums/confidence"
-
 	"github.com/ZupIT/horusec-devkit/pkg/enums/severities"
 )
 

--- a/internal/services/formatters/ruby/brakeman/entities/warning_test.go
+++ b/internal/services/formatters/ruby/brakeman/entities/warning_test.go
@@ -17,9 +17,8 @@ package entities
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/ZupIT/horusec-devkit/pkg/enums/severities"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetDetails(t *testing.T) {

--- a/internal/services/formatters/ruby/brakeman/formatter.go
+++ b/internal/services/formatters/ruby/brakeman/formatter.go
@@ -19,18 +19,17 @@ import (
 	"strings"
 
 	"github.com/ZupIT/horusec-devkit/pkg/entities/vulnerability"
-	vulnhash "github.com/ZupIT/horusec/internal/utils/vuln_hash"
-
-	"github.com/ZupIT/horusec/internal/enums/images"
-
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
+
 	dockerEntities "github.com/ZupIT/horusec/internal/entities/docker"
 	errorsEnums "github.com/ZupIT/horusec/internal/enums/errors"
+	"github.com/ZupIT/horusec/internal/enums/images"
 	"github.com/ZupIT/horusec/internal/helpers/messages"
 	"github.com/ZupIT/horusec/internal/services/formatters"
 	"github.com/ZupIT/horusec/internal/services/formatters/ruby/brakeman/entities"
+	vulnhash "github.com/ZupIT/horusec/internal/utils/vuln_hash"
 )
 
 type Formatter struct {

--- a/internal/services/formatters/ruby/brakeman/formatter_test.go
+++ b/internal/services/formatters/ruby/brakeman/formatter_test.go
@@ -18,17 +18,15 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
-	"github.com/ZupIT/horusec/internal/utils/testutil"
-
 	entitiesAnalysis "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
-
 	"github.com/stretchr/testify/assert"
 
 	cliConfig "github.com/ZupIT/horusec/config"
+	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
 	"github.com/ZupIT/horusec/internal/entities/workdir"
 	"github.com/ZupIT/horusec/internal/services/formatters"
+	"github.com/ZupIT/horusec/internal/utils/testutil"
 )
 
 func TestParseOutput(t *testing.T) {

--- a/internal/services/formatters/ruby/bundler/entities/output.go
+++ b/internal/services/formatters/ruby/bundler/entities/output.go
@@ -19,9 +19,9 @@ import (
 	"strings"
 
 	"github.com/ZupIT/horusec-devkit/pkg/enums/confidence"
-	"github.com/ZupIT/horusec/internal/services/formatters/ruby/bundler/entities/enums"
-
 	"github.com/ZupIT/horusec-devkit/pkg/enums/severities"
+
+	"github.com/ZupIT/horusec/internal/services/formatters/ruby/bundler/entities/enums"
 )
 
 type Output struct {

--- a/internal/services/formatters/ruby/bundler/formatter.go
+++ b/internal/services/formatters/ruby/bundler/formatter.go
@@ -23,19 +23,18 @@ import (
 
 	"github.com/ZupIT/horusec-devkit/pkg/entities/vulnerability"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/confidence"
-	"github.com/ZupIT/horusec/internal/utils/file"
-	vulnhash "github.com/ZupIT/horusec/internal/utils/vuln_hash"
-
-	"github.com/ZupIT/horusec/internal/enums/images"
-
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
+
 	dockerEntities "github.com/ZupIT/horusec/internal/entities/docker"
 	errorsEnums "github.com/ZupIT/horusec/internal/enums/errors"
+	"github.com/ZupIT/horusec/internal/enums/images"
 	"github.com/ZupIT/horusec/internal/helpers/messages"
 	"github.com/ZupIT/horusec/internal/services/formatters"
 	"github.com/ZupIT/horusec/internal/services/formatters/ruby/bundler/entities"
+	"github.com/ZupIT/horusec/internal/utils/file"
+	vulnhash "github.com/ZupIT/horusec/internal/utils/vuln_hash"
 )
 
 type Formatter struct {

--- a/internal/services/formatters/ruby/bundler/formatter_test.go
+++ b/internal/services/formatters/ruby/bundler/formatter_test.go
@@ -18,17 +18,15 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
-	"github.com/ZupIT/horusec/internal/utils/testutil"
-
 	entitiesAnalysis "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
-
 	"github.com/stretchr/testify/assert"
 
 	cliConfig "github.com/ZupIT/horusec/config"
+	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
 	"github.com/ZupIT/horusec/internal/entities/workdir"
 	"github.com/ZupIT/horusec/internal/services/formatters"
+	"github.com/ZupIT/horusec/internal/utils/testutil"
 )
 
 func TestParseOutput(t *testing.T) {

--- a/internal/services/formatters/service.go
+++ b/internal/services/formatters/service.go
@@ -25,21 +25,21 @@ import (
 	"github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
 	"github.com/ZupIT/horusec-devkit/pkg/entities/vulnerability"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/confidence"
-	commitauthor "github.com/ZupIT/horusec/internal/entities/commit_author"
-	"github.com/ZupIT/horusec/internal/utils/file"
-	vulnhash "github.com/ZupIT/horusec/internal/utils/vuln_hash"
-
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/severities"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
 	engine "github.com/ZupIT/horusec-engine"
+
 	"github.com/ZupIT/horusec/config"
+	commitauthor "github.com/ZupIT/horusec/internal/entities/commit_author"
 	dockerentity "github.com/ZupIT/horusec/internal/entities/docker"
 	"github.com/ZupIT/horusec/internal/helpers/messages"
 	custonrules "github.com/ZupIT/horusec/internal/services/custom_rules"
 	"github.com/ZupIT/horusec/internal/services/docker"
 	"github.com/ZupIT/horusec/internal/services/git"
+	"github.com/ZupIT/horusec/internal/utils/file"
+	vulnhash "github.com/ZupIT/horusec/internal/utils/vuln_hash"
 )
 
 // MaxCharacters is the maximum length of code that a vulnerability can have.
@@ -265,6 +265,7 @@ func (s *Service) GetConfigCMDByFileExtension(projectSubPath, imageCmd, ext stri
 func (s *Service) GetProjectPathWithWorkdir(projectSubPath string) string {
 	return filepath.Join(s.GetConfigProjectPath(), projectSubPath)
 }
+
 func (s *Service) IsDockerDisabled() bool {
 	return s.config.DisableDocker
 }

--- a/internal/services/formatters/service_test.go
+++ b/internal/services/formatters/service_test.go
@@ -23,30 +23,26 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
-	"github.com/ZupIT/horusec/internal/entities/workdir"
-	"github.com/ZupIT/horusec/internal/helpers/messages"
-	"github.com/ZupIT/horusec/internal/utils/testutil"
-
+	"github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
+	"github.com/ZupIT/horusec-devkit/pkg/entities/vulnerability"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/confidence"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/severities"
+	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
+	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
 	engine "github.com/ZupIT/horusec-engine"
-
-	commitauthor "github.com/ZupIT/horusec/internal/entities/commit_author"
-	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
-
-	"github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
-	"github.com/ZupIT/horusec-devkit/pkg/entities/vulnerability"
-
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 	"github.com/ZupIT/horusec/config"
+	commitauthor "github.com/ZupIT/horusec/internal/entities/commit_author"
 	dockerentities "github.com/ZupIT/horusec/internal/entities/docker"
+	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
+	"github.com/ZupIT/horusec/internal/entities/workdir"
+	"github.com/ZupIT/horusec/internal/helpers/messages"
 	"github.com/ZupIT/horusec/internal/services/engines/java"
+	"github.com/ZupIT/horusec/internal/utils/testutil"
 )
 
 func TestParseFindingsToVulnerabilities(t *testing.T) {
@@ -100,7 +96,6 @@ func TestParseFindingsToVulnerabilities(t *testing.T) {
 	require.Len(t, analysis.AnalysisVulnerabilities, len(expectedVulnerabilities))
 	for idx := range expectedVulnerabilities {
 		assert.Equal(t, expectedVulnerabilities[idx], analysis.AnalysisVulnerabilities[idx].Vulnerability)
-
 	}
 }
 
@@ -208,7 +203,6 @@ func TestGetCommitAuthor(t *testing.T) {
 		assert.NotEmpty(t, result)
 		assert.NotEqual(t, notExpected, result)
 	})
-
 }
 
 func TestGetConfigProjectPath(t *testing.T) {
@@ -456,7 +450,7 @@ func TestGetFilepathFromFilename(t *testing.T) {
 		relativeFilePath := filepath.Join("examples", "go", "example1")
 		filename := "server.go"
 
-		err := os.MkdirAll(filepath.Join(dirName, relativeFilePath), 0700)
+		err := os.MkdirAll(filepath.Join(dirName, relativeFilePath), 0o700)
 		assert.NoError(t, err)
 
 		file, err := os.Create(filepath.Join(dirName, relativeFilePath, filename))
@@ -470,7 +464,6 @@ func TestGetFilepathFromFilename(t *testing.T) {
 			_ = file.Close()
 			_ = os.RemoveAll(dirName)
 		})
-
 	})
 	t.Run("should return empty when path from filename is not found", func(t *testing.T) {
 		cfg := &config.Config{
@@ -500,7 +493,7 @@ func TestGetConfigCMDByFileExtension(t *testing.T) {
 		relativeFilePath := filepath.Join("examples", "go", "example1", "/")
 		filename := "package-lock.json"
 
-		err := os.MkdirAll(filepath.Join(dirName, relativeFilePath), 0700)
+		err := os.MkdirAll(filepath.Join(dirName, relativeFilePath), 0o700)
 		assert.NoError(t, err)
 		file, err := os.Create(filepath.Join(dirName, relativeFilePath, filename))
 		assert.NotNil(t, file)
@@ -535,7 +528,6 @@ func TestGetConfigCMDByFileExtension(t *testing.T) {
 			_ = file.Close()
 			_ = os.RemoveAll(dirName)
 		})
-
 	})
 	t.Run("should return cmd when cmd has no workdir", func(t *testing.T) {
 		cfg := &config.Config{

--- a/internal/services/formatters/shell/shellcheck/formatter.go
+++ b/internal/services/formatters/shell/shellcheck/formatter.go
@@ -19,20 +19,18 @@ import (
 	"strings"
 
 	"github.com/ZupIT/horusec-devkit/pkg/entities/vulnerability"
-	vulnhash "github.com/ZupIT/horusec/internal/utils/vuln_hash"
-
-	"github.com/ZupIT/horusec/internal/enums/images"
-
 	"github.com/ZupIT/horusec-devkit/pkg/enums/confidence"
-	"github.com/ZupIT/horusec-devkit/pkg/enums/severities"
-
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
+	"github.com/ZupIT/horusec-devkit/pkg/enums/severities"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
+
 	dockerEntities "github.com/ZupIT/horusec/internal/entities/docker"
+	"github.com/ZupIT/horusec/internal/enums/images"
 	"github.com/ZupIT/horusec/internal/helpers/messages"
 	"github.com/ZupIT/horusec/internal/services/formatters"
 	"github.com/ZupIT/horusec/internal/services/formatters/shell/shellcheck/entities"
+	vulnhash "github.com/ZupIT/horusec/internal/utils/vuln_hash"
 )
 
 type Formatter struct {

--- a/internal/services/formatters/shell/shellcheck/formatter_test.go
+++ b/internal/services/formatters/shell/shellcheck/formatter_test.go
@@ -18,17 +18,15 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
-	"github.com/ZupIT/horusec/internal/utils/testutil"
-
 	entitiesAnalysis "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
-
 	"github.com/stretchr/testify/assert"
 
 	cliConfig "github.com/ZupIT/horusec/config"
+	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
 	"github.com/ZupIT/horusec/internal/entities/workdir"
 	"github.com/ZupIT/horusec/internal/services/formatters"
+	"github.com/ZupIT/horusec/internal/utils/testutil"
 )
 
 func TestParseOutput(t *testing.T) {

--- a/internal/services/formatters/swift/horusecswift/formatter.go
+++ b/internal/services/formatters/swift/horusecswift/formatter.go
@@ -16,6 +16,7 @@ package horusecswift
 
 import (
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
+
 	"github.com/ZupIT/horusec/internal/services/engines/swift"
 	"github.com/ZupIT/horusec/internal/services/formatters"
 )

--- a/internal/services/formatters/yaml/horuseckubernetes/formatter.go
+++ b/internal/services/formatters/yaml/horuseckubernetes/formatter.go
@@ -16,6 +16,7 @@ package horuseckubernetes
 
 import (
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
+
 	"github.com/ZupIT/horusec/internal/services/engines/kubernetes"
 	"github.com/ZupIT/horusec/internal/services/formatters"
 )

--- a/internal/services/git/git.go
+++ b/internal/services/git/git.go
@@ -24,10 +24,10 @@ import (
 	"strconv"
 	"strings"
 
-	commitauthor "github.com/ZupIT/horusec/internal/entities/commit_author"
-
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
+
 	"github.com/ZupIT/horusec/config"
+	commitauthor "github.com/ZupIT/horusec/internal/entities/commit_author"
 	"github.com/ZupIT/horusec/internal/helpers/messages"
 )
 

--- a/internal/services/horusec_api/horus_api.go
+++ b/internal/services/horusec_api/horus_api.go
@@ -22,12 +22,12 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/google/uuid"
-
 	"github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
 	"github.com/ZupIT/horusec-devkit/pkg/entities/cli"
 	"github.com/ZupIT/horusec-devkit/pkg/services/http/request"
 	"github.com/ZupIT/horusec-devkit/pkg/services/http/request/entities"
+	"github.com/google/uuid"
+
 	"github.com/ZupIT/horusec/config"
 )
 

--- a/internal/services/horusec_api/horus_api_test.go
+++ b/internal/services/horusec_api/horus_api_test.go
@@ -26,11 +26,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
+	enumHorusec "github.com/ZupIT/horusec-devkit/pkg/enums/analysis"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
-	enumHorusec "github.com/ZupIT/horusec-devkit/pkg/enums/analysis"
 	cliConfig "github.com/ZupIT/horusec/config"
 )
 
@@ -54,6 +54,7 @@ func createSendHandlerWithStatus(status int) http.HandlerFunc {
 		w.WriteHeader(status)
 	}
 }
+
 func createFindHandlerWithStatus(status int) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		type Content struct {
@@ -130,7 +131,6 @@ func TestServiceSendAnalysis(t *testing.T) {
 					_, err = io.WriteString(file, string(localhostCert))
 					assert.NoError(t, err)
 					return svr, file
-
 				},
 			},
 
@@ -159,7 +159,6 @@ func TestServiceSendAnalysis(t *testing.T) {
 					_, err = io.WriteString(file, string(localhostCert))
 					assert.NoError(t, err)
 					return svr, file
-
 				},
 			},
 
@@ -188,7 +187,6 @@ func TestServiceSendAnalysis(t *testing.T) {
 					_, err = io.WriteString(file, string(localhostCert))
 					assert.NoError(t, err)
 					return svr, file
-
 				},
 			},
 			wantErr: true,
@@ -216,7 +214,6 @@ func TestServiceSendAnalysis(t *testing.T) {
 					_, err = io.WriteString(file, string(localhostCert))
 					assert.NoError(t, err)
 					return svr, file
-
 				},
 			},
 			wantErr: true,
@@ -244,7 +241,6 @@ func TestServiceSendAnalysis(t *testing.T) {
 					_, err = io.WriteString(file, string(localhostCert))
 					assert.NoError(t, err)
 					return svr, file
-
 				},
 			},
 			wantErr: true,
@@ -272,7 +268,6 @@ func TestServiceSendAnalysis(t *testing.T) {
 					_, err = io.WriteString(file, "invalidCertificate")
 					assert.NoError(t, err)
 					return svr, file
-
 				},
 			},
 			wantErr: true,
@@ -389,7 +384,6 @@ func TestServiceGetAnalysis(t *testing.T) {
 					_, err = io.WriteString(file, string(localhostCert))
 					assert.NoError(t, err)
 					return svr, file
-
 				},
 			},
 			want:    expectedUUID,
@@ -414,7 +408,6 @@ func TestServiceGetAnalysis(t *testing.T) {
 					_, err = io.WriteString(file, "invalidCertificate")
 					assert.NoError(t, err)
 					return svr, file
-
 				},
 			},
 			want:    expectedUUID,

--- a/internal/services/sonarqube/sonarqube.go
+++ b/internal/services/sonarqube/sonarqube.go
@@ -17,11 +17,11 @@ package sonarqube
 import (
 	"strconv"
 
-	"github.com/ZupIT/horusec/internal/entities/sonarqube"
-
 	horusecEntities "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
 	vulnEntity "github.com/ZupIT/horusec-devkit/pkg/entities/vulnerability"
 	horusecSeverity "github.com/ZupIT/horusec-devkit/pkg/enums/severities"
+
+	"github.com/ZupIT/horusec/internal/entities/sonarqube"
 )
 
 type SonarQube struct {

--- a/internal/services/sonarqube/sonarqube_test.go
+++ b/internal/services/sonarqube/sonarqube_test.go
@@ -18,13 +18,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-
 	"github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
 	"github.com/ZupIT/horusec-devkit/pkg/entities/vulnerability"
 	enumHorusec "github.com/ZupIT/horusec-devkit/pkg/enums/analysis"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/severities"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestConvertVulnerabilityDataToSonarQube(t *testing.T) {

--- a/internal/usecases/cli/cli.go
+++ b/internal/usecases/cli/cli.go
@@ -23,13 +23,12 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/ZupIT/horusec-devkit/pkg/enums/severities"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/vulnerability"
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
-
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/go-ozzo/ozzo-validation/v4/is"
 
-	"github.com/ZupIT/horusec-devkit/pkg/enums/severities"
 	"github.com/ZupIT/horusec/config"
 	"github.com/ZupIT/horusec/internal/entities/workdir"
 	"github.com/ZupIT/horusec/internal/enums/outputtype"
@@ -225,6 +224,7 @@ func isVulnerabilityValid(vulnType string) bool {
 	}
 	return false
 }
+
 func checkIfIsURL(rawURL string) validation.RuleFunc {
 	return func(value interface{}) error {
 		_, err := url.ParseRequestURI(rawURL)

--- a/internal/usecases/cli/cli_test.go
+++ b/internal/usecases/cli/cli_test.go
@@ -20,16 +20,13 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/google/uuid"
-
 	validation "github.com/go-ozzo/ozzo-validation/v4"
-
-	"github.com/ZupIT/horusec/internal/enums/outputtype"
-
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/ZupIT/horusec/config"
 	"github.com/ZupIT/horusec/internal/entities/workdir"
+	"github.com/ZupIT/horusec/internal/enums/outputtype"
 )
 
 func TestValidateConfigs(t *testing.T) {

--- a/internal/utils/copy/copy_test.go
+++ b/internal/utils/copy/copy_test.go
@@ -63,5 +63,4 @@ func TestCopy(t *testing.T) {
 
 	assert.NoFileExists(t, filepath.Join(dst, "go.mod"))
 	assert.NoFileExists(t, filepath.Join(dst, "go.sum"))
-
 }

--- a/internal/utils/file/file.go
+++ b/internal/utils/file/file.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
+
 	"github.com/ZupIT/horusec/internal/helpers/messages"
 )
 

--- a/internal/utils/file/file_test.go
+++ b/internal/utils/file/file_test.go
@@ -20,10 +20,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/ZupIT/horusec/internal/services/formatters/csharp/dotnet_cli/enums"
-
 	"github.com/stretchr/testify/assert"
 
+	"github.com/ZupIT/horusec/internal/services/formatters/csharp/dotnet_cli/enums"
 	"github.com/ZupIT/horusec/internal/utils/testutil"
 )
 
@@ -62,6 +61,7 @@ func TestGetSubPathByExtension(t *testing.T) {
 		assert.Equal(t, "", response)
 	})
 }
+
 func TestCreateAndWriteFile(t *testing.T) {
 	wd := t.TempDir()
 	t.Run("Should create a file with input and return no error", func(t *testing.T) {
@@ -128,7 +128,6 @@ func TestGetDependencyCodeFilepathAndLine(t *testing.T) {
 		assert.Zero(t, file)
 		assert.Zero(t, line)
 	})
-
 }
 
 func TestGetCode(t *testing.T) {

--- a/internal/utils/json/json_test.go
+++ b/internal/utils/json/json_test.go
@@ -17,9 +17,8 @@ package json
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	horusecEntities "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestConvertInterfaceToMapString(t *testing.T) {

--- a/internal/utils/testutil/analysis_mock.go
+++ b/internal/utils/testutil/analysis_mock.go
@@ -17,18 +17,17 @@ package testutil
 import (
 	"time"
 
+	"github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
 	"github.com/ZupIT/horusec-devkit/pkg/entities/vulnerability"
 	analysisenum "github.com/ZupIT/horusec-devkit/pkg/enums/analysis"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/confidence"
-	vulnerabilityenum "github.com/ZupIT/horusec-devkit/pkg/enums/vulnerability"
-	vulnhash "github.com/ZupIT/horusec/internal/utils/vuln_hash"
-
-	"github.com/google/uuid"
-
-	"github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/severities"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
+	vulnerabilityenum "github.com/ZupIT/horusec-devkit/pkg/enums/vulnerability"
+	"github.com/google/uuid"
+
+	vulnhash "github.com/ZupIT/horusec/internal/utils/vuln_hash"
 )
 
 // CreateAnalysisMock creates a mocked plain entity to use in test suites.

--- a/internal/utils/testutil/analyzer_mock.go
+++ b/internal/utils/testutil/analyzer_mock.go
@@ -15,9 +15,8 @@
 package testutil
 
 import (
-	"github.com/stretchr/testify/mock"
-
 	mockutils "github.com/ZupIT/horusec-devkit/pkg/utils/mock"
+	"github.com/stretchr/testify/mock"
 )
 
 type AnalyzerMock struct {

--- a/internal/utils/testutil/binary.go
+++ b/internal/utils/testutil/binary.go
@@ -22,7 +22,6 @@ import (
 	"runtime"
 
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger/enums"
-
 	"github.com/onsi/ginkgo"
 )
 

--- a/internal/utils/testutil/docker_mock.go
+++ b/internal/utils/testutil/docker_mock.go
@@ -15,20 +15,17 @@
 package testutil
 
 import (
+	"context"
 	"io"
 
-	"github.com/docker/docker/api/types/network"
-
 	mockutils "github.com/ZupIT/horusec-devkit/pkg/utils/mock"
-
-	"context"
-
-	dockerentities "github.com/ZupIT/horusec/internal/entities/docker"
-
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/mock"
+
+	dockerentities "github.com/ZupIT/horusec/internal/entities/docker"
 )
 
 type DockerClientMock struct {

--- a/internal/utils/testutil/formatter_mock.go
+++ b/internal/utils/testutil/formatter_mock.go
@@ -15,13 +15,13 @@
 package testutil
 
 import (
-	"github.com/stretchr/testify/mock"
-
 	"github.com/ZupIT/horusec-devkit/pkg/entities/vulnerability"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 	mockutils "github.com/ZupIT/horusec-devkit/pkg/utils/mock"
 	engine "github.com/ZupIT/horusec-engine"
+	"github.com/stretchr/testify/mock"
+
 	commitauthor "github.com/ZupIT/horusec/internal/entities/commit_author"
 	dockerentities "github.com/ZupIT/horusec/internal/entities/docker"
 )

--- a/internal/utils/testutil/horusec_api_mock.go
+++ b/internal/utils/testutil/horusec_api_mock.go
@@ -15,12 +15,10 @@
 package testutil
 
 import (
+	"github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
+	utilsmock "github.com/ZupIT/horusec-devkit/pkg/utils/mock"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/mock"
-
-	utilsmock "github.com/ZupIT/horusec-devkit/pkg/utils/mock"
-
-	"github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
 )
 
 type HorusecAPIMock struct {

--- a/internal/utils/testutil/language_detect_mock.go
+++ b/internal/utils/testutil/language_detect_mock.go
@@ -15,10 +15,9 @@
 package testutil
 
 import (
-	"github.com/stretchr/testify/mock"
-
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
 	mockutils "github.com/ZupIT/horusec-devkit/pkg/utils/mock"
+	"github.com/stretchr/testify/mock"
 )
 
 type LanguageDetectMock struct {

--- a/internal/utils/testutil/print_results_mock.go
+++ b/internal/utils/testutil/print_results_mock.go
@@ -15,10 +15,9 @@
 package testutil
 
 import (
-	"github.com/stretchr/testify/mock"
-
 	entitiesAnalysis "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
 	mockutils "github.com/ZupIT/horusec-devkit/pkg/utils/mock"
+	"github.com/stretchr/testify/mock"
 )
 
 type PrintResultsMock struct {

--- a/internal/utils/testutil/prompt_mock.go
+++ b/internal/utils/testutil/prompt_mock.go
@@ -15,9 +15,8 @@
 package testutil
 
 import (
-	"github.com/stretchr/testify/mock"
-
 	mockutils "github.com/ZupIT/horusec-devkit/pkg/utils/mock"
+	"github.com/stretchr/testify/mock"
 )
 
 type PromptMock struct {
@@ -32,6 +31,7 @@ func (m *PromptMock) Ask(label, defaultValue string) (string, error) {
 	args := m.MethodCalled("Ask")
 	return args.Get(0).(string), mockutils.ReturnNilOrError(args, 1)
 }
+
 func (m *PromptMock) Select(label string, items []string) (string, error) {
 	args := m.MethodCalled("Select")
 	return args.Get(0).(string), mockutils.ReturnNilOrError(args, 1)

--- a/internal/utils/testutil/rules_test_generic.go
+++ b/internal/utils/testutil/rules_test_generic.go
@@ -17,11 +17,11 @@ package testutil
 import (
 	"testing"
 
+	engine "github.com/ZupIT/horusec-engine"
+	"github.com/ZupIT/horusec-engine/text"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	engine "github.com/ZupIT/horusec-engine"
-	"github.com/ZupIT/horusec-engine/text"
 	enginesenum "github.com/ZupIT/horusec/internal/enums/engines"
 )
 
@@ -49,6 +49,7 @@ func assertExpectedFindingAndRuleCase(t *testing.T, findings []engine.Finding, t
 		assert.Equal(t, tt.Rule.Description, finding.Description)
 	}
 }
+
 func TestSafeCode(t *testing.T, testcases []*RuleTestCase) {
 	for _, tt := range testcases {
 		t.Run(tt.Name, func(t *testing.T) {

--- a/internal/utils/vuln_hash/vuln_hash_test.go
+++ b/internal/utils/vuln_hash/vuln_hash_test.go
@@ -17,9 +17,8 @@ package vulnhash
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/ZupIT/horusec-devkit/pkg/entities/vulnerability"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBind(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Nathan Martins <nathan.martins@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

This pull request run some auto format tools for golang, the idea is to avoid messy imports and code. The first two are related to imports organization, the tools are [goimports](https://pkg.go.dev/golang.org/x/tools/cmd/goimports) and [gci](https://github.com/daixiang0/gci). The other two are the [gofmt](https://pkg.go.dev/cmd/gofmt) and [gofumpt](https://github.com/mvdan/gofumpt) which are formaters that focus on code. This pull request dependents on another other two, one updating the makefile with a format command and another updating lint with some new validations.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
