### PR TITLE
printresults:fix - duplicated vulnerability severities on result

### DIFF
--- a/internal/controllers/printresults/print_results.go
+++ b/internal/controllers/printresults/print_results.go
@@ -263,12 +263,13 @@ func (pr *PrintResults) getTotalVulnsBySeverity() map[vulnerabilityenum.Type]map
 }
 
 func (pr *PrintResults) getDefaultTotalVulnBySeverity() map[vulnerabilityenum.Type]map[severities.Severity]int {
-	count := pr.getDefaultCountBySeverity()
+	// NOTE: Here we call pr.getDefaultCountBySeverity for each key on map
+	// to avoid reuse the same map pointer to all keys.
 	return map[vulnerabilityenum.Type]map[severities.Severity]int{
-		vulnerabilityenum.Vulnerability: count,
-		vulnerabilityenum.RiskAccepted:  count,
-		vulnerabilityenum.FalsePositive: count,
-		vulnerabilityenum.Corrected:     count,
+		vulnerabilityenum.Vulnerability: pr.getDefaultCountBySeverity(),
+		vulnerabilityenum.RiskAccepted:  pr.getDefaultCountBySeverity(),
+		vulnerabilityenum.FalsePositive: pr.getDefaultCountBySeverity(),
+		vulnerabilityenum.Corrected:     pr.getDefaultCountBySeverity(),
 	}
 }
 

--- a/internal/controllers/printresults/print_results_test.go
+++ b/internal/controllers/printresults/print_results_test.go
@@ -467,18 +467,9 @@ ReferenceHash: 9824269893d4df5e66a4fe7f53a715117bb722910228152b04831b6d2ad19a5b
 ==================================================================================
 
 In this analysis, a total of 11 possible vulnerabilities were found and we classified them into:
-Total of False Positive HIGH is: 3
-Total of False Positive MEDIUM is: 1
-Total of False Positive LOW is: 7
-Total of Corrected HIGH is: 3
-Total of Corrected MEDIUM is: 1
-Total of Corrected LOW is: 7
 Total of Vulnerability HIGH is: 3
 Total of Vulnerability MEDIUM is: 1
 Total of Vulnerability LOW is: 7
-Total of Risk Accepted HIGH is: 3
-Total of Risk Accepted MEDIUM is: 1
-Total of Risk Accepted LOW is: 7
 
 `
 


### PR DESCRIPTION
On #760 we made an improvement on `getDefaultTotalVulnBySeverity` which
reuse the map returned from `getDefaultCountBySeverity` as a value for
all keys on the default map of vulnerability severities, but since a map
in Go is a pointer we was using the same map to all keys and when we
were going to count vulnerabilities by severity, we would update the
same pointer for all the keys in that map, which caused inconsistent
and duplicated values in the final result.

This commit revert this change and call pr.getDefaultCountBySeverity for
all keys on this map.

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
