### PR TITLE
scripts:bugfix - fixing error in url validation with latest rc and beta

### DIFF
--- a/deployments/scripts/install.sh
+++ b/deployments/scripts/install.sh
@@ -32,7 +32,7 @@ horusecSetVersion() {
     echo "Version set to $LATEST_BETA"
     VERSION_DOWNLOAD=$LATEST_BETA
   elif [ "$VERSION_DOWNLOAD" = "latest" ]; then
-    echo "Version set to $LATEST_BETA"
+    echo "Version set to latest"
     VERSION_DOWNLOAD='latest'
   elif echo $VERSION_DOWNLOAD | grep -Eq $regex; then
     echo "Version set to $VERSION_DOWNLOAD"
@@ -40,7 +40,6 @@ horusecSetVersion() {
     echo "input not match required params: 'latest-rc' 'latest-beta' 'latest' or a semantic version compliant, check https://github.com/ZupIT/horusec/releases"
     exit 1
   fi
-  echo "Download version: $VERSION_DOWNLOAD"
 }
 
 horusecIdentifyOSLatest() {
@@ -145,9 +144,11 @@ horusecIdentifyOS() {
 # correct download link for the version informed by the user.
 isOldURLVersion() {
   if [ $VERSION_DOWNLOAD != "latest" ]; then
-    VERSION_WITHOUT_PREFIX=$(echo "$VERSION_DOWNLOAD" | sed -e "s/v//g")
 
-    VERSION_WITHOUT_DOTS=$(echo "$VERSION_WITHOUT_PREFIX" | sed -e "s/\.//g")
+    VERSION_WITHOUT_V_PREFIX=$(echo "$VERSION_DOWNLOAD" | sed -e "s/v//g")
+    VERSION_WITHOUT_BETA_PREFIX=$(echo "$VERSION_WITHOUT_V_PREFIX" | sed -r "s/-beta\.[0-9]+//g")
+    VERSION_WITHOUT_RC_PREFIX=$(echo "$VERSION_WITHOUT_BETA_PREFIX" | sed -r "s/-rc\.[0-9]+//g")
+    VERSION_WITHOUT_DOTS=$(echo "$VERSION_WITHOUT_RC_PREFIX" | sed -e "s/\.//g")
 
     if [ "$VERSION_WITHOUT_DOTS" -gt 264 ]; then
       IS_NEW_URL=true


### PR DESCRIPTION
Updating install script validation to cover the beta and rc new tags. The `isOldURL Version` function checks for versions before `2.6.4`, for this the function remove special characters leaving only numbers and verify if the version is greater than the informed version. The validation was not removing beta and rc data from the version. Removed duplicated `echo` informing the version and fixed error in latest version `echo` printing the beta version.

Signed-off-by: Nathan Martins <nathan.martins@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
