### PR TITLE
engine/java:chore - updating JS-JAVA-150 to match log4j lower than 2.16.0

### DIFF
--- a/internal/services/engines/java/rules.go
+++ b/internal/services/engines/java/rules.go
@@ -2600,17 +2600,17 @@ func NewVulnerableRemoteCodeInjectionApacheLog4j() text.TextRule {
 		Metadata: engine.Metadata{
 			ID:          "HS-JAVA-150",
 			Name:        "Remote code injection Apache Log4j",
-			Description: "Log4j versions prior to 2.15.0 are subject to a remote code execution vulnerability via the ldap JNDI parser. For more information checkout the CVE-2021-44228 (https://nvd.nist.gov/vuln/detail/CVE-2021-44228) advisory.",
+			Description: "Log4j versions prior to 2.16.0 are subject to a remote code execution vulnerability via the ldap JNDI parser. For more information checkout the CVE-2021-44228 (https://nvd.nist.gov/vuln/detail/CVE-2021-44228) and CVE-2021-45046 (https://nvd.nist.gov/vuln/detail/CVE-2021-45046) advisories.",
 			Severity:    severities.Critical.ToString(),
 			Confidence:  confidence.Medium.ToString(),
 		},
 		Type: text.OrMatch,
 		Expressions: []*regexp.Regexp{
-			regexp.MustCompile(`compile.*group:.*org\.apache\.logging\.log4j.*name:.*log4j.*version:.*(('|")((2\.([0-9]\.|1[0-4]))|(1\.))).*('|")`),
-			regexp.MustCompile(`compile.*log4j.*(:((2\.([0-9]\.|1[0-4]))|(1\.))).*('|")`),
-			regexp.MustCompile(`<groupId>(.*|\n).*org\.apache\.logging\.log4j.*(.*|\n).*<artifactId>.*log4j.*</artifactId>(.*|\n)*(version>((2\.([0-9]\.|1[0-4]))|(1\.)))(.*|\n)*</version>`),
-			regexp.MustCompile(`<dependency.*org.*org\.apache\.logging\.log4j.*name.*log4j.*rev.*((2\.([0-9]\.|1[0-4]))|(1\.)).*/>`),
-			regexp.MustCompile(`<(log4j2|log4j)\.version>.*((2\.([0-9]\.|1[0-4]))|(1\.)).*</(log4j2|log4j)\.version>`),
+			regexp.MustCompile(`compile.*group:.*org\.apache\.logging\.log4j.*name:.*log4j.*version:.*(('|")(2\.([0-9]\.|1[0-5]))|([0-1]\.[0-9]+\.[0-9]+)).*('|")`),
+			regexp.MustCompile(`compile.*log4j.*(:((2\.([0-9]\.|1[0-5]))|([0-1]\.[0-9]+\.[0-9]+))).*('|")`),
+			regexp.MustCompile(`<groupId>(.*|\n).*org\.apache\.logging\.log4j.*(.*|\n).*<artifactId>.*log4j.*</artifactId>(.*|\n)*(version>((2\.([0-9]\.|1[0-5]))|([0-1]\.[0-9]+\.[0-9]+)))(.*|\n)*</version>`),
+			regexp.MustCompile(`<dependency.*org.*org\.apache\.logging\.log4j.*name.*log4j.*rev.*(2\.([0-9]\.|1[0-5]))|([0-1]\.[0-9]+\.[0-9]+).*/>`),
+			regexp.MustCompile(`<(log4j2|log4j)\.version>.*(2\.([0-9]\.|1[0-5]))|([0-1]\.[0-9]+\.[0-9]+).*</(log4j2|log4j)\.version>`),
 		},
 	}
 }

--- a/internal/services/engines/java/sample_test.go
+++ b/internal/services/engines/java/sample_test.go
@@ -923,7 +923,7 @@ public class Foo {
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.15.0</version>
+            <version>2.16.0</version>
         </dependency>
     </dependencies>
 </project>
@@ -973,9 +973,9 @@ repositories {
 dependencies {
 
     // SLF4J as a facade over Log4j2 required dependencies
-    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.15.0'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.15.0'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.15.0'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.16.0'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.16.0'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.16.0'
 
     // Bridges from other logging implementations to SLF4J. Be careful not to bridge SLF4J itself to
     compile group: 'org.slf4j', name: 'jul-to-slf4j', version: '1.7.25' // JUL bridge
@@ -984,7 +984,6 @@ dependencies {
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }
-
 `
 
 	Sample3GradleVulnerableHSJAVA150 = `
@@ -1043,7 +1042,7 @@ dependencies {
     compile 'com.epam.reportportal:agent-java-testng:4.2.3'
     
     compile 'com.epam.reportportal:logger-java-log4j:4.0.1'
-    compile 'org.slf4j:slf4j-log4j12:2.15.0'
+    compile 'org.slf4j:slf4j-log4j12:2.16.0'
 }
 
 
@@ -1096,8 +1095,8 @@ test {
     <dependency org="com.auth0" name="java-jwt" rev="3.3.0" />
     <dependency org="com.zaxxer" name="HikariCP" rev="3.1.0" />
     <dependency org="org.postgresql" name="postgresql" rev="42.2.2" />
-    <dependency org="org.apache.logging.log4j" name="log4j-api" rev="2.15.0" />
-    <dependency org="org.apache.logging.log4j" name="log4j-core" rev="2.15.0" />
+    <dependency org="org.apache.logging.log4j" name="log4j-api" rev="2.16.0" />
+    <dependency org="org.apache.logging.log4j" name="log4j-core" rev="2.16.0" />
 
 
 
@@ -1163,7 +1162,7 @@ test {
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <log4j2.version>2.15.0</log4j2.version>
+        <log4j2.version>2.16.0</log4j2.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Updated rule HS-JAVA-150 to match log4j when it's lower than 2.16.0. Also made a improvement in regex to avoid false positives with futures version like 3.0.0.

Signed-off-by: Nathan Martins <nathan.martins@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
