### PR TITLE
formatters/trivy:fix - find correct line of dependency

### DIFF
--- a/internal/services/formatters/generic/trivy/formatter.go
+++ b/internal/services/formatters/generic/trivy/formatter.go
@@ -166,7 +166,7 @@ func (f *Formatter) setVulnerabilitiesOutput(vulnerabilities []*entities.Vulnera
 	for _, vuln := range vulnerabilities {
 		addVuln := f.getVulnBase()
 		addVuln.Code = fmt.Sprintf("%s v%s", vuln.PkgName, vuln.InstalledVersion)
-		_, _, addVuln.Line = file.GetDependencyInfo([]string{target}, addVuln.Code)
+		_, _, addVuln.Line = file.GetDependencyInfo(addVuln.Code, target)
 		addVuln.File = target
 		addVuln.Details = vuln.GetDetails()
 		addVuln.Severity = severities.GetSeverityByString(vuln.Severity)

--- a/internal/utils/file/file.go
+++ b/internal/utils/file/file.go
@@ -241,7 +241,7 @@ func GetDependencyCodeFilepathAndLine(
 		return "", "", ""
 	}
 
-	return GetDependencyInfo(paths, dependency)
+	return GetDependencyInfo(dependency, paths...)
 }
 
 // nolint: funlen
@@ -266,12 +266,12 @@ func getPathsByExtension(projectPath, subPath string, extensions ...string) ([]s
 	})
 }
 
-// getDependencyInfo return the path inside paths that match the dependency.
+// GetDependencyInfo return the path inside paths that match the dependency.
 //
 // The line and the dependency trimmed is also returned.
 //
 //nolint:funlen,gocyclo
-func GetDependencyInfo(paths []string, dependency string) (string, string, string) {
+func GetDependencyInfo(dependency string, paths ...string) (string, string, string) {
 	var line int
 
 	for _, path := range paths {

--- a/internal/utils/file/file.go
+++ b/internal/utils/file/file.go
@@ -241,7 +241,7 @@ func GetDependencyCodeFilepathAndLine(
 		return "", "", ""
 	}
 
-	return getDependencyInfo(paths, dependency)
+	return GetDependencyInfo(paths, dependency)
 }
 
 // nolint: funlen
@@ -271,7 +271,7 @@ func getPathsByExtension(projectPath, subPath string, extensions ...string) ([]s
 // The line and the dependency trimmed is also returned.
 //
 //nolint:funlen,gocyclo
-func getDependencyInfo(paths []string, dependency string) (string, string, string) {
+func GetDependencyInfo(paths []string, dependency string) (string, string, string) {
 	var line int
 
 	for _, path := range paths {


### PR DESCRIPTION
Signed-off-by: Danang Heriyadi <danang.heriyadi19@gmail.com>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
Tried to solve https://github.com/ZupIT/horusec/issues/881 bug by adding some code to find where the correct line. I am not sure it's effective or not. But it's work.  In my code, I define the start line from 0, is that correct?

**- How to verify it**
```bash
$ git clone https://github.com/sqreen/go-dvwa.git
$ cd go-dvwa
$ horusec generate
$ horusec start -p $(pwd)
```
Check Horusec report on the go.sum file it will show as below:
```bash
==================================================================================

Language: Generic
Severity: UNKNOWN
Line: 73
Column: 0
SecurityTool: Trivy
Confidence: MEDIUM
File: /home/danang/Project/Horusec/go-dvwa/go.sum
Code: github.com/gin-gonic/gin
Details: Installed Version: "1.3.0", Update to Version: "v1.6.0" for fix this issue.
Type: Vulnerability
ReferenceHash: 305e9fe32192f87c2ae313293102c8715fbbbf7e65ff76aa428a9f31c9aca02f

==================================================================================

Language: Generic
Severity: UNKNOWN
Line: 223
Column: 0
SecurityTool: Trivy
Confidence: MEDIUM
File: /home/danang/Project/Horusec/go-dvwa/go.sum
Code: github.com/labstack/echo/v4
Details: Installed Version: "4.1.17", Update to Version: "v4.1.18-0.20201215153152-4422e3b66b9f" for fix this issue.
Type: Vulnerability
ReferenceHash: 9638f420ede278f73f221370043c730b64c2c3dd7dae3ac441425aebe83bba63

==================================================================================

Language: Generic
Severity: UNKNOWN
Line: 309
Column: 0
SecurityTool: Trivy
Confidence: MEDIUM
File: /home/danang/Project/Horusec/go-dvwa/go.sum
Code: github.com/satori/go.uuid
Details: Installed Version: "1.2.0", Update to Version: "v1.2.1-0.20181016170032-d91630c85102" for fix this issue.
Type: Vulnerability
ReferenceHash: da0698507f527a58779a52c478955f4defc6c320bf430840d942ea10a6423c7e

==================================================================================

```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
