### PR TITLE
analyzer:fix - not printing information severity when enabled

### DIFF
--- a/internal/controllers/analyzer/analyzer.go
+++ b/internal/controllers/analyzer/analyzer.go
@@ -631,6 +631,7 @@ func (a *Analyzer) removeInfoVulnerabilities() *analysis.Analysis {
 	return a.analysis
 }
 
+// nolint: funlen,gocyclo
 func (a *Analyzer) removeVulnerabilitiesBySeverity() *analysis.Analysis {
 	var vulnerabilities []analysis.AnalysisVulnerabilities
 	severitiesToIgnore := a.config.SeveritiesToIgnore
@@ -639,6 +640,11 @@ outer:
 	for index := range a.analysis.AnalysisVulnerabilities {
 		vuln := a.analysis.AnalysisVulnerabilities[index]
 		for _, severity := range severitiesToIgnore {
+			// Force to print INFO vulnerabilities when information severity is enabled.
+			if severity == severities.Info.ToString() && a.config.EnableInformationSeverity {
+				continue
+			}
+
 			if strings.EqualFold(string(vuln.Vulnerability.Severity), severity) {
 				continue outer
 			}


### PR DESCRIPTION
Previously when use use the flag --information-severity the information
vulnerabilities was not been printing by PrintResults, this is because we
was getting a conflict between --information-severity and
--ignore-severity flags, the default values of --ignore-severity is INFO,
so when we use the flag --information-severity we was still not printing
because the INFO vulnerabilities was been ignored by --ignored-severity
flag.

This commit fix this issue by forcing the print of INFO vulnerabilities
when --information-severity is enabled.

Fixes #785

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
