### PR TITLE
docker:chore - rename SetData method of AnalysisData

### DIFF
--- a/internal/entities/docker/analysis_data.go
+++ b/internal/entities/docker/analysis_data.go
@@ -23,6 +23,8 @@ import (
 	"github.com/ZupIT/horusec/internal/enums/images"
 )
 
+// AnalysisData holds the image and command that will be used to start an
+// analysis of a tool inside a Docker container.
 type AnalysisData struct {
 	CustomImage  string
 	DefaultImage string
@@ -30,17 +32,23 @@ type AnalysisData struct {
 	Language     languages.Language
 }
 
+// IsInvalid check if current analysis data contains an empty image ou command.
 func (a *AnalysisData) IsInvalid() bool {
 	return a.DefaultImage == "" || a.CMD == ""
 }
 
-func (a *AnalysisData) SetData(customImage, imageWithTag string) *AnalysisData {
+// SetImage set the custom image and default image that will be used by analysis
+//
+// Note that customImage could be an empty string and defaultImage **should**
+// contains docker tag, e.g go:1.17.
+func (a *AnalysisData) SetImage(customImage, defaultImage string) *AnalysisData {
 	a.CustomImage = customImage
-	a.DefaultImage = path.Join(images.DefaultRegistry, imageWithTag)
+	a.DefaultImage = path.Join(images.DefaultRegistry, defaultImage)
 
 	return a
 }
 
+// GetCustomOrDefaultImage return the user custom image or default.
 func (a *AnalysisData) GetCustomOrDefaultImage() string {
 	if a.CustomImage != "" {
 		return a.CustomImage

--- a/internal/entities/docker/analysis_data_test.go
+++ b/internal/entities/docker/analysis_data_test.go
@@ -42,7 +42,7 @@ func TestSetData(t *testing.T) {
 			CMD: "test",
 		}
 
-		newData := data.SetData("other-host.io/t/test:latest", "test:v1.0.0")
+		newData := data.SetImage("other-host.io/t/test:latest", "test:v1.0.0")
 		assert.Equal(t, "other-host.io/t/test:latest", newData.CustomImage)
 		assert.Equal(t, "docker.io/test:v1.0.0", newData.DefaultImage)
 	})

--- a/internal/services/docker/docker_api_test.go
+++ b/internal/services/docker/docker_api_test.go
@@ -144,7 +144,7 @@ func TestDockerAPI_CreateLanguageAnalysisContainer(t *testing.T) {
 		ad := &dockerEntities.AnalysisData{
 			CMD: Cmd,
 		}
-		ad.SetData("", Image)
+		ad.SetImage("", Image)
 		_, err := api.CreateLanguageAnalysisContainer(ad)
 
 		assert.Error(t, err)
@@ -165,7 +165,7 @@ func TestDockerAPI_CreateLanguageAnalysisContainer(t *testing.T) {
 		ad := &dockerEntities.AnalysisData{
 			CMD: Cmd,
 		}
-		ad.SetData("", Image)
+		ad.SetImage("", Image)
 		_, err := api.CreateLanguageAnalysisContainer(ad)
 
 		assert.Error(t, err)
@@ -193,7 +193,7 @@ func TestDockerAPI_CreateLanguageAnalysisContainer(t *testing.T) {
 		ad := &dockerEntities.AnalysisData{
 			CMD: Cmd,
 		}
-		ad.SetData("", Image)
+		ad.SetImage("", Image)
 		_, err := api.CreateLanguageAnalysisContainer(ad)
 
 		assert.Error(t, err)
@@ -218,7 +218,7 @@ func TestDockerAPI_CreateLanguageAnalysisContainer(t *testing.T) {
 		ad := &dockerEntities.AnalysisData{
 			CMD: Cmd,
 		}
-		ad.SetData("", Image)
+		ad.SetImage("", Image)
 		_, err := api.CreateLanguageAnalysisContainer(ad)
 
 		assert.Error(t, err)
@@ -243,7 +243,7 @@ func TestDockerAPI_CreateLanguageAnalysisContainer(t *testing.T) {
 		ad := &dockerEntities.AnalysisData{
 			CMD: Cmd,
 		}
-		ad.SetData("", Image)
+		ad.SetImage("", Image)
 		_, err := api.CreateLanguageAnalysisContainer(ad)
 
 		assert.NoError(t, err)

--- a/internal/services/formatters/c/flawfinder/formatter.go
+++ b/internal/services/formatters/c/flawfinder/formatter.go
@@ -66,7 +66,7 @@ func (f *Formatter) getConfigData(projectSubPath string) *docker.AnalysisData {
 		Language: languages.C,
 	}
 
-	return analysisData.SetData(f.GetCustomImageByLanguage(languages.C), images.C)
+	return analysisData.SetImage(f.GetCustomImageByLanguage(languages.C), images.C)
 }
 
 func (f *Formatter) parseOutput(output string) error {

--- a/internal/services/formatters/csharp/dotnet_cli/formatter.go
+++ b/internal/services/formatters/csharp/dotnet_cli/formatter.go
@@ -76,7 +76,7 @@ func (f *Formatter) getConfigData(projectSubPath string) *docker.AnalysisData {
 		Language: languages.CSharp,
 	}
 
-	return analysisData.SetData(f.GetCustomImageByLanguage(languages.CSharp), images.Csharp)
+	return analysisData.SetImage(f.GetCustomImageByLanguage(languages.CSharp), images.Csharp)
 }
 
 // nolint:gocyclo

--- a/internal/services/formatters/csharp/scs/formatter.go
+++ b/internal/services/formatters/csharp/scs/formatter.go
@@ -146,7 +146,7 @@ func (f *Formatter) getDockerConfig(projectSubPath string) *docker.AnalysisData 
 
 	analysisData.SetSlnName(filename)
 
-	return analysisData.SetData(f.GetCustomImageByLanguage(languages.CSharp), images.Csharp)
+	return analysisData.SetImage(f.GetCustomImageByLanguage(languages.CSharp), images.Csharp)
 }
 
 func (f *Formatter) getSeverity(ruleID string) severities.Severity {

--- a/internal/services/formatters/elixir/mixaudit/formatter.go
+++ b/internal/services/formatters/elixir/mixaudit/formatter.go
@@ -69,7 +69,7 @@ func (f *Formatter) getConfigData(projectSubPath string) *dockerEntities.Analysi
 		Language: languages.Elixir,
 	}
 
-	return analysisData.SetData(f.GetCustomImageByLanguage(languages.Elixir), images.Elixir)
+	return analysisData.SetImage(f.GetCustomImageByLanguage(languages.Elixir), images.Elixir)
 }
 
 func (f *Formatter) parseOutput(output string) error {

--- a/internal/services/formatters/elixir/sobelow/formatter.go
+++ b/internal/services/formatters/elixir/sobelow/formatter.go
@@ -80,7 +80,7 @@ func (f *Formatter) getConfigData(projectSubPath string) *dockerEntities.Analysi
 		Language: languages.Elixir,
 	}
 
-	return analysisData.SetData(f.GetCustomImageByLanguage(languages.Elixir), images.Elixir)
+	return analysisData.SetImage(f.GetCustomImageByLanguage(languages.Elixir), images.Elixir)
 }
 
 func (f *Formatter) parseOutput(output, projectSubPath string) {

--- a/internal/services/formatters/generic/dependency_check/formatter.go
+++ b/internal/services/formatters/generic/dependency_check/formatter.go
@@ -69,7 +69,7 @@ func (f *Formatter) getConfigData(projectSubPath string) *dockerEntities.Analysi
 		Language: languages.Generic,
 	}
 
-	return analysisData.SetData(f.GetCustomImageByLanguage(languages.Generic), images.Generic)
+	return analysisData.SetImage(f.GetCustomImageByLanguage(languages.Generic), images.Generic)
 }
 
 func (f *Formatter) parseOutput(output string) error {

--- a/internal/services/formatters/generic/semgrep/formatter.go
+++ b/internal/services/formatters/generic/semgrep/formatter.go
@@ -70,7 +70,7 @@ func (f *Formatter) getDockerConfig(projectSubPath string) *docker.AnalysisData 
 		Language: languages.Generic,
 	}
 
-	return analysisData.SetData(f.GetCustomImageByLanguage(languages.Generic), images.Generic)
+	return analysisData.SetImage(f.GetCustomImageByLanguage(languages.Generic), images.Generic)
 }
 
 func (f *Formatter) parseOutput(output string) error {

--- a/internal/services/formatters/generic/trivy/formatter.go
+++ b/internal/services/formatters/generic/trivy/formatter.go
@@ -131,7 +131,7 @@ func (f *Formatter) getDockerConfig(cmd, projectSubPath string) *dockerEntities.
 		Language: languages.Generic,
 	}
 
-	return analysisData.SetData(f.GetCustomImageByLanguage(languages.Generic), images.Generic)
+	return analysisData.SetImage(f.GetCustomImageByLanguage(languages.Generic), images.Generic)
 }
 
 func (f *Formatter) parseOutput(output, cmd, projectSubPath string) error {

--- a/internal/services/formatters/go/gosec/formatter.go
+++ b/internal/services/formatters/go/gosec/formatter.go
@@ -125,5 +125,5 @@ func (f *Formatter) getDockerConfig(projectSubPath string) *docker.AnalysisData 
 		Language: languages.Go,
 	}
 
