### PR TITLE
images:chore - upgrade Docker tags

### DIFF
--- a/internal/enums/images/images.go
+++ b/internal/enums/images/images.go
@@ -18,18 +18,18 @@ import "github.com/ZupIT/horusec-devkit/pkg/enums/languages"
 
 const (
 	DefaultRegistry = "docker.io"
-	C               = "horuszup/horusec-c:v1.0.0"
-	Csharp          = "horuszup/horusec-csharp:v1.0.1"
-	Elixir          = "horuszup/horusec-elixir:v1.0.0"
+	C               = "horuszup/horusec-c:v1.0.1"
+	Csharp          = "horuszup/horusec-csharp:v1.1.0"
+	Elixir          = "horuszup/horusec-elixir:v1.1.0"
 	Generic         = "horuszup/horusec-generic:v1.1.0"
-	Go              = "horuszup/horusec-go:v1.0.1"
+	Go              = "horuszup/horusec-go:v1.2.0"
 	HCL             = "horuszup/horusec-hcl:v1.1.0"
-	Javascript      = "horuszup/horusec-js:v1.0.0"
-	Leaks           = "horuszup/horusec-leaks:v1.0.1"
-	PHP             = "horuszup/horusec-php:v1.0.0"
+	Javascript      = "horuszup/horusec-js:v1.2.0"
+	Leaks           = "horuszup/horusec-leaks:v1.1.0"
+	PHP             = "horuszup/horusec-php:v1.0.1"
 	Python          = "horuszup/horusec-python:v1.0.0"
-	Ruby            = "horuszup/horusec-ruby:v1.0.2"
-	Shell           = "horuszup/horusec-shell:v1.0.0"
+	Ruby            = "horuszup/horusec-ruby:v1.1.0"
+	Shell           = "horuszup/horusec-shell:v1.0.1"
 )
 
 func MapValues() map[languages.Language]string {


### PR DESCRIPTION
This commit upgrade the tags for almost all languages that is supported
by Horusec.

Python was not upgraded because the safety and bandit was not released
with official support for Python 3.10.

Generic and HCL was not upgraded too because we need to upgrade the
installation script of tools that is installed on Dockerfile (tfsec,
semgrep and dependency check) which will be done separately.

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
