### PR TITLE
language_detect:fix ignore files correctly on Windows

### DIFF
--- a/internal/controllers/language_detect/language_detect.go
+++ b/internal/controllers/language_detect/language_detect.go
@@ -164,7 +164,7 @@ func (ld *LanguageDetect) checkDefaultPathsToIgnore(path string) bool {
 
 func (ld *LanguageDetect) checkAdditionalPathsToIgnore(path string) bool {
 	for _, value := range ld.config.FilesOrPathsToIgnore {
-		matched, _ := doublestar.Match(strings.TrimSpace(value), path)
+		matched, _ := doublestar.Match(filepath.ToSlash(strings.TrimSpace(value)), filepath.ToSlash(path))
 		if matched {
 			return true
 		}


### PR DESCRIPTION
Previously when checking which files should be ignored by analysis on
Windows the directories patterns was not working properly, this is
because we was expecting that these paths would be always Unix like
paths so when a user set a path `**/tests/**` we can not ignore the
tests directory on Windows since the path would be `**\\tests\\**`.

This commit fix this issue converting all paths and all patterns to Unix
like paths before checking if should be ignored. Now `**/tests/**` would
match both `foo/bar/tests` and `foo\\bar\\tests`.

If the user set the pattern to use Windows slashes like `**\\tests\\**`,
this will work correctly only on Windows, so it is recommend that users
should always use the Unix slashes when configuring patterns that should
be ignored by analysis.

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
