### PR TITLE
engine:chore - improvement tests for rules of the swift

### DIFF
--- a/internal/services/engines/java/rules.go
+++ b/internal/services/engines/java/rules.go
@@ -114,7 +114,7 @@ func NewXMLParsingVulnerableToXXEWithTransformerFactory() text.TextRule {
 	}
 }
 
-// DEPRECATED Repeated vulnerability, same as HS-JAVA-5
+// Deprecated: Repeated vulnerability, same as HS-JAVA-5
 //
 //func NewXMLParsingVulnerableToXXEWithSchemaFactory() text.TextRule {
 //	return text.TextRule{
@@ -272,7 +272,7 @@ func NewServerHostnamesShouldBeVerifiedDuringSSLTLSConnectionsWithMail() text.Te
 	}
 }
 
-// DEPRECATED Repeated vulnerability, same as HS-JAVA-14
+// Deprecated: Repeated vulnerability, same as HS-JAVA-14
 //
 //func NewServerHostnamesShouldBeVerifiedDuringSSLTLSConnectionsWithJakartaMail() text.TextRule {
 //	return text.TextRule{
@@ -291,7 +291,7 @@ func NewServerHostnamesShouldBeVerifiedDuringSSLTLSConnectionsWithMail() text.Te
 //	}
 //}
 
-// DEPRECATED Repeated vulnerability, same as HS-JAVA-11
+// Deprecated: Repeated vulnerability, same as HS-JAVA-11
 //
 //func NewTrustManagerThatAcceptAnyCertificatesServer() text.TextRule {
 //	return text.TextRule{
@@ -311,7 +311,7 @@ func NewServerHostnamesShouldBeVerifiedDuringSSLTLSConnectionsWithMail() text.Te
 //	}
 //}
 
-// DEPRECATED Repeated vulnerability, same as HS-JAVA-11
+// Deprecated: Repeated vulnerability, same as HS-JAVA-11
 //
 //func NewTrustManagerThatAcceptAnyCertificatesIssuers() text.TextRule {
 //	return text.TextRule{
@@ -365,7 +365,7 @@ func NewInsecureWebViewImplementation() text.TextRule {
 	}
 }
 
-// DEPRECATED Simply using SQL Cipher does not appear to be a vulnerability, to this becomes a vulnerability will
+// Deprecated: Simply using SQL Cipher does not appear to be a vulnerability, to this becomes a vulnerability will
 // depend on what is stored, how it was stored and the sql cipher version, removed to avoid false positives.
 // reference: https://www.zetetic.net/blog/2019/08/14/defcon-sqlite-attacks/
 //
@@ -386,7 +386,7 @@ func NewInsecureWebViewImplementation() text.TextRule {
 //	}
 //}
 
-// DEPRECATED This vulnerability should search for a hardcoded secret, the actual implemented way
+// Deprecated: This vulnerability should search for a hardcoded secret, the actual implemented way
 // will only lead to false positives, leaks engine already does a search for hardcoded credentials.
 // reference: https://rules.sonarsource.com/java/type/Vulnerability/RSPEC-6301?search=realm
 //
@@ -954,7 +954,7 @@ func NewQueryDatabaseOfSMSContacts() text.TextRule {
 	}
 }
 
-//Deprecated: the javax package is deprecated in the Jakarta EE newest version. We'll use jakarta package.
+// Deprecated: the javax package is deprecated in the Jakarta EE newest version. We'll use jakarta package.
 func NewPotentialPathTraversal() text.TextRule {
 	return text.TextRule{
 		Metadata: engine.Metadata{
@@ -1511,7 +1511,7 @@ func NewClassesShouldNotBeLoadedDynamically() text.TextRule {
 	}
 }
 
-// DEPRECATED Repeated vulnerability, same as HS-JAVA-12
+// Deprecated: Repeated vulnerability, same as HS-JAVA-12
 //
 //func NewHostnameVerifierVerifyShouldNotAlwaysReturnTrue() text.TextRule {
 //	return text.TextRule{
@@ -1638,7 +1638,7 @@ func NewOpenSAML2ShouldBeConfiguredToPreventAuthenticationBypass() text.TextRule
 	}
 }
 
