### PR TITLE
alpha:bugfix - fixing errors with alpha workflow publish release

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -27,12 +27,12 @@ jobs:
       COSIGN_KEY_LOCATION: /tmp/cosign.key
       COSIGN_PWD: ${{ secrets.COSIGN_PWD }}
 
-
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
@@ -43,6 +43,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
@@ -91,6 +92,7 @@ jobs:
           cosign sign -key $COSIGN_KEY_LOCATION horuszup/horusec-cli:alpha
         env:
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PWD }}
+
       - name: Create local tag
         run: mage -v createAlphaTag
 
@@ -106,6 +108,7 @@ jobs:
           GORELEASER_CURRENT_TAG: v0.0.0-alpha
           CURRENT_DATE: ${{ steps.date.outputs.date }}
           CLI_VERSION: alpha
+
       - name: Delete outdate release
         uses: dev-drprasad/delete-tag-and-release@v0.2.0
         env:
@@ -113,58 +116,61 @@ jobs:
         with:
           delete_release: true
           tag_name: alpha
+
       - name: Update alpha release
-        uses: meeDamian/github-release@2.0
+        uses: softprops/action-gh-release@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          tag: alpha
           name: alpha
-          draft: false
+          tag_name: alpha
           prerelease: true
-          commitish: ${{ github.sha }}
-          gzip: false
-          allow_override: true
-          files: |
-            checksums.txt:./dist/checksums.txt
-            checksums.txt.sig:./dist/checksums.txt.sig
-            cosign.pub:./deployments/cosign.pub
-            horusec_linux_amd64:./dist/horusec_linux_amd64/horusec
-            horusec_linux_amd64.sig:./dist/horusec_linux_amd64/horusec.sig
-            horusec_linux_x86:./dist/horusec_linux_386/horusec
-            horusec_linux_x86.sig:./dist/horusec_linux_386/horusec.sig
-            horusec_mac_amd64:./dist/horusec_darwin_amd64/horusec
-            horusec_mac_amd64.sig:./dist/horusec_darwin_amd64/horusec.sig
-            horusec_win_amd64.exe:./dist/horusec_windows_amd64/horusec.exe
-            horusec_win_amd64.exe.sig:./dist/horusec_windows_amd64/horusec.exe.sig
-            horusec_win_x86.exe:./dist/horusec_windows_386/horusec.exe
-            horusec_win_x86.exe.sig:./dist/horusec_windows_386/horusec.exe.sig
-            horusec_linux_arm64:./dist/horusec_linux_arm64/horusec
-            horusec_linux_arm64.sig:./dist/horusec_linux_arm64/horusec.sig
-            horusec_win_arm64.exe:./dist/horusec_windows_arm64/horusec.exe
-            horusec_win_arm64.exe.sig:./dist/horusec_windows_arm64/horusec.exe.sig
-            horusec_mac_arm64:./dist/horusec_darwin_arm64/horusec
-            horusec_mac_arm64.sig:./dist/horusec_darwin_arm64/horusec.sig
-
-
-            horusec_linux_amd64_stand_alone:./dist/horusec-standalone_linux_amd64/horusec
-            horusec_linux_amd64_stand_alone.sig:./dist/horusec-standalone_linux_amd64/horusec.sig
-            horusec_linux_x86_stand_alone:./dist/horusec-standalone_linux_386/horusec
-            horusec_linux_x86_stand_alone.sig:./dist/horusec-standalone_linux_386/horusec.sig
-            horusec_mac_amd64_stand_alone:./dist/horusec-standalone_darwin_amd64/horusec
-            horusec_mac_amd64_stand_alone.sig:./dist/horusec-standalone_darwin_amd64/horusec.sig
-            horusec_win_amd64_stand_alone.exe:./dist/horusec-standalone_windows_amd64/horusec.exe
-            horusec_win_amd64_stand_alone.exe.sig:./dist/horusec-standalone_windows_amd64/horusec.exe.sig
-            horusec_win_x86.exe_stand_alone:./dist/horusec-standalone_windows_386/horusec.exe
-            horusec_win_x86.exe_stand_alone.sig:./dist/horusec-standalone_windows_386/horusec.exe.sig
-            horusec_linux_arm64_stand_alone:./dist/horusec-standalone_linux_arm64/horusec
-            horusec_linux_arm64_stand_alone.sig:./dist/horusec-standalone_linux_arm64/horusec.sig
-            horusec_win_arm64_stand_alone.exe:./dist/horusec-standalone_windows_arm64/horusec.exe
-            horusec_win_arm64_stand_alone.exe.sig:./dist/horusec-standalone_windows_arm64/horusec.exe.sig
-            horusec_mac_arm64_stand_alone:./dist/horusec-standalone_darwin_arm64/horusec
-            horusec_mac_arm64_stand_alone.sig:./dist/horusec-standalone_darwin_arm64/horusec.sig
-
+          draft: false
+          target_commitish: ${{ github.sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           body: |
+            ## Description
+
+            This tag it's updated every time there's a change in the main branch. It's a developement tag and should not be used in production.
+
             ## Docker images
+
             - `docker pull horuszup/horusec-cli:alpha`
+          files: |
+            ./dist/checksums.txt
+            ./dist/checksums.txt.sig
+            ./deployments/cosign.pub
+            ./dist/horusec_linux_amd64/horusec_linux_amd64
+            ./dist/horusec_linux_amd64/horusec_linux_amd64.sig
+            ./dist/horusec_linux_386/horusec_linux_x86
+            ./dist/horusec_linux_386/horusec_linux_x86.sig
+            ./dist/horusec_darwin_amd64/horusec_mac_amd64
+            ./dist/horusec_darwin_amd64/horusec_mac_amd64.sig
+            ./dist/horusec_windows_amd64/horusec_win_amd64.exe
+            ./dist/horusec_windows_amd64/horusec_win_amd64.exe.sig
+            ./dist/horusec_windows_386/horusec_win_x86.exe
+            ./dist/horusec_windows_386/horusec_win_x86.exe.sig
+            ./dist/horusec_linux_arm64/horusec_linux_arm64
+            ./dist/horusec_linux_arm64/horusec_linux_arm64.sig
+            ./dist/horusec_windows_arm64/horusec_win_arm64.exe
+            ./dist/horusec_windows_arm64/horusec_win_arm64.exe.sig
+            ./dist/horusec_darwin_arm64/horusec_mac_arm64
+            ./dist/horusec_darwin_arm64/horusec_mac_arm64.sig
+
+            ./dist/horusec-standalone_linux_amd64/horusec_linux_amd64_stand_alone
+            ./dist/horusec-standalone_linux_amd64/horusec_linux_amd64_stand_alone.sig
+            ./dist/horusec-standalone_linux_386/horusec_linux_x86_stand_alone
+            ./dist/horusec-standalone_linux_386/horusec_linux_x86_stand_alone.sig
+            ./dist/horusec-standalone_darwin_amd64/horusec_mac_amd64_stand_alone
+            ./dist/horusec-standalone_darwin_amd64/horusec_mac_amd64_stand_alone.sig
+            ./dist/horusec-standalone_windows_amd64/horusec_win_amd64_stand_alone.exe
+            ./dist/horusec-standalone_windows_amd64/horusec_win_amd64_stand_alone.exe.sig
+            ./dist/horusec-standalone_windows_386/horusec_win_x86_stand_alone.exe
+            ./dist/horusec-standalone_windows_386/horusec_win_x86_stand_alone.exe.sig
+            ./dist/horusec-standalone_linux_arm64/horusec_linux_arm64_stand_alone
+            ./dist/horusec-standalone_linux_arm64/horusec_linux_arm64_stand_alone.sig
+            ./dist/horusec-standalone_windows_arm64/horusec_win_arm64_stand_alone.exe
+            ./dist/horusec-standalone_windows_arm64/horusec_win_arm64_stand_alone.exe.sig
+            ./dist/horusec-standalone_darwin_arm64/horusec_mac_arm64_stand_alone
+            ./dist/horusec-standalone_darwin_arm64/horusec_mac_arm64_stand_alone.sig
+
       - name: Push updates
         run: mage -v gitPushAlpha

--- a/deployments/Dockerfile-gorelease-amd64
+++ b/deployments/Dockerfile-gorelease-amd64
@@ -14,6 +14,6 @@
 
 FROM docker:20.10-git
 
-COPY /horusec /usr/local/bin/horusec
+COPY /horusec_linux_amd64 /usr/local/bin/horusec
 
 CMD [ "sh" ]

--- a/deployments/Dockerfile-gorelease-arm64
+++ b/deployments/Dockerfile-gorelease-arm64
@@ -1,0 +1,19 @@
+# Copyright 2021 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM docker:20.10-git
+
+COPY /horusec_linux_arm64 /usr/local/bin/horusec
+
+CMD [ "sh" ]

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ZupIT/horusec
 go 1.17
 
 require (
-	github.com/ZupIT/horusec-devkit v1.0.20
+	github.com/ZupIT/horusec-devkit v1.0.21
 	github.com/ZupIT/horusec-engine v0.3.6
 	github.com/bmatcuk/doublestar/v4 v4.0.2
 	github.com/briandowns/spinner v1.16.0
@@ -60,7 +60,7 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
-	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
+	golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871 // indirect
 	golang.org/x/net v0.0.0-20211123203042-d83791d6bcd9 // indirect
 	golang.org/x/sys v0.0.0-20211124211545-fe61309f8881 // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWX
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/ZupIT/horusec-devkit v1.0.17/go.mod h1:wTsXrXTD1YrChTQEng8EvVg+zL9nMUIQkhUG85sQwuQ=
-github.com/ZupIT/horusec-devkit v1.0.20 h1:kxM3/65HQc3CH4qhbuDN4I8c4Auz3C0kFCdtYetJrD8=
-github.com/ZupIT/horusec-devkit v1.0.20/go.mod h1:OyD/c5VGmmIxZamErINJJZ3ZFVFQJKRnh6/5a69n1J4=
+github.com/ZupIT/horusec-devkit v1.0.21 h1:vAY0/DV+EMdfSae6cu8lF0UpGrJe1uuMW3H/TDznvdE=
+github.com/ZupIT/horusec-devkit v1.0.21/go.mod h1:ZNpTXWcN0tG7jHokH12Zi94Y2iiV1qxslElvfSD/kDE=
 github.com/ZupIT/horusec-engine v0.3.6 h1:m/kL9K8+OVAaYjagoDmNFFDEA3BnyJbcx0DfNYGyaDM=
 github.com/ZupIT/horusec-engine v0.3.6/go.mod h1:s3SZQ9gXXlEcIagEuopZJga+Dw6RBFWMD7Rh5A+tIys=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
@@ -590,6 +590,7 @@ github.com/jackc/pgconn v1.8.1/go.mod h1:JV6m6b6jhjdmzchES0drzCcYcAHS1OPD5xu3OZ/
 github.com/jackc/pgconn v1.9.0/go.mod h1:YctiPyvzfU11JFxoXokUOOKQXQmDMoJL9vJzHH8/2JY=
 github.com/jackc/pgconn v1.9.1-0.20210724152538-d89c8390a530/go.mod h1:4z2w8XhRbP1hYxkpTuBjTS3ne3J48K83+u0zoyvg2pI=
 github.com/jackc/pgconn v1.10.0/go.mod h1:4z2w8XhRbP1hYxkpTuBjTS3ne3J48K83+u0zoyvg2pI=
+github.com/jackc/pgconn v1.10.1/go.mod h1:4z2w8XhRbP1hYxkpTuBjTS3ne3J48K83+u0zoyvg2pI=
 github.com/jackc/pgio v1.0.0/go.mod h1:oP+2QK2wFfUWgr+gxjoBH9KGBb31Eio69xUb0w5bYf8=
 github.com/jackc/pgmock v0.0.0-20190831213851-13a1b77aafa2/go.mod h1:fGZlG77KXmcq05nJLRkk0+p82V8B8Dw8KN2/V9c/OAE=
 github.com/jackc/pgmock v0.0.0-20201204152224-4fe30f7445fd/go.mod h1:hrBW0Enj2AZTNpt/7Y5rr2xe/9Mn757Wtb2xeBzPv2c=
@@ -603,6 +604,7 @@ github.com/jackc/pgproto3/v2 v2.0.0-rc3.0.20190831210041-4c03ce451f29/go.mod h1:
 github.com/jackc/pgproto3/v2 v2.0.1/go.mod h1:WfJCnwN3HIg9Ish/j3sgWXnAfK8A9Y0bwXYU5xKaEdA=
 github.com/jackc/pgproto3/v2 v2.0.6/go.mod h1:WfJCnwN3HIg9Ish/j3sgWXnAfK8A9Y0bwXYU5xKaEdA=
 github.com/jackc/pgproto3/v2 v2.1.1/go.mod h1:WfJCnwN3HIg9Ish/j3sgWXnAfK8A9Y0bwXYU5xKaEdA=
+github.com/jackc/pgproto3/v2 v2.2.0/go.mod h1:WfJCnwN3HIg9Ish/j3sgWXnAfK8A9Y0bwXYU5xKaEdA=
 github.com/jackc/pgservicefile v0.0.0-20200307190119-3430c5407db8/go.mod h1:vsD4gTJCa9TptPL8sPkXrLZ+hDuNrZCnj29CQpr4X1E=
 github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b/go.mod h1:vsD4gTJCa9TptPL8sPkXrLZ+hDuNrZCnj29CQpr4X1E=
 github.com/jackc/pgtype v0.0.0-20190421001408-4ed0de4755e0/go.mod h1:hdSHsc1V01CGwFsrv11mJRHWJ6aifDLfdV3aVjFF0zg=
@@ -614,6 +616,7 @@ github.com/jackc/pgtype v1.3.1-0.20200606141011-f6355165a91c/go.mod h1:cvk9Bgu/V
 github.com/jackc/pgtype v1.7.0/go.mod h1:ZnHF+rMePVqDKaOfJVI4Q8IVvAQMryDlDkZnKOI75BE=
 github.com/jackc/pgtype v1.8.1-0.20210724151600-32e20a603178/go.mod h1:C516IlIV9NKqfsMCXTdChteoXmwgUceqaLfjg2e3NlM=
 github.com/jackc/pgtype v1.8.1/go.mod h1:LUMuVrfsFfdKGLw+AFFVv6KtHOFMwRgDDzBt76IqCA4=
+github.com/jackc/pgtype v1.9.0/go.mod h1:LUMuVrfsFfdKGLw+AFFVv6KtHOFMwRgDDzBt76IqCA4=
 github.com/jackc/pgx/v4 v4.0.0-20190420224344-cc3461e65d96/go.mod h1:mdxmSJJuR08CZQyj1PVQBHy9XOp5p8/SHH6a0psbY9Y=
 github.com/jackc/pgx/v4 v4.0.0-20190421002000-1b8f0016e912/go.mod h1:no/Y67Jkk/9WuGR0JG/JseM9irFbnEPbuWV2EELPNuM=
 github.com/jackc/pgx/v4 v4.0.0-pre1.0.20190824185557-6972a5742186/go.mod h1:X+GQnOEnf1dqHGpw7JmHqHc1NxDoalibchSk9/RWuDc=
@@ -623,13 +626,16 @@ github.com/jackc/pgx/v4 v4.6.1-0.20200606145419-4e5062306904/go.mod h1:ZDaNWkt9s
 github.com/jackc/pgx/v4 v4.11.0/go.mod h1:i62xJgdrtVDsnL3U8ekyrQXEwGNTRoG7/8r+CIdYfcc=
 github.com/jackc/pgx/v4 v4.12.1-0.20210724153913-640aa07df17c/go.mod h1:1QD0+tgSXP7iUjYm9C1NxKhny7lq6ee99u/z+IHFcgs=
 github.com/jackc/pgx/v4 v4.13.0/go.mod h1:9P4X524sErlaxj0XSGZk7s+LD0eOyu1ZDUrrpznYDF0=
+github.com/jackc/pgx/v4 v4.14.0/go.mod h1:jT3ibf/A0ZVCp89rtCIN0zCJxcE74ypROmHEZYsG/j8=
 github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.1/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
+github.com/jackc/puddle v1.2.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.2/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
+github.com/jinzhu/now v1.1.3/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
@@ -1076,8 +1082,9 @@ golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210920023735-84f357641f63/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 h1:7I4JAnoQBe7ZtJcBaYHi5UtiO8tQHbUSXxL+pnGRANg=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871 h1:/pEO3GD/ABYAjuakUS6xSEmmlyVS4kxBNkeA9tLJiTI=
+golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -1172,6 +1179,7 @@ golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211123203042-d83791d6bcd9 h1:0qxwC5n+ttVOINCBeRHO0nq9X7uy8SDsPoi5OaCdIEI=
 golang.org/x/net v0.0.0-20211123203042-d83791d6bcd9/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -1589,11 +1597,11 @@ gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gorm.io/driver/postgres v1.1.0/go.mod h1:hXQIwafeRjJvUm+OMxcFWyswJ/vevcpPLlGocwAwuqw=
-gorm.io/driver/postgres v1.2.1/go.mod h1:SHRZhu+D0tLOHV5qbxZRUM6kBcf3jp/kxPz2mYMTsNY=
+gorm.io/driver/postgres v1.2.3/go.mod h1:pJV6RgYQPG47aM1f0QeOzFH9HxQc8JcmAgjRCgS0wjs=
 gorm.io/gorm v1.21.9/go.mod h1:F+OptMscr0P2F2qU97WT1WimdH9GaQPoDW7AYd5i2Y0=
 gorm.io/gorm v1.21.11/go.mod h1:F+OptMscr0P2F2qU97WT1WimdH9GaQPoDW7AYd5i2Y0=
-gorm.io/gorm v1.22.0/go.mod h1:F+OptMscr0P2F2qU97WT1WimdH9GaQPoDW7AYd5i2Y0=
-gorm.io/gorm v1.22.2/go.mod h1:F+OptMscr0P2F2qU97WT1WimdH9GaQPoDW7AYd5i2Y0=
+gorm.io/gorm v1.22.3/go.mod h1:F+OptMscr0P2F2qU97WT1WimdH9GaQPoDW7AYd5i2Y0=
+gorm.io/gorm v1.22.4/go.mod h1:1aeVC+pe9ZmvKZban/gW4QPra7PRoTEssyc922qCAkk=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -31,6 +31,7 @@ builds:
       - amd64
       - arm64
       - 386
+    binary: horusec_{{ replace (replace .Os "windows" "win") "darwin" "mac" }}_{{ replace .Arch "386" "x86" }}
   - id: horusec-standalone
     env: [ CGO_ENABLED=0 ]
     main: ./cmd/app/main.go
@@ -48,6 +49,7 @@ builds:
       - amd64
       - arm64
       - 386
+    binary: horusec_{{ replace (replace .Os "windows" "win") "darwin" "mac" }}_{{ replace .Arch "386" "x86" }}_stand_alone
 changelog:
   skip: true
 snapshot:
@@ -121,7 +123,7 @@ dockers:
     skip_push: false
     goos: linux
     goarch: amd64
-    dockerfile: ./deployments/Dockerfile-gorelease
+    dockerfile: ./deployments/Dockerfile-gorelease-amd64
     use: docker
     build_flag_templates:
       - "--pull"
@@ -137,7 +139,7 @@ dockers:
     skip_push: false
     goos: linux
     goarch: arm64
-    dockerfile: ./deployments/Dockerfile-gorelease
+    dockerfile: ./deployments/Dockerfile-gorelease-arm64
     use: docker
     build_flag_templates:
       - "--pull"


### PR DESCRIPTION
Replaced workflow action used to publish the release, also had to change binary names to match the actual name in release, since the new action does not support renaming during publish. The binary names changes let to another change, i had to change the goreleaser Dockerfiles to match correct binary according to architecture.

Depends on a new devkit tag with the https://github.com/ZupIT/horusec-devkit/pull/140 fixes.

Signed-off-by: Nathan Martins <nathan.martins@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
