### PR TITLE
cli:chore - deprecate monitor-retry-count flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ lint:
 	$(GOLANG_CI_LINT) run -v --timeout=5m -c .golangci.yml ./...
 
 coverage:
-	curl -fsSL https://raw.githubusercontent.com/ZupIT/horusec-devkit/main/scripts/coverage.sh | bash -s 91 ./cmd
+	curl -fsSL https://raw.githubusercontent.com/ZupIT/horusec-devkit/main/scripts/coverage.sh | bash -s 90 ./cmd
 	curl -fsSL https://raw.githubusercontent.com/ZupIT/horusec-devkit/main/scripts/coverage.sh | bash -s 90 ./config
 	curl -fsSL https://raw.githubusercontent.com/ZupIT/horusec-devkit/main/scripts/coverage.sh | bash -s 86 ./internal
 

--- a/cmd/app/start/start.go
+++ b/cmd/app/start/start.go
@@ -269,7 +269,23 @@ func (s *Start) CreateStartCommand() *cobra.Command {
 			)
 	}
 
-	return startCmd
+	return s.setDeprecatedFlags(startCmd)
+}
+
+func (s *Start) setDeprecatedFlags(cmd *cobra.Command) *cobra.Command {
+	flags := cmd.PersistentFlags()
+
+	if err := flags.MarkHidden("monitor-retry-count"); err != nil {
+		logger.LogPanic(fmt.Sprintf(messages.PanicMarkHiddenFlag, "monitor-retry-count"), err)
+	}
+
+	if err := flags.MarkDeprecated(
+		"monitor-retry-count", "monitor component no longer exists in Horusec. Use only --analysis-timeout.",
+	); err != nil {
+		logger.LogPanic(fmt.Sprintf(messages.PanicMarkDeprecatedFlag, "monitor-retry-count"), err)
+	}
+
+	return cmd
 }
 
 func (s *Start) runE(cmd *cobra.Command, _ []string) error {

--- a/internal/controllers/analyzer/analyzer.go
+++ b/internal/controllers/analyzer/analyzer.go
@@ -258,23 +258,17 @@ func (a *Analyzer) startDetectVulnerabilities(langs []languages.Language) {
 		wg.Wait()
 	}()
 
-	timeout := a.config.TimeoutInSecondsAnalysis
-	timer := time.After(time.Duration(timeout) * time.Second)
-	retry := a.config.MonitorRetryInSeconds
-	tick := time.NewTicker(time.Duration(retry) * time.Second)
-	defer tick.Stop()
+	timeout := time.After(time.Duration(a.config.TimeoutInSecondsAnalysis) * time.Second)
 	for {
 		select {
 		case <-done:
 			a.loading.Stop()
 			return
-		case <-timer:
+		case <-timeout:
 			a.docker.DeleteContainersFromAPI()
 			a.config.IsTimeout = true
 			a.loading.Stop()
 			return
-		case <-tick.C:
-			timeout -= retry
 		}
 	}
 }

--- a/internal/helpers/messages/panic.go
+++ b/internal/helpers/messages/panic.go
@@ -21,4 +21,6 @@ const (
 	MsgPanicGetFlagValue                   = "{HORUSEC_CLI} Error on getting flag value, check and try again: "
 	MsgPanicNotConnectDocker               = "{HORUSEC_CLI} Error when try connect in docker."
 	MsgPanicGetConfigFilePath              = "{HORUSEC-CLI} Error on get config file path."
+	PanicMarkHiddenFlag                    = "{HORUSEC-CLI} Internal error occurred to hidden %s flag: "
+	PanicMarkDeprecatedFlag                = "{HORUSEC-CLI} Internal error occurred to mark %s flag as deprecated: "
 )


### PR DESCRIPTION
Previously we control all execution of tools using a `monitor` package,
but this package contained a lot of data races that was fixed on #477
and the monitor retry count flag was no longer necessary, since this was
used to control the timeout counter.

This commit mark monitor-retry-count flag as hidden and deprecated, so
new users will not see this flag and users that is currently using this
flag on pipelines will see a warning saying to use just --analysis-timeout
flag.

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