-	return analysisData.SetData(f.GetCustomImageByLanguage(languages.Go), images.Go)
+	return analysisData.SetImage(f.GetCustomImageByLanguage(languages.Go), images.Go)
 }

--- a/internal/services/formatters/go/nancy/formatter.go
+++ b/internal/services/formatters/go/nancy/formatter.go
@@ -132,7 +132,7 @@ func (f *Formatter) getDockerConfig(projectSubPath string) *docker.AnalysisData 
 		Language: languages.Go,
 	}
 
-	return analysisData.SetData(f.GetCustomImageByLanguage(languages.Go), images.Go)
+	return analysisData.SetImage(f.GetCustomImageByLanguage(languages.Go), images.Go)
 }
 
 func (f *Formatter) removeHorusecFolder(path string) string {

--- a/internal/services/formatters/hcl/checkov/formatter.go
+++ b/internal/services/formatters/hcl/checkov/formatter.go
@@ -70,7 +70,7 @@ func (f *Formatter) getDockerConfig(projectSubPath string) *dockerEntities.Analy
 		Language: languages.HCL,
 	}
 
-	return analysisData.SetData(f.GetCustomImageByLanguage(languages.HCL), images.HCL)
+	return analysisData.SetImage(f.GetCustomImageByLanguage(languages.HCL), images.HCL)
 }
 
 func (f *Formatter) parseOutput(output string) error {

--- a/internal/services/formatters/hcl/tfsec/formatter.go
+++ b/internal/services/formatters/hcl/tfsec/formatter.go
@@ -70,7 +70,7 @@ func (f *Formatter) getDockerConfig(projectSubPath string) *dockerEntities.Analy
 		Language: languages.HCL,
 	}
 
