### PR TITLE
mage:bugfix - fixing error that cli date was being print equal the date command

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -18,6 +18,7 @@
 package main
 
 import (
+	"fmt"
 
 	// mage:import
 	_ "github.com/ZupIT/horusec-devkit/pkg/utils/mageutils"
@@ -26,5 +27,10 @@ import (
 
 // GetCurrentDate execute "echo", `::set-output name=date::$(date "+%a %b %d %H:%M:%S %Y")`
 func GetCurrentDate() error {
-	return sh.RunV("echo", `::set-output name=date::$(date "+%a %b %d %H:%M:%S %Y")`)
+	date, err := sh.Output("date", "+%a %b %d %H:%M:%S %Y")
+	if err != nil {
+		return err
+	}
+
+	return sh.RunV("echo", fmt.Sprintf("::set-output name=date::%s", date))
 }


### PR DESCRIPTION
Fixes the following error with the Built field:
```
Version:          v2.6.5
Git commit:       ee72d9f844d2448a491f2cd564321c1b5cccd2fa
Built:            $(date "+%a %b %d %H:%M:%S %Y")
Distribution:     normal

```
Signed-off-by: Nathan Martins <nathan.martins@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
