### PR TITLE
services/git:bugfix - error git diff breaking parse and invalid filepath

### DIFF
--- a/internal/services/formatters/service.go
+++ b/internal/services/formatters/service.go
@@ -143,10 +143,14 @@ func (s *Service) RemoveSrcFolderFromPath(path string) string {
 	if path == "" || len(path) <= 4 || !strings.Contains(path[:4], "src") {
 		return path
 	}
+
+	path = strings.Replace(filepath.ToSlash(path), "/src/", "", 1)
+
 	if runtime.GOOS == "windows" {
-		return strings.Replace(path, `src\`, "", 1)
+		return filepath.FromSlash(path)
 	}
-	return strings.Replace(path, "src/", "", 1)
+
+	return path
 }
 
 func (s *Service) GetCodeWithMaxCharacters(code string, column int) string {

--- a/internal/services/formatters/service_test.go
+++ b/internal/services/formatters/service_test.go
@@ -423,8 +423,13 @@ func TestService_GetCodeWithMaxCharacters(t *testing.T) {
 func TestRemoveSrcFolderFromPath(t *testing.T) {
 	t.Run("should return path without src prefix", func(t *testing.T) {
 		monitorController := NewFormatterService(&analysis.Analysis{}, testutil.NewDockerMock(), &config.Config{})
-		result := monitorController.RemoveSrcFolderFromPath(filepath.Join("src", "something"))
+		result := monitorController.RemoveSrcFolderFromPath(filepath.Join("/", "src", "something"))
 		assert.Equal(t, filepath.Base("something"), result)
+	})
+	t.Run("should return path without src prefix", func(t *testing.T) {
+		monitorController := NewFormatterService(&analysis.Analysis{}, testutil.NewDockerMock(), &config.Config{})
+		result := monitorController.RemoveSrcFolderFromPath(filepath.Join("/", "src", "something", "test"))
+		assert.Equal(t, filepath.Join("something", "test"), result)
 	})
 	t.Run("should return path without diff when src is after 4 index position", func(t *testing.T) {
 		monitorController := NewFormatterService(&analysis.Analysis{}, testutil.NewDockerMock(), &config.Config{})

--- a/internal/services/git/git_test.go
+++ b/internal/services/git/git_test.go
@@ -110,6 +110,14 @@ func TestGetCommitAuthor(t *testing.T) {
 	t.Run("Should return a new service", func(t *testing.T) {
 		assert.NotEmpty(t, New(&config.Config{}))
 	})
+
+	t.Run("Should not return git diff in output", func(t *testing.T) {
+		bytes, err := service.executeCMD("1", "README.md")
+
+		assert.NoError(t, err)
+		assert.NotEmpty(t, bytes)
+		assert.NotContains(t, string(bytes), "diff --git")
+	})
 }
 
 func TestRepositoryIsShallow(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Nathan Martins <nathan.martins@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

- Changing function that removes default src/ horusec folder from filepath to prevent it being reported as `/hcl/example1/main.tf`, which will be looked up from root and break git blame function. Now it will return the correted path 
 like this `hcl/example1/main.tf`

- Added flag `--no-patch` into git blame function to avoid diff info. Without it, in some cases will return extra information and break the json parse. Following the example of the output that results in error.

```
                {
			"author": "Otávio Santana",
			"email":"otaviopolianasantana@gmail.com",
			"message": "Updates sample to Java Vulnerabilities (#4)",
			"date": "2021-12-02 08:22:25 -0300",
			"commitHash": "3aea61743d526c833f0a3ddf289807dafa505370"
		}

diff --git a/java/example1/src/main/java/br/com/zup/vulnerabilities/trust/AllTrustSSLSocketFactoryIssue.java b/java/example1/src/main/java/br/com/zup/vulnerabilities/trust/AllTrustSSLSocketFactoryIssue.java
--- /dev/null
+++ b/java/example1/src/main/java/br/com/zup/vulnerabilities/trust/AllTrustSSLSocketFactoryIssue.java
@@ -0,0 +39,1 @@
+        }
```

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
