### PR TITLE
cli:chore - send logging to stderr instead stdout

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -401,7 +401,7 @@ func (c *Config) ConfigureLogger() error {
 	if err != nil {
 		return err
 	}
-	logger.LogSetOutput(log, os.Stdout)
+	logger.LogSetOutput(log, os.Stderr)
 	logger.LogDebugWithLevel("Set log file to " + log.Name())
 	return nil
 }


### PR DESCRIPTION
Previously when we need to read the logging debug we can't redirect
analysis result to /dev/null to get only the logs because all logging
and results is sent to sdout. This commit change the writer of logger to
send them to stderr instead of stdout, with this we can get only log
results using `./horusec start -p > /dev/null` or get only analysis
results using `./horusec start -p 2> /dev/null`


Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
