### PR TITLE
formatters/bundler:fix upgrade to fix crash on execution

### DIFF
--- a/internal/services/formatters/ruby/deployments/Dockerfile
+++ b/internal/services/formatters/ruby/deployments/Dockerfile
@@ -14,5 +14,7 @@
 
 FROM ruby:2.7.5-alpine
 
+RUN apk add git
+
 RUN gem install brakeman -v 5.1.1
-RUN gem install bundler-audit -v 0.9.0
+RUN gem install bundler-audit -v 0.9.0.1


### PR DESCRIPTION
Bundler on version 0.9.0 had a bug that make the execution crash, this
commit upgrade to version 0.9.0.1 that contains a fix for this issue.
Read more: https://github.com/rubysec/bundler-audit/issues/319

This commit also change the Dockerfile do install Git, since on 2.7.x
images is not installed by default, and is a requirement to execute
Bundler.
https://github.com/rubysec/bundler-audit#requirements

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
