### PR TITLE
cli:fix - typo on description of enable-shellcheck flag

### DIFF
--- a/cmd/app/start/start.go
+++ b/cmd/app/start/start.go
@@ -257,7 +257,7 @@ func (s *Start) CreateStartCommand() *cobra.Command {
 		BoolP(
 			"enable-shellcheck", "j",
 			s.configs.EnableShellCheck,
-			"Enable shellcheck. Example -h=\"true\". Default: false",
+			`Enable shellcheck. Example -j="true". Default: false`,
 		)
 
 	if !dist.IsStandAlone() {


### PR DESCRIPTION
Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
