### PR TITLE
deployments/Dockerfile:chore - improve approach to build cli

### DIFF
--- a/deployments/Dockerfile
+++ b/deployments/Dockerfile
@@ -19,9 +19,9 @@ RUN apk update && apk add --no-cache git
 ADD . /horusec
 WORKDIR /horusec
 
-RUN go get -t -v -d ./...
+RUN go mod download
 
-RUN env GOOS=linux go build -o /bin/horusec ./cmd/app/main.go
+RUN env GOOS=linux go build -ldflags '-s -w' -o /bin/horusec ./cmd/app/main.go
 
 FROM docker:20.10-git
 


### PR DESCRIPTION
Previously we was download the dependencies using `go get`, but since we
are using go modules, a better approach should be use `go mod download`
to download and cache all dependencies.

This commit also add a new build flags on binary to remove debug
information which will make de final binary smaller.

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
