### PR TITLE
nancy:fix - empty file name, code and line on vulnerability result

### DIFF
--- a/internal/services/formatters/csharp/dotnet_cli/formatter.go
+++ b/internal/services/formatters/csharp/dotnet_cli/formatter.go
@@ -143,7 +143,7 @@ func (f *Formatter) parseFieldByIndex(index int, fieldValue string, dependency *
 
 func (f *Formatter) newVulnerability(dependency *dotnetDependency, projectSubPath string) *vulnerability.Vulnerability {
 	code, filePath, line := file.GetDependencyCodeFilepathAndLine(
-		f.GetConfigProjectPath(), projectSubPath, CsProjExt, dependency.Name,
+		f.GetConfigProjectPath(), projectSubPath, dependency.Name, CsProjExt,
 	)
 
 	vuln := &vulnerability.Vulnerability{

--- a/internal/services/formatters/go/nancy/formatter.go
+++ b/internal/services/formatters/go/nancy/formatter.go
@@ -33,7 +33,10 @@ import (
 	vulnHash "github.com/ZupIT/horusec/internal/utils/vuln_hash"
 )
 
-const goModulesExt = ".mod"
+const (
+	goModulesExt = ".mod"
+	goSumExt     = ".sum"
+)
 
 type Formatter struct {
 	formatters.IService
@@ -103,7 +106,7 @@ func (f *Formatter) newVulnerability(
 	projectSubPath string,
 ) *vulnerability.Vulnerability {
 	code, filePath, line := file.GetDependencyCodeFilepathAndLine(
-		f.GetConfigProjectPath(), projectSubPath, goModulesExt, vulnerable.getDependency(),
+		f.GetConfigProjectPath(), projectSubPath, vulnerable.getDependency(), goModulesExt, goSumExt,
 	)
 
 	vuln := &vulnerability.Vulnerability{

--- a/internal/services/formatters/go/nancy/formatter_test.go
+++ b/internal/services/formatters/go/nancy/formatter_test.go
@@ -47,21 +47,29 @@ func TestParseOutput(t *testing.T) {
 		formatter := NewFormatter(service)
 		formatter.StartAnalysis("")
 
-		assert.Len(t, analysis.AnalysisVulnerabilities, 2)
+		assert.False(t, analysis.HasErrors(), "Expected no errors on analysis: %s", analysis.Errors)
+		assert.Len(t, analysis.AnalysisVulnerabilities, 3)
 
-		for _, vuln := range analysis.AnalysisVulnerabilities {
-			assert.Equal(t, languages.Go, vuln.Vulnerability.Language, "Expected Go as vulnerability language")
-			assert.Equal(t, tools.Nancy, vuln.Vulnerability.SecurityTool, "Expected nancy as security tool")
-			assert.NotEmpty(t, vuln.Vulnerability.Severity, "Expected not empty vulnerability severity")
-			assert.NotEmpty(t, vuln.Vulnerability.Details, "Expected not empty vulnerability details")
-			assert.Equal(t, confidence.High, vuln.Vulnerability.Confidence, "Expected high as vulnerability confidence")
-			assert.NotEmpty(t, vuln.Vulnerability.Code, "Expected not empty vulnerability code")
-			assert.NotEmpty(t, vuln.Vulnerability.Line, "Expected not empty vulnerability line")
-			assert.Equal(
+		for _, v := range analysis.AnalysisVulnerabilities {
+			vuln := v.Vulnerability
+
+			expectedGoModPath := filepath.Join(cfg.ProjectPath, "go.mod")
+			expectedGoSumPath := filepath.Join(cfg.ProjectPath, "go.sum")
+
+			assert.Equal(t, languages.Go, vuln.Language, "Expected Go as vulnerability language")
+			assert.Equal(t, tools.Nancy, vuln.SecurityTool, "Expected nancy as security tool")
+			assert.NotEmpty(t, vuln.Severity, "Expected not empty vulnerability severity")
+			assert.NotEmpty(t, vuln.Details, "Expected not empty vulnerability details")
+			assert.Equal(t, confidence.High, vuln.Confidence, "Expected high as vulnerability confidence")
+			assert.NotEmpty(t, vuln.Code, "Expected not empty vulnerability code")
+			assert.NotEmpty(t, vuln.Line, "Expected not empty vulnerability line")
+
+			assert.Condition(
 				t,
-				filepath.Join(cfg.ProjectPath, "go.mod"),
-				vuln.Vulnerability.File,
-				"Expected equals vulnerability file",
+				func() bool {
+					return vuln.File == expectedGoModPath || vuln.File == expectedGoSumPath
+				},
+				"Expected vulnerability file %q to be %q or %q", vuln.File, expectedGoModPath, expectedGoSumPath,
 			)
 		}
 	})
@@ -168,6 +176,43 @@ const output = `
           "CvssVector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
           "Cve": "CVE-2019-11840",
           "Reference": "https://ossindex.sonatype.org/vulnerability/5121f5ff-9831-44a6-af2e-24f7301d1df7?component-type=golang\\u0026component-name=golang.org%2Fx%2Fcrypto\\u0026utm_source=nancy-client\\u0026utm_medium=integration\\u0026utm_content=0.0.0-dev",
+          "Excluded": false
+        }
+      ],
+      "InvalidSemVer": false
+    },
+    {
+      "Coordinates": "pkg:golang/github.com/coreos/etcd@3.3.10",
+      "Reference": "https://ossindex.sonatype.org/component/pkg:golang/github.com/coreos/etcd@3.3.10?utm_source=nancy-client\\u0026utm_medium=integration\\u0026utm_content=1.0.28",
+      "Vulnerabilities": [
+        {
+          "ID": "bba60acb-c7b5-4621-af69-f4085a8301d0",
+          "Title": "[CVE-2020-15114] In etcd before versions 3.3.23 and 3.4.10, the etcd gateway is a simple TCP prox...",
+          "Description": "In etcd before versions 3.3.23 and 3.4.10, the etcd gateway is a simple TCP proxy to allow for basic service discovery and access. However, it is possible to include the gateway address as an endpoint. This results in a denial of service, since the endpoint can become stuck in a loop of requesting itself until there are no more available file descriptors to accept connections on the gateway.",
+          "CvssScore": "7.7",
+          "CvssVector": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:C/C:N/I:N/A:H",
+          "Cve": "CVE-2020-15114",
+          "Reference": "https://ossindex.sonatype.org/vulnerability/bba60acb-c7b5-4621-af69-f4085a8301d0?component-type=golang\\u0026component-name=github.com%2Fcoreos%2Fetcd\\u0026utm_source=nancy-client\\u0026utm_medium=integration\\u0026utm_content=1.0.28",
+          "Excluded": false
+        },
+        {
+          "ID": "5def94e5-b89c-4a94-b9c6-ae0e120784c2",
+          "Title": "[CVE-2020-15115] etcd before versions 3.3.23 and 3.4.10 does not perform any password length vali...",
+          "Description": "etcd before versions 3.3.23 and 3.4.10 does not perform any password length validation, which allows for very short passwords, such as those with a length of one. This may allow an attacker to guess or brute-force users' passwords with little computational effort.",
+          "CvssScore": "5.8",
+          "CvssVector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:N/A:N",
+          "Cve": "CVE-2020-15115",
+          "Reference": "https://ossindex.sonatype.org/vulnerability/5def94e5-b89c-4a94-b9c6-ae0e120784c2?component-type=golang\\u0026component-name=github.com%2Fcoreos%2Fetcd\\u0026utm_source=nancy-client\\u0026utm_medium=integration\\u0026utm_content=1.0.28",
+          "Excluded": false
+        },
+        {
+          "ID": "d373dc3f-aa88-483b-b501-20fe5382cc80",
+          "Title": "[CVE-2020-15136] In ectd before versions 3.4.10 and 3.3.23, gateway TLS authentication is only ap...",
+          "Description": "In ectd before versions 3.4.10 and 3.3.23, gateway TLS authentication is only applied to endpoints detected in DNS SRV records. When starting a gateway, TLS authentication will only be attempted on endpoints identified in DNS SRV records for a given domain, which occurs in the discoverEndpoints function. No authentication is performed against endpoints provided in the --endpoints flag. This has been fixed in versions 3.4.10 and 3.3.23 with improved documentation and deprecation of the functionality.",
+          "CvssScore": "6.5",
+          "CvssVector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:L/A:N",
+          "Cve": "CVE-2020-15136",
+          "Reference": "https://ossindex.sonatype.org/vulnerability/d373dc3f-aa88-483b-b501-20fe5382cc80?component-type=golang\\u0026component-name=github.com%2Fcoreos%2Fetcd\\u0026utm_source=nancy-client\\u0026utm_medium=integration\\u0026utm_content=1.0.28",
           "Excluded": false
         }
       ],

--- a/internal/utils/file/file.go
+++ b/internal/utils/file/file.go
@@ -217,8 +217,10 @@ func getCodeFromDesiredLine(file *os.File, desiredLine int) string {
 // ext that match the dependency name.
 //
 // Return the file, code sample and line that match the dependency name.
-func GetDependencyCodeFilepathAndLine(projectPath, subPath, ext, dependency string) (code, file, line string) {
-	paths, err := getPathsByExtension(projectPath, subPath, ext)
+func GetDependencyCodeFilepathAndLine(
+	projectPath, subPath, dependency string, extensions ...string,
+) (code, file, line string) {
+	paths, err := getPathsByExtension(projectPath, subPath, extensions...)
 	if err != nil {
 		return "", "", ""
 	}
@@ -226,17 +228,22 @@ func GetDependencyCodeFilepathAndLine(projectPath, subPath, ext, dependency stri
 	return getDependencyInfo(paths, dependency)
 }
 
-func getPathsByExtension(projectPath, subPath, ext string) ([]string, error) {
+// nolint: funlen
+func getPathsByExtension(projectPath, subPath string, extensions ...string) ([]string, error) {
 	var paths []string
 
 	pathToWalk := projectPathWithSubPath(projectPath, subPath)
-	return paths, filepath.Walk(pathToWalk, func(walkPath string, info os.FileInfo, err error) error {
+	return paths, filepath.Walk(pathToWalk, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
 
-		if filepath.Ext(walkPath) == ext {
-			paths = append(paths, walkPath)
+		fileExt := filepath.Ext(path)
+
+		for _, ext := range extensions {
+			if fileExt == ext {
+				paths = append(paths, path)
+			}
 		}
 
 		return nil

--- a/internal/utils/file/file_test.go
+++ b/internal/utils/file/file_test.go
@@ -109,7 +109,10 @@ func TestCreateAndWriteFile(t *testing.T) {
 
 func TestGetDependencyCodeFilepathAndLine(t *testing.T) {
 	t.Run("Should run with success", func(t *testing.T) {
-		code, file, line := file.GetDependencyCodeFilepathAndLine(testutil.CsharpExample1, "", dotnetcli.CsProjExt, "Microsoft.AspNetCore.Http")
+		code, file, line := file.GetDependencyCodeFilepathAndLine(
+			testutil.CsharpExample1, "", "Microsoft.AspNetCore.Http", dotnetcli.CsProjExt,
+		)
+
 		expectedCode := "<PackageReference Include=\"Microsoft.AspNetCore.Http\" Version=\"2.2.2\"/>"
 		expectedFile := filepath.Join(testutil.CsharpExample1, "NetCoreVulnerabilities", "NetCoreVulnerabilities.csproj")
 		expectedLine := "7"
@@ -118,13 +121,19 @@ func TestGetDependencyCodeFilepathAndLine(t *testing.T) {
 		assert.Equal(t, expectedCode, code)
 	})
 	t.Run("Should return empty when path is invalid", func(t *testing.T) {
-		code, file, line := file.GetDependencyCodeFilepathAndLine("invalidPath", "", dotnetcli.CsProjExt, "Microsoft.AspNetCore.Http")
+		code, file, line := file.GetDependencyCodeFilepathAndLine(
+			"invalidPath", "", "Microsoft.AspNetCore.Http", dotnetcli.CsProjExt,
+		)
+
 		assert.Zero(t, code)
 		assert.Zero(t, file)
 		assert.Zero(t, line)
 	})
 	t.Run("Should return empty when path is valid but has no files", func(t *testing.T) {
-		code, file, line := file.GetDependencyCodeFilepathAndLine(t.TempDir(), "", dotnetcli.CsProjExt, "Microsoft.AspNetCore.Http")
+		code, file, line := file.GetDependencyCodeFilepathAndLine(
+			t.TempDir(), "", "Microsoft.AspNetCore.Http", dotnetcli.CsProjExt,
+		)
+
 		assert.Zero(t, code)
 		assert.Zero(t, file)
 		assert.Zero(t, line)


### PR DESCRIPTION
Previously when we execute Nany, we was searching the vulnerability only
on go.mod files, but Nancy analyse go.sum files too, so when some
vulnerability returned by Nany that is only  declared on go.sum the
vulnerability result show a File without file name (only the project
path) and the Code and Line empty.

This commit change the function `GetDependencyCodeFilepathAndLine` to
receive a list of extensions that can match on the given projectPath, so
the Nancy formatter was changed to pass .mod and .sum extensions. Since
the function signature was changed to be variadic the references was
changed too to follow the new parameter orders.

The success test case was also changed to cover this scenario.

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
