### PR TITLE
formatters:fix - invalid work dir path on Windows

### DIFF
--- a/internal/services/formatters/service.go
+++ b/internal/services/formatters/service.go
@@ -96,6 +96,9 @@ func (s *Service) GetConfigProjectPath() string {
 
 func (s *Service) AddWorkDirInCmd(cmd, projectSubPath string, tool tools.Tool) string {
 	if projectSubPath != "" {
+		// Since the command will run inside a Docker container we need
+		// to convert any Windows slash (\) to Unix slash (/).
+		projectSubPath = filepath.ToSlash(projectSubPath)
 		logger.LogDebugWithLevel(messages.MsgDebugShowWorkdir, tool.ToString(), projectSubPath)
 		return strings.ReplaceAll(cmd, "{{WORK_DIR}}", fmt.Sprintf("cd %s", projectSubPath))
 	}

--- a/internal/utils/file/file_test.go
+++ b/internal/utils/file/file_test.go
@@ -51,14 +51,12 @@ func TestGetFilePathIntoBasePath(t *testing.T) {
 
 func TestGetSubPathByExtension(t *testing.T) {
 	t.Run("Should return sub path for .go", func(t *testing.T) {
-		path, _ := filepath.Abs(".")
-		response := file.GetSubPathByExtension(path, "", "*.go")
-		assert.Equal(t, "", response)
+		response := file.GetSubPathByExtension(testutil.GoExample1, "", "*.go")
+		assert.Equal(t, filepath.Join("api", "routes"), response)
 	})
 
-	t.Run("Should not matches matches", func(t *testing.T) {
-		path, _ := filepath.Abs(".")
-		response := file.GetSubPathByExtension(path, "test", "*.test")
+	t.Run("Should return empty path for not found extension", func(t *testing.T) {
+		response := file.GetSubPathByExtension(testutil.GoExample1, "", "*.test")
 		assert.Equal(t, "", response)
 	})
 }


### PR DESCRIPTION
Previously when we were running on Windows we was setting a Windows path
as a work dir inside a Docker container. For example, we start the
analysis, and we try to find a path that contains go.mod files, we found
the path C:\user\some\path and we was using this path (with Windows
slashes) as a work dir on Docker, so when the command try to access this
path (cd some\path) we was getting errors.

This commit fix this issue converting any path to Unix path before
replacing the {{WORK_DIR}} of command.

Some tests of formatter was changed to expected that any path used on
{{WORK_DIR}} should be a Unix like path.

This commit also make some improvements on `utils/file` private
functions, resolving a TODO by refactoring the function to use a better
approach to get the relative directory of a file path. Some functions
was renamed to make more clear what they are doing and new debug logging
was added to inform the path that the searched files was founded.

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
