### PR TITLE
dependency_check:chore - improve tests and code cleaning

### DIFF
--- a/internal/services/formatters/generic/dependency_check/analysis.go
+++ b/internal/services/formatters/generic/dependency_check/analysis.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package entities
+package dependencycheck
 
-type Analysis struct {
-	Dependencies []*Dependency `json:"dependencies"`
+type dependencyCheckAnalysis struct {
+	Dependencies []*dependencyCheckDependency `json:"dependencies"`
 }

--- a/internal/services/formatters/generic/dependency_check/dependency.go
+++ b/internal/services/formatters/generic/dependency_check/dependency.go
@@ -12,19 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package entities
+package dependencycheck
 
 import (
 	"strings"
 )
 
-type Dependency struct {
-	FileName        string           `json:"fileName"`
-	FilePath        string           `json:"filePath"`
-	Vulnerabilities []*Vulnerability `json:"vulnerabilities"`
+type dependencyCheckDependency struct {
+	FileName        string                          `json:"fileName"`
+	FilePath        string                          `json:"filePath"`
+	Vulnerabilities []*dependencyCheckVulnerability `json:"vulnerabilities"`
 }
 
-func (d *Dependency) GetVulnerability() *Vulnerability {
+func (d *dependencyCheckDependency) getVulnerability() *dependencyCheckVulnerability {
 	for _, vulnerability := range d.Vulnerabilities {
 		if strings.Contains(vulnerability.Name, "CWE") {
 			return vulnerability
@@ -38,7 +38,7 @@ func (d *Dependency) GetVulnerability() *Vulnerability {
 	return nil
 }
 
-func (d *Dependency) GetFile() string {
+func (d *dependencyCheckDependency) getFile() string {
 	index := strings.Index(d.FilePath, "?")
 	if index < 0 {
 		return d.FilePath

--- a/internal/services/formatters/generic/dependency_check/dependency_test.go
+++ b/internal/services/formatters/generic/dependency_check/dependency_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package entities
+package dependencycheck
 
 import (
 	"testing"
@@ -22,10 +22,10 @@ import (
 
 func TestGetVulnerability(t *testing.T) {
 	t.Run("should success get vulnerability without cwe", func(t *testing.T) {
-		dependency := &Dependency{
+		dependency := &dependencyCheckDependency{
 			FileName: "test",
 			FilePath: "test",
-			Vulnerabilities: []*Vulnerability{
+			Vulnerabilities: []*dependencyCheckVulnerability{
 				{
 					Description: "test",
 					Severity:    "test",
@@ -34,14 +34,14 @@ func TestGetVulnerability(t *testing.T) {
 			},
 		}
 
-		assert.NotNil(t, dependency.GetVulnerability())
+		assert.NotNil(t, dependency.getVulnerability())
 	})
 
 	t.Run("should success get vulnerability with cwe", func(t *testing.T) {
-		dependency := &Dependency{
+		dependency := &dependencyCheckDependency{
 			FileName: "test",
 			FilePath: "test",
-			Vulnerabilities: []*Vulnerability{
+			Vulnerabilities: []*dependencyCheckVulnerability{
 				{
 					Description: "test",
 					Severity:    "test",
@@ -50,33 +50,33 @@ func TestGetVulnerability(t *testing.T) {
 			},
 		}
 
-		assert.NotNil(t, dependency.GetVulnerability())
+		assert.NotNil(t, dependency.getVulnerability())
 	})
 
 	t.Run("should return nil when do not contains vulnerability", func(t *testing.T) {
-		dependency := &Dependency{}
+		dependency := &dependencyCheckDependency{}
 
-		assert.Nil(t, dependency.GetVulnerability())
+		assert.Nil(t, dependency.getVulnerability())
 	})
 }
 
 func TestGetFile(t *testing.T) {
 	t.Run("should success get file", func(t *testing.T) {
-		dependency := &Dependency{
+		dependency := &dependencyCheckDependency{
 			FilePath: "test?test",
 		}
 
-		file := dependency.GetFile()
+		file := dependency.getFile()
 		assert.NotEmpty(t, file)
 		assert.Equal(t, "test", file)
 	})
 
 	t.Run("should success get file", func(t *testing.T) {
-		dependency := &Dependency{
+		dependency := &dependencyCheckDependency{
 			FilePath: "test2",
 		}
 
-		file := dependency.GetFile()
+		file := dependency.getFile()
 		assert.NotEmpty(t, file)
 		assert.Equal(t, "test2", file)
 	})

--- a/internal/services/formatters/generic/dependency_check/formatter_test.go
+++ b/internal/services/formatters/generic/dependency_check/formatter_test.go
@@ -18,130 +18,219 @@ import (
 	"errors"
 	"testing"
 
-	entitiesAnalysis "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
+	"github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
+	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 	"github.com/stretchr/testify/assert"
 
-	cliConfig "github.com/ZupIT/horusec/config"
+	"github.com/ZupIT/horusec/config"
 	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
-	"github.com/ZupIT/horusec/internal/entities/workdir"
 	"github.com/ZupIT/horusec/internal/services/formatters"
 	"github.com/ZupIT/horusec/internal/utils/testutil"
 )
 
-const output = "{ \"dependencies\":[ { \"isVirtual\":false, \"fileName\":\"app.js\", \"filePath\":\"\\/src\\/app.js" +
-	"\", \"md5\":\"d3bf3a62b0f02ffaa11516d7f1aa7c83\", \"sha1\":\"eac9ad35db19d0f30eee6f4704e57634ea4f6f9c\", \"sh" +
-	"a256\":\"39bf0d903ffaef9ecddbdb40a3658a2bd5a3fdb1741ccd58a6cf58be841ec692\", \"evidenceCollected\":{ \"vendor" +
-	"Evidence\":[ ], \"productEvidence\":[ ], \"versionEvidence\":[ ] } }, { \"isVirtual\":true, \"fileName\":\"co" +
-	"okie-signature:1.0.3\", \"filePath\":\"\\/src\\/package-lock.json?cookie-signature\", \"projectReferences\":[" +
-	" \"package-lock.json: transitive\" ], \"evidenceCollected\":{ \"vendorEvidence\":[ { \"type\":\"vendor\", \"c" +
-	"onfidence\":\"HIGH\", \"source\":\"package.json\", \"name\":\"name\", \"value\":\"cookie-signature\" } ], \"p" +
-	"roductEvidence\":[ { \"type\":\"product\", \"confidence\":\"HIGHEST\", \"source\":\"package.json\", \"name\"" +
-	":\"name\", \"value\":\"cookie-signature\" } ], \"versionEvidence\":[ { \"type\":\"version\", \"confidence\"" +
-	":\"HIGHEST\", \"source\":\"package.json\", \"name\":\"version\", \"value\":\"1.0.3\" } ] }, \"packages\":[ { " +
-	"\"id\":\"pkg:npm\\/cookie-signature@1.0.3\", \"confidence\":\"HIGHEST\", \"url\":\"https:\\/\\/ossindex.sona" +
-	"type.org\\/component\\/pkg:npm\\/cookie-signature@1.0.3?utm_source=dependency-check&utm_medium=integration&ut" +
-	"m_content=6.2.2\" } ], \"vulnerabilities\":[ { \"source\":\"NPM\", \"name\":\"134\", \"unscored\":\"true\"," +
-	" \"severity\":\"moderate\", \"cwes\":[ ], \"description\":\"Affected versions of `cookie-signature` are vul" +
-	"nerable to timing attacks as a result of using a fail-early comparison instead of a constant-time comparison" +
-	". \\n\\nTiming attacks remove the exponential increase in entropy gained from increased secret length, by pr" +
-	"oviding per-character feedback on the correctness of a guess via miniscule timing differences.\\n\\nUnder fav" +
-	"orable network conditions, an attacker can exploit this to guess the secret in no more than `charset*length` " +
-	"guesses, instead of `charset^length` guesses required were the timing attack not present. \\n\", \"notes\":\"" +
-	"\", \"references\":[ { \"source\":\"Advisory 134: Timing Attack\", \"name\":\"- [Commit #3979108](https:\\/\\" +
-	"/github.com\\/tj\\/node-cookie-signature\\/commit\\/39791081692e9e14aa62855369e1c7f80fbfd50e)\" } ], \"vulnera" +
-	"bleSoftware\":[ { \"software\":{ \"id\":\"cpe:2.3:a:*:cookie-signature:\\\\<\\\\=1.0.5:*:*:*:*:*:*:*\" } } ]" +
-	" }, { \"source\":\"OSSINDEX\", \"name\":\"CWE-208: Information Exposure Through Timing Discrepancy\", \"unsc" +
-	"ored\":\"true\", \"severity\":\"Unknown\", \"cwes\":[ \"CWE-208\" ], \"description\":\"Two separate operatio" +
-	"ns in a product require different amounts of time to complete, in a way that is observable to an actor and " +
-	"reveals security-relevant information about the state of the product, such as whether a particular operation" +
-	" was successful or not.\", \"notes\":\"\", \"references\":[ { \"source\":\"OSSINDEX\", \"url\":\"https:\\/\\" +
-	"/ossindex.sonatype.org\\/vulnerability\\/bf671e3a-9d6a-4d46-a724-01b92b80e7a3?component-type=npm&component-n" +
-	"ame=cookie-signature&utm_source=dependency-check&utm_medium=integration&utm_content=6.2.2\", \"name\":\"CWE-" +
-	"208: Information Exposure Through Timing Discrepancy\" } ], \"vulnerableSoftware\":[ { \"software\":{ \"id\"" +
-	":\"cpe:2.3:a:*:cookie-signature:1.0.3:*:*:*:*:*:*:*\", \"vulnerabilityIdMatched\":\"true\" } } ] } ] } ] }"
-
 func TestStartGenericOwaspDependencyCheck(t *testing.T) {
-	t.Run("should success execute container and process output", func(t *testing.T) {
+	t.Run("Should success parse output to analysis", func(t *testing.T) {
 		dockerAPIControllerMock := testutil.NewDockerMock()
-		analysis := &entitiesAnalysis.Analysis{}
-		config := &cliConfig.Config{}
-		config.WorkDir = &workdir.WorkDir{}
-
-		config.EnableOwaspDependencyCheck = true
 		dockerAPIControllerMock.On("CreateLanguageAnalysisContainer").Return(output, nil)
 
-		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, config)
+		analysis := new(analysis.Analysis)
+
+		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, newConfig())
+		formatter := NewFormatter(service)
+		formatter.StartAnalysis("")
+
+		assert.Len(t, analysis.AnalysisVulnerabilities, 1)
+		for _, v := range analysis.AnalysisVulnerabilities {
+			vuln := v.Vulnerability
+
+			assert.Equal(t, tools.OwaspDependencyCheck, vuln.SecurityTool)
+			assert.Equal(t, languages.Generic, vuln.Language)
+			assert.NotEmpty(t, vuln.Details, "Expected not empty details")
+			assert.NotEmpty(t, vuln.Code, "Expected not empty code")
+			assert.NotEmpty(t, vuln.File, "Expected not empty file name")
+			assert.NotEmpty(t, vuln.Severity, "Expected not empty severity")
+
+		}
+	})
+
+	t.Run("should add error on analysis when parse invalid output", func(t *testing.T) {
+		dockerAPIControllerMock := testutil.NewDockerMock()
+		dockerAPIControllerMock.On("CreateLanguageAnalysisContainer").Return("{", nil)
+
+		analysis := new(analysis.Analysis)
+
+		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, newConfig())
+
+		formatter := NewFormatter(service)
+		formatter.StartAnalysis("")
+
+		assert.Len(t, analysis.AnalysisVulnerabilities, 0)
+		assert.True(t, analysis.HasErrors(), "Expected errors on analysis")
+	})
+
+	t.Run("should add error from docker on analysis", func(t *testing.T) {
+		dockerAPIControllerMock := testutil.NewDockerMock()
+		dockerAPIControllerMock.On("CreateLanguageAnalysisContainer").Return("", errors.New("test"))
+
+		analysis := new(analysis.Analysis)
+
+		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, newConfig())
 		formatter := NewFormatter(service)
 
 		formatter.StartAnalysis("")
 
-		assert.NotEmpty(t, analysis)
-		assert.Len(t, analysis.AnalysisVulnerabilities, 1)
+		assert.True(t, analysis.HasErrors(), "Expected errors on analysis")
 	})
 
-	t.Run("should return error when invalid output", func(t *testing.T) {
+	t.Run("should parse empty output without errors", func(t *testing.T) {
 		dockerAPIControllerMock := testutil.NewDockerMock()
-		analysis := &entitiesAnalysis.Analysis{}
-		config := &cliConfig.Config{}
-		config.WorkDir = &workdir.WorkDir{}
-
-		dockerAPIControllerMock.On("CreateLanguageAnalysisContainer").Return("{", nil)
-
-		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, config)
-		formatter := NewFormatter(service)
-
-		assert.NotPanics(t, func() {
-			formatter.StartAnalysis("")
-		})
-	})
-
-	t.Run("should return error when executing container", func(t *testing.T) {
-		dockerAPIControllerMock := testutil.NewDockerMock()
-		analysis := &entitiesAnalysis.Analysis{}
-		config := &cliConfig.Config{}
-		config.WorkDir = &workdir.WorkDir{}
-
-		dockerAPIControllerMock.On("CreateLanguageAnalysisContainer").Return("", errors.New("test"))
-
-		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, config)
-		formatter := NewFormatter(service)
-
-		assert.NotPanics(t, func() {
-			formatter.StartAnalysis("")
-		})
-	})
-
-	t.Run("should return nil when empty output", func(t *testing.T) {
-		dockerAPIControllerMock := testutil.NewDockerMock()
-		analysis := &entitiesAnalysis.Analysis{}
-		config := &cliConfig.Config{}
-		config.WorkDir = &workdir.WorkDir{}
-
 		dockerAPIControllerMock.On("CreateLanguageAnalysisContainer").Return("", nil)
 
-		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, config)
-		formatter := NewFormatter(service)
+		analysis := new(analysis.Analysis)
 
-		assert.NotPanics(t, func() {
-			formatter.StartAnalysis("")
-		})
+		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, newConfig())
+
+		formatter := NewFormatter(service)
+		formatter.StartAnalysis("")
+
+		assert.False(t, analysis.HasErrors(), "Expected no errors on analysis")
 	})
 
 	t.Run("should not execute tool because it's ignored", func(t *testing.T) {
-		analysis := &entitiesAnalysis.Analysis{}
+		analysis := new(analysis.Analysis)
+
 		dockerAPIControllerMock := testutil.NewDockerMock()
-		config := &cliConfig.Config{}
-		config.WorkDir = &workdir.WorkDir{}
-		config.ToolsConfig = toolsconfig.ToolsConfig{
+
+		cfg := newConfig()
+		cfg.ToolsConfig = toolsconfig.ToolsConfig{
 			tools.OwaspDependencyCheck: toolsconfig.Config{
 				IsToIgnore: true,
 			},
 		}
 
-		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, config)
+		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, cfg)
 		formatter := NewFormatter(service)
-
 		formatter.StartAnalysis("")
 	})
 }
+
+func newConfig() *config.Config {
+	cfg := config.New()
+	cfg.EnableOwaspDependencyCheck = true
+	return cfg
+}
+
+const output = `
+{
+  "dependencies": [
+    {
+      "isVirtual": false,
+      "fileName": "app.js",
+      "filePath": "\\/src\\/app.js",
+      "md5": "d3bf3a62b0f02ffaa11516d7f1aa7c83",
+      "sha1": "eac9ad35db19d0f30eee6f4704e57634ea4f6f9c",
+      "sha256": "39bf0d903ffaef9ecddbdb40a3658a2bd5a3fdb1741ccd58a6cf58be841ec692",
+      "evidenceCollected": {
+        "vendorEvidence": [],
+        "productEvidence": [],
+        "versionEvidence": []
+      }
+    },
+    {
+      "isVirtual": true,
+      "fileName": "cookie-signature:1.0.3",
+      "filePath": "\\/src\\/package-lock.json?cookie-signature",
+      "projectReferences": [
+        "package-lock.json: transitive"
+      ],
+      "evidenceCollected": {
+        "vendorEvidence": [
+          {
+            "type": "vendor",
+            "confidence": "HIGH",
+            "source": "package.json",
+            "name": "name",
+            "value": "cookie-signature"
+          }
+        ],
+        "productEvidence": [
+          {
+            "type": "product",
+            "confidence": "HIGHEST",
+            "source": "package.json",
+            "name": "name",
+            "value": "cookie-signature"
+          }
+        ],
+        "versionEvidence": [
+          {
+            "type": "version",
+            "confidence": "HIGHEST",
+            "source": "package.json",
+            "name": "version",
+            "value": "1.0.3"
+          }
+        ]
+      },
+      "packages": [
+        {
+          "id": "pkg:npm\\/cookie-signature@1.0.3",
+          "confidence": "HIGHEST",
+          "url": "https:\\/\\/ossindex.sonatype.org\\/component\\/pkg:npm\\/cookie-signature@1.0.3?utm_source=dependency-check&utm_medium=integration&utm_content=6.2.2"
+        }
+      ],
+      "vulnerabilities": [
+        {
+          "source": "NPM",
+          "name": "134",
+          "unscored": "true",
+          "severity": "moderate",
+          "cwes": [],
+          "description": "Affected versions of cookie-signature are vulnerable to timing attacks as a result of using a fail-early comparison instead of a constant-time comparison. \n\nTiming attacks remove the exponential increase in entropy gained from increased secret length, by providing per-character feedback on the correctness of a guess via miniscule timing differences.\n\nUnder favorable network conditions, an attacker can exploit this to guess the secret in no more than charset*length guesses, instead of charset^length guesses required were the timing attack not present. \n",
+          "notes": "",
+          "references": [
+            {
+              "source": "Advisory 134: Timing Attack",
+              "name": "- [Commit #3979108](https:\\/\\/github.com\\/tj\\/node-cookie-signature\\/commit\\/39791081692e9e14aa62855369e1c7f80fbfd50e)"
+            }
+          ],
+          "vulnerableSoftware": [
+            {
+              "software": {
+                "id": "cpe:2.3:a:*:cookie-signature:\\<\\=1.0.5:*:*:*:*:*:*:*"
+              }
+            }
+          ]
+        },
+        {
+          "source": "OSSINDEX",
+          "name": "CWE-208: Information Exposure Through Timing Discrepancy",
+          "unscored": "true",
+          "severity": "Unknown",
+          "cwes": [
+            "CWE-208"
+          ],
+          "description": "Two separate operations in a product require different amounts of time to complete, in a way that is observable to an actor and reveals security-relevant information about the state of the product, such as whether a particular operation was successful or not.",
+          "notes": "",
+          "references": [
+            {
+              "source": "OSSINDEX",
+              "url": "https:\\/\\/ossindex.sonatype.org\\/vulnerability\\/bf671e3a-9d6a-4d46-a724-01b92b80e7a3?component-type=npm&component-name=cookie-signature&utm_source=dependency-check&utm_medium=integration&utm_content=6.2.2",
+              "name": "CWE-208: Information Exposure Through Timing Discrepancy"
+            }
+          ],
+          "vulnerableSoftware": [
+            {
+              "software": {
+                "id": "cpe:2.3:a:*:cookie-signature:1.0.3:*:*:*:*:*:*:*",
+                "vulnerabilityIdMatched": "true"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+`

--- a/internal/services/formatters/generic/dependency_check/vulnerability.go
+++ b/internal/services/formatters/generic/dependency_check/vulnerability.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package entities
+package dependencycheck
 
 import (
 	"strings"
@@ -29,14 +29,14 @@ const (
 	Low      = "low"
 )
 
-type Vulnerability struct {
+type dependencyCheckVulnerability struct {
 	Description string `json:"description"`
 	Severity    string `json:"severity"`
 	Name        string `json:"name"`
 }
 
 //nolint:funlen // need to be bigger than 10
-func (v *Vulnerability) GetSeverity() severities.Severity {
+func (v *dependencyCheckVulnerability) getSeverity() severities.Severity {
 	switch strings.ToLower(v.Severity) {
 	case Highest, Critical:
 		return severities.Critical

--- a/internal/services/formatters/generic/dependency_check/vulnerability_test.go
+++ b/internal/services/formatters/generic/dependency_check/vulnerability_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package entities
+package dependencycheck
 
 import (
 	"testing"
@@ -23,27 +23,27 @@ import (
 
 func TestGetSeverity(t *testing.T) {
 	t.Run("should success severity", func(t *testing.T) {
-		vuln := &Vulnerability{}
+		vuln := &dependencyCheckVulnerability{}
 
 		vuln.Severity = "highest"
-		assert.Equal(t, severities.Critical, vuln.GetSeverity())
+		assert.Equal(t, severities.Critical, vuln.getSeverity())
 
 		vuln.Severity = "critical"
-		assert.Equal(t, severities.Critical, vuln.GetSeverity())
+		assert.Equal(t, severities.Critical, vuln.getSeverity())
 
 		vuln.Severity = "high"
-		assert.Equal(t, severities.High, vuln.GetSeverity())
+		assert.Equal(t, severities.High, vuln.getSeverity())
 
 		vuln.Severity = "moderate"
-		assert.Equal(t, severities.Medium, vuln.GetSeverity())
+		assert.Equal(t, severities.Medium, vuln.getSeverity())
 
 		vuln.Severity = "medium"
-		assert.Equal(t, severities.Medium, vuln.GetSeverity())
+		assert.Equal(t, severities.Medium, vuln.getSeverity())
 
 		vuln.Severity = "low"
-		assert.Equal(t, severities.Low, vuln.GetSeverity())
+		assert.Equal(t, severities.Low, vuln.getSeverity())
 
 		vuln.Severity = "test"
-		assert.Equal(t, severities.Unknown, vuln.GetSeverity())
+		assert.Equal(t, severities.Unknown, vuln.getSeverity())
 	})
 }


### PR DESCRIPTION
This commit add some new asserts on successful parsing dependency check
results, to verify that all fields of Vulnerability was filled.

Some code organization was also made, and the entities packages was
removed and the dependency check schema output was moved to
dependencycheck package.

Updates #718

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