-	return analysisData.SetData(f.GetCustomImageByLanguage(languages.HCL), images.HCL)
+	return analysisData.SetImage(f.GetCustomImageByLanguage(languages.HCL), images.HCL)
 }
 
 func (f *Formatter) parseOutput(output string) error {

--- a/internal/services/formatters/javascript/npmaudit/formatter.go
+++ b/internal/services/formatters/javascript/npmaudit/formatter.go
@@ -75,7 +75,7 @@ func (f *Formatter) getDockerConfig(projectSubPath string) *dockerEntities.Analy
 		Language: languages.Javascript,
 	}
 
-	return analysisData.SetData(f.GetCustomImageByLanguage(languages.Javascript), images.Javascript)
+	return analysisData.SetImage(f.GetCustomImageByLanguage(languages.Javascript), images.Javascript)
 }
 
 func (f *Formatter) parseOutput(containerOutput, projectSubPath string) error {

--- a/internal/services/formatters/javascript/yarnaudit/formatter.go
+++ b/internal/services/formatters/javascript/yarnaudit/formatter.go
@@ -77,7 +77,7 @@ func (f *Formatter) getDockerConfig(projectSubPath string) *dockerEntities.Analy
 		Language: languages.Javascript,
 	}
 
-	return analysisData.SetData(f.GetCustomImageByLanguage(languages.Javascript), images.Javascript)
+	return analysisData.SetImage(f.GetCustomImageByLanguage(languages.Javascript), images.Javascript)
 }
 
 func (f *Formatter) parseOutput(containerOutput, projectSubPath string) error {

--- a/internal/services/formatters/leaks/gitleaks/formatter.go
+++ b/internal/services/formatters/leaks/gitleaks/formatter.go
@@ -125,7 +125,7 @@ func (f *Formatter) getDockerConfig(projectSubPath string) *dockerEntities.Analy
 		Language: languages.Leaks,
 	}
 