-//Deprecated: the javax package is deprecated in the Jakarta EE newest version. We'll use jakarta package.
+// Deprecated: the javax package is deprecated in the Jakarta EE newest version. We'll use jakarta package.
 func NewHttpServletRequestGetRequestedSessionIdShouldNotBeUsed() text.TextRule {
 	return text.TextRule{
 		Metadata: engine.Metadata{
@@ -1690,7 +1690,7 @@ func NewLDAPAuthenticatedAnalyzeYourCode() text.TextRule {
 	}
 }
 
-//Deprecated: the javax package is deprecated in the Jakarta EE newest version. We'll use jakarta package.
+// Deprecated: the javax package is deprecated in the Jakarta EE newest version. We'll use jakarta package.
 func NewWebApplicationsShouldHotHaveAMainMethod() text.TextRule {
 	return text.TextRule{
 		Metadata: engine.Metadata{
@@ -1850,7 +1850,7 @@ func NewJARURLConnection() text.TextRule {
 	}
 }
 
-// DEPRECATED Repeated vulnerability, same as HS-JAVA-23
+// Deprecated: Repeated vulnerability, same as HS-JAVA-23
 //
 //func NewSetOrReadClipboardData() text.TextRule {
 //	return text.TextRule{
@@ -1870,7 +1870,7 @@ func NewJARURLConnection() text.TextRule {
 //	}
 //}
 
-// DEPRECATED Repeated vulnerability, same as HS-JAVA-111
+// Deprecated: Repeated vulnerability, same as HS-JAVA-111
 //
 //func NewMessageDigest() text.TextRule {
 //	return text.TextRule{

--- a/internal/services/engines/swift/rule_manager.go
+++ b/internal/services/engines/swift/rule_manager.go
@@ -38,7 +38,7 @@ func rules() []engine.Rule {
 		NewTLS13NotUsed(),
 		NewDTLS12NotUsed(),
 		NewCoreDataDatabase(),
-		NewSQLiteDatabase(),
+		//NewSQLiteDatabase(),
 
 		// Or rules
 		NewWeakDesCryptoCipher(),
@@ -57,5 +57,6 @@ func rules() []engine.Rule {
 		NewKeyboardCache(),
 		NewTLSMinimum(),
 		NewRealmDatabase(),
+		NewSQLInjection(),
 	}
 }

--- a/internal/services/engines/swift/rules.go
+++ b/internal/services/engines/swift/rules.go
@@ -23,22 +23,25 @@ import (
 	"github.com/ZupIT/horusec-engine/text"
 )
 
-func NewSQLiteDatabase() text.TextRule {
-	return text.TextRule{
-		Metadata: engine.Metadata{
-			ID:          "HS-SWIFT-1",
-			Name:        "SQLite Database",
-			Description: "App uses SQLite Database. Sensitive Information should be encrypted.",
-			Severity:    severities.Medium.ToString(),
-			Confidence:  confidence.Low.ToString(),
-		},
-		Type: text.AndMatch,
-		Expressions: []*regexp.Regexp{
-			regexp.MustCompile(`sqlite3_exec`),
-			regexp.MustCompile(`sqlite3_finalize`),
-		},
-	}
-}
+// Deprecated: This rule is not usage really in any swift project,
+// because when use sqlite3_exec internally it's running the commands sqlite3_prepare_v2, sqlite3_step, sqlite3_finalize
+// then is not necessary use sqlite3_finalize and this rule not will get anywhere vulnerability
+//func NewSQLiteDatabase() text.TextRule {
+//	return text.TextRule{
+//		Metadata: engine.Metadata{
+//			ID:          "HS-SWIFT-1",
+//			Name:        "SQLite Database",
+//			Description: "App uses SQLite Database. Sensitive Information should be encrypted.",
+//			Severity:    severities.Medium.ToString(),
+//			Confidence:  confidence.Low.ToString(),
+//		},
+//		Type: text.AndMatch,
+//		Expressions: []*regexp.Regexp{
+//			regexp.MustCompile(`sqlite3_exec`),
+//			regexp.MustCompile(`sqlite3_finalize`),
+//		},
+//	}
+//}
 
 func NewCoreDataDatabase() text.TextRule {
 	return text.TextRule{
@@ -449,6 +452,22 @@ func NewMD2Collision() text.TextRule {
 		Type: text.Regular,
 		Expressions: []*regexp.Regexp{
 			regexp.MustCompile(`CC_MD2\(`),
+		},
+	}
+}
+
+func NewSQLInjection() text.TextRule {
+	return text.TextRule{
+		Metadata: engine.Metadata{
+			ID:          "HS-SWIFT-24",
+			Name:        "SQL Injection",
+			Description: "The input values included in SQL queries need to be passed in safely. Bind variables in prepared statements can be used to easily mitigate the risk of SQL injection. For more information checkout the CWE-89 (https://cwe.mitre.org/data/definitions/89.html) advisory.",
+			Severity:    severities.High.ToString(),
+			Confidence:  confidence.Low.ToString(),
+		},
+		Type: text.Regular,
+		Expressions: []*regexp.Regexp{
+			regexp.MustCompile(`(?i)((sqlite3_exec|executeChange|raw)\(.?((.*|\n)*)?)?(select|update|insert|delete)((.*|\n)*)?.*((["|']*)(\s?)(\+))`),
 		},
 	}
 }

--- a/internal/services/engines/swift/rules_test.go
+++ b/internal/services/engines/swift/rules_test.go
@@ -37,6 +37,20 @@ func TestRulesVulnerableCode(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "HS-SWIFT-24",
+			Src:  SampleVulnerableHSSWIFT24,
+			Rule: NewSQLInjection(),
+			Findings: []engine.Finding{
+				{
+					CodeSample: `let err = SD.executeChange("SELECT * FROM User where user="+ valuesFromInput) {`,
+					SourceLocation: engine.Location{
+						Line:   2,
+						Column: 13,
+					},
+				},
+			},
+		},
 	}
 
 	testutil.TestVulnerableCode(t, testcases)
@@ -48,6 +62,11 @@ func TestRulesSafeCode(t *testing.T) {
 			Name: "HS-SWIFT-6",
 			Rule: NewWeakMD5CryptoCipher(),
 			Src:  SampleSafeHSSWIFT6,
+		},
+		{
+			Name: "HS-SWIFT-24",
+			Rule: NewSQLInjection(),
+			Src:  SampleSafeHSSWIFT24,
 		},
 	}
 	testutil.TestSafeCode(t, testcases)

--- a/internal/services/engines/swift/samples_test.go
+++ b/internal/services/engines/swift/samples_test.go
@@ -17,8 +17,18 @@ package swift
 const (
 	SampleVulnerableHSSWIFT6 = `import CryptoSwift
 
-		"SwiftSummit".md5()`
+		"SwiftSummit".md5()
+`
+	SampleVulnerableHSSWIFT24 = `
+let err = SD.executeChange("SELECT * FROM User where user="+ valuesFromInput) {
+    //there was an error during the insert, handle it here
+} else {
+    //no error, the row was inserted successfully
+}
+`
+)
 
+const (
 	SampleSafeHSSWIFT6 = `import Foundation
 import var CommonCrypto.CC_MD5_DIGEST_LENGTH
 import func CommonCrypto.CC_MD5
@@ -43,4 +53,12 @@ func MD5(string: String) -> Data {
 
 //Test:
 let md5Data = MD5(string:"Hello")`
+
+	SampleSafeHSSWIFT24 = `
+if let err = SD.executeChange("SELECT * FROM User where user=?", withArgs: [name, population, isWarm, foundedIn]) {
+    //there was an error during the insert, handle it here
+} else {
+    //no error, the row was inserted successfully
+}
+`
 )


### PR DESCRIPTION
- Add rule to HS-SWIFT-24
- Was removed HS-SWIFT-1 because: This rule is not affective, if need you can see this thread https://stackoverflow.com/questions/1718929/should-i-use-sqlite3-finalize-after-i-performed-a-query-with-sqlite3-exec

Signed-off-by: wilian <wilian.silva@zup.com.br>
