### PR TITLE
scripts:chore - remove redundant logging

### DIFF
--- a/deployments/scripts/install.sh
+++ b/deployments/scripts/install.sh
@@ -22,25 +22,17 @@ LATEST_BETA=$(git ls-remote --exit-code --sort='v:refname' --tags https://github
 regex='^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
 
 horusecSetVersion () {
-    if [ -z "$VERSION_DOWNLOAD" ]; then
-        echo "invalid input, empty string"
-        exit 1
-    elif [ "$VERSION_DOWNLOAD" = "latest-rc" ] ; then
-        echo "Version set to $LATEST_RC"
+    if [ "$VERSION_DOWNLOAD" = "latest-rc" ] ; then
         VERSION_DOWNLOAD=$LATEST_RC
     elif [ "$VERSION_DOWNLOAD" = "latest-beta" ] ; then
-        echo "Version set to $LATEST_BETA"
         VERSION_DOWNLOAD=$LATEST_BETA
     elif  [ "$VERSION_DOWNLOAD" = "latest" ] ; then
-        echo "Version set to $LATEST_BETA"
         VERSION_DOWNLOAD='latest'
-    elif echo $VERSION_DOWNLOAD| grep -Eq  $regex; then
-        echo "Version set to $VERSION_DOWNLOAD"
-    else
-      echo "input not match required params: 'latest-rc' 'latest-beta' 'latest' or a semantic version compliant, check https://github.com/ZupIT/horusec/releases"
-      exit 1
+    elif ! echo $VERSION_DOWNLOAD| grep -Eq  $regex; then
+        echo "input not match required params: 'latest-rc' 'latest-beta' 'latest' or a semantic version compliant, check https://github.com/ZupIT/horusec/releases"
+        exit 1
     fi
-    echo "Download version: $VERSION_DOWNLOAD"
+    echo "Downloading version: $VERSION_DOWNLOAD"
 
 }
 


### PR DESCRIPTION
Previously if the user input `latest` version to download we was logging
that the download would be the latest-rc and also the latest version.
Even though the logging in wrong, we don't need to inform twice which
version is being downloaded, so this commit remove the redundant logging
and also use the same error message that is showed when user pass an
invalid version to when user not pass any input.

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
