### PR TITLE
all:chore - replace Sprintf to filepath|path.Join to join paths

### DIFF
--- a/internal/controllers/analyzer/analyzer.go
+++ b/internal/controllers/analyzer/analyzer.go
@@ -20,6 +20,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -504,7 +505,7 @@ func (a *Analyzer) getCustomOrDefaultImage(language languages.Language) string {
 	if customImage := a.config.CustomImages[language]; customImage != "" {
 		return customImage
 	}
-	return fmt.Sprintf("%s/%s", images.DefaultRegistry, images.MapValues()[language])
+	return path.Join(images.DefaultRegistry, images.MapValues()[language])
 }
 
 // SetFalsePositivesAndRiskAcceptInVulnerabilities set analysis vulnerabilities to false

--- a/internal/entities/docker/analysis_data.go
+++ b/internal/entities/docker/analysis_data.go
@@ -15,7 +15,7 @@
 package docker
 
 import (
-	"fmt"
+	"path"
 	"strings"
 
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
@@ -36,7 +36,7 @@ func (a *AnalysisData) IsInvalid() bool {
 
 func (a *AnalysisData) SetData(customImage, imageWithTag string) *AnalysisData {
 	a.CustomImage = customImage
-	a.DefaultImage = fmt.Sprintf("%s/%s", images.DefaultRegistry, imageWithTag)
+	a.DefaultImage = path.Join(images.DefaultRegistry, imageWithTag)
 
 	return a
 }

--- a/internal/services/docker/docker_api.go
+++ b/internal/services/docker/docker_api.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -372,9 +373,9 @@ func (d *API) DeleteContainersFromAPI() {
 
 func (d *API) getSourceFolder() (path string) {
 	if d.config.ContainerBindProjectPath != "" {
-		path = fmt.Sprintf("%s/.horusec/%s", d.config.ContainerBindProjectPath, d.analysisID.String())
+		path = filepath.Join(d.config.ContainerBindProjectPath, ".horusec", d.analysisID.String())
 	} else {
-		path = fmt.Sprintf("%s/.horusec/%s", d.config.ProjectPath, d.analysisID.String())
+		path = filepath.Join(d.config.ProjectPath, ".horusec", d.analysisID.String())
 	}
 
 	separator := path[1:2]

--- a/internal/services/formatters/javascript/npmaudit/formatter.go
+++ b/internal/services/formatters/javascript/npmaudit/formatter.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -139,7 +140,7 @@ func (f *Formatter) getVersionText(version string) string {
 }
 
 func (f *Formatter) getVulnerabilityLineByName(version, module, file string) string {
-	fileExisting, err := os.Open(fmt.Sprintf("%s/%s", f.GetConfigProjectPath(), file))
+	fileExisting, err := os.Open(filepath.Join(f.GetConfigProjectPath(), file))
 	if err != nil {
 		return ""
 	}

--- a/internal/services/formatters/javascript/yarnaudit/formatter.go
+++ b/internal/services/formatters/javascript/yarnaudit/formatter.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -152,7 +153,7 @@ func (f *Formatter) getDefaultVulnerabilitySeverity(projectSubPath string) *vuln
 }
 
 func (f *Formatter) getVulnerabilityLineByName(module, version, file string) string {
-	fileExisting, err := os.Open(fmt.Sprintf("%s/%s", f.GetConfigProjectPath(), file))
+	fileExisting, err := os.Open(filepath.Join(f.GetConfigProjectPath(), file))
 	if err != nil {
 		return ""
 	}

--- a/internal/services/formatters/ruby/bundler/formatter.go
+++ b/internal/services/formatters/ruby/bundler/formatter.go
@@ -16,8 +16,8 @@ package bundler
 
 import (
 	"bufio"
-	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -147,7 +147,7 @@ func (f *Formatter) getDefaultVulnerabilitySeverity() *vulnerability.Vulnerabili
 }
 
 func (f *Formatter) getVulnerabilityLineByName(module, fileName string) string {
-	fileExisting, err := os.Open(fmt.Sprintf("%s/%s", f.GetConfigProjectPath(), fileName))
+	fileExisting, err := os.Open(filepath.Join(f.GetConfigProjectPath(), fileName))
 	if err != nil {
 		return ""
 	}


### PR DESCRIPTION
Previously on npm audit, yarn audit and bundler audit we use fmt.Sprintf
to join file path which cause bugs on Windows.

This commit replace these usages to use filepath.Join instead.

This commit also replace Sprintf usages on Docker images paths to use
path.Join which is appropriate to deal with slash-separated paths. Note
that the `path` package is (and should) only used to handle paths that
are separated by forward slashes which is the case of Docker images.

Read more from path package: https://pkg.go.dev/path

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