-	return analysisData.SetData(f.GetCustomImageByLanguage(languages.Leaks), images.Leaks)
+	return analysisData.SetImage(f.GetCustomImageByLanguage(languages.Leaks), images.Leaks)
 }
 
 func (f *Formatter) getDefaultSeverity() *vulnerability.Vulnerability {

--- a/internal/services/formatters/php/phpcs/formatter.go
+++ b/internal/services/formatters/php/phpcs/formatter.go
@@ -69,7 +69,7 @@ func (f *Formatter) getDockerConfig(projectSubPath string) *dockerEntities.Analy
 		Language: languages.PHP,
 	}
 
-	return analysisData.SetData(f.GetCustomImageByLanguage(languages.PHP), images.PHP)
+	return analysisData.SetImage(f.GetCustomImageByLanguage(languages.PHP), images.PHP)
 }
 
 func (f *Formatter) parseOutput(output string) error {

--- a/internal/services/formatters/python/bandit/formatter.go
+++ b/internal/services/formatters/python/bandit/formatter.go
@@ -70,7 +70,7 @@ func (f *Formatter) getDockerConfig(projectSubPath string) *dockerEntities.Analy
 		Language: languages.Python,
 	}
 
-	return analysisData.SetData(f.GetCustomImageByLanguage(languages.Python), images.Python)
+	return analysisData.SetImage(f.GetCustomImageByLanguage(languages.Python), images.Python)
 }
 
 func (f *Formatter) parseOutput(output string) error {

--- a/internal/services/formatters/python/safety/formatter.go
+++ b/internal/services/formatters/python/safety/formatter.go
@@ -76,7 +76,7 @@ func (f *Formatter) getDockerConfig(projectSubPath string) *dockerEntities.Analy
 		Language: languages.Python,
 	}
 
-	return analysisData.SetData(f.GetCustomImageByLanguage(languages.Python), images.Python)
+	return analysisData.SetImage(f.GetCustomImageByLanguage(languages.Python), images.Python)
 }
 
 func (f *Formatter) parseOutput(output, projectSubPath string) error {

--- a/internal/services/formatters/ruby/brakeman/formatter.go
+++ b/internal/services/formatters/ruby/brakeman/formatter.go
@@ -127,7 +127,7 @@ func (f *Formatter) getDockerConfig(projectSubPath string) *docker.AnalysisData 
 		Language: languages.Ruby,
 	}
 
-	return analysisData.SetData(f.GetCustomImageByLanguage(languages.Ruby), images.Ruby)
+	return analysisData.SetImage(f.GetCustomImageByLanguage(languages.Ruby), images.Ruby)
 }
 
 func (f *Formatter) isNotFoundRailsProject(output string) bool {

--- a/internal/services/formatters/ruby/bundler/formatter.go
+++ b/internal/services/formatters/ruby/bundler/formatter.go
@@ -85,7 +85,7 @@ func (f *Formatter) getDockerConfig(projectSubPath string) *dockerEntities.Analy
 		Language: languages.Ruby,
 	}
 
-	return analysisData.SetData(f.GetCustomImageByLanguage(languages.Ruby), images.Ruby)
+	return analysisData.SetImage(f.GetCustomImageByLanguage(languages.Ruby), images.Ruby)
 }
 
 func (f *Formatter) verifyGemLockError(output string) error {

--- a/internal/services/formatters/shell/shellcheck/formatter.go
+++ b/internal/services/formatters/shell/shellcheck/formatter.go
@@ -117,7 +117,7 @@ func (f *Formatter) getDockerConfig(projectSubPath string) *dockerEntities.Analy
 		Language: languages.Shell,
 	}
 
-	return analysisData.SetData(f.GetCustomImageByLanguage(languages.Shell), images.Shell)
+	return analysisData.SetImage(f.GetCustomImageByLanguage(languages.Shell), images.Shell)
 }
 
 func (f *Formatter) isIgnoredFix(message string) bool {


### PR DESCRIPTION
This commit rename `SetData` to `SetImage` to avoid confusion since
`SetData` is too generic and it doesn't make it clear which data is
being modified.

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
