### PR TITLE
cli:fix - duplicate show usage on validation errors

### DIFF
--- a/cmd/app/start/start.go
+++ b/cmd/app/start/start.go
@@ -308,16 +308,14 @@ func (s *Start) startAnalysis(cmd *cobra.Command) (totalVulns int, err error) {
 	if err := s.askIfRunInDirectorySelected(s.isRunPromptQuestion(cmd)); err != nil {
 		return 0, err
 	}
-	if err := s.configsValidations(cmd); err != nil {
+	if err := s.validateConfig(); err != nil {
 		return 0, err
 	}
 	return s.executeAnalysisDirectory()
 }
 
-func (s *Start) configsValidations(cmd *cobra.Command) error {
+func (s *Start) validateConfig() error {
 	if err := usecases.ValidateConfig(s.configs); err != nil {
-		logger.LogErrorWithLevel(messages.MsgErrorInvalidConfigs, err)
-		_ = cmd.Help()
 		return err
 	}
 

--- a/internal/helpers/messages/error.go
+++ b/internal/helpers/messages/error.go
@@ -50,7 +50,6 @@ const (
 	MsgErrorWhenCheckDockerRunning       = "{HORUSEC_CLI} Error when check if docker is running."
 	MsgErrorWhenDockerIsLowerVersion     = "{HORUSEC_CLI} Your docker version is below of: "
 	MsgErrorWhenGitIsLowerVersion        = "{HORUSEC_CLI} Your git version is below of: "
-	MsgErrorInvalidConfigs               = "{HORUSEC_CLI} Errors on validate configuration: "
 	MsgErrorRemoveAnalysisFolder         = "{HORUSEC_CLI} Error when remove analysis project inside .horusec"
 	MsgErrorDetectLanguage               = "{HORUSEC_CLI} Error when detect language"
 	MsgErrorCopyProjectToHorusecAnalysis = "{HORUSEC_CLI} Error when copy project to .horusec folder"


### PR DESCRIPTION
On cobra if `runE` return an error the usage is showed automatically and
the error message is printed, so this commit remove an unnecessary log
error and a call to `cmd.Help()` function which print the usage of help
command twice.

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
