### PR TITLE
tfsec:chore - improve tests and code cleaning

### DIFF
--- a/internal/services/formatters/hcl/tfsec/location.go
+++ b/internal/services/formatters/hcl/tfsec/location.go
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package entities
+package tfsec
 
-type Vulnerabilities struct {
-	Results []Result `json:"results"`
+type Location struct {
+	Filename  string `json:"filename"`
+	StartLine int    `json:"start_line"`
+	EndLine   int    `json:"end_line"`
 }

--- a/internal/services/formatters/hcl/tfsec/result.go
+++ b/internal/services/formatters/hcl/tfsec/result.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package entities
+package tfsec
 
 import (
 	"fmt"
@@ -21,7 +21,7 @@ import (
 	"github.com/ZupIT/horusec-devkit/pkg/enums/severities"
 )
 
-type Result struct {
+type tfsecResult struct {
 	RuleID      string   `json:"rule_id"`
 	Link        string   `json:"link"`
 	Location    Location `json:"location"`
@@ -29,27 +29,27 @@ type Result struct {
 	Severity    string   `json:"severity"`
 }
 
-func (r *Result) GetDetails() string {
+func (r *tfsecResult) getDetails() string {
 	return r.RuleID + " -> [" + r.Description + "]"
 }
 
-func (r *Result) GetStartLine() string {
+func (r *tfsecResult) getStartLine() string {
 	return strconv.Itoa(r.Location.StartLine)
 }
 
-func (r *Result) GetCode() string {
+func (r *tfsecResult) getCode() string {
 	return fmt.Sprintf("code beetween line %d and %d.", r.Location.StartLine, r.Location.EndLine)
 }
 
-func (r *Result) GetFilename() string {
+func (r *tfsecResult) getFilename() string {
 	return r.Location.Filename
 }
 
-func (r *Result) GetSeverity() severities.Severity {
+func (r *tfsecResult) getSeverity() severities.Severity {
 	return r.mapSeverityValues()[r.Severity]
 }
 
-func (r *Result) mapSeverityValues() map[string]severities.Severity {
+func (r *tfsecResult) mapSeverityValues() map[string]severities.Severity {
 	return map[string]severities.Severity{
 		"ERROR":   severities.High,
 		"WARNING": severities.Medium,

--- a/internal/services/formatters/hcl/tfsec/result_test.go
+++ b/internal/services/formatters/hcl/tfsec/result_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package entities
+package tfsec
 
 import (
 	"testing"
@@ -20,8 +20,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func resultMock() *Result {
-	return &Result{
+func resultMock() *tfsecResult {
+	return &tfsecResult{
 		RuleID: "AWS123",
 		Link:   "test",
 		Location: Location{
@@ -36,24 +36,24 @@ func resultMock() *Result {
 
 func TestGetDetails(t *testing.T) {
 	t.Run("should success get result details", func(t *testing.T) {
-		assert.NotEmpty(t, resultMock().GetDetails())
+		assert.NotEmpty(t, resultMock().getDetails())
 	})
 }
 
 func TestGetStartLine(t *testing.T) {
 	t.Run("should success get start line", func(t *testing.T) {
-		assert.NotEmpty(t, resultMock().GetStartLine())
+		assert.NotEmpty(t, resultMock().getStartLine())
 	})
 }
 
 func TestGetCode(t *testing.T) {
 	t.Run("should success get code", func(t *testing.T) {
-		assert.NotEmpty(t, resultMock().GetCode())
+		assert.NotEmpty(t, resultMock().getCode())
 	})
 }
 
 func TestGetFilename(t *testing.T) {
 	t.Run("should success get filename", func(t *testing.T) {
-		assert.NotEmpty(t, resultMock().GetFilename())
+		assert.NotEmpty(t, resultMock().getFilename())
 	})
 }

--- a/internal/services/formatters/hcl/tfsec/vulnerabilities.go
+++ b/internal/services/formatters/hcl/tfsec/vulnerabilities.go
@@ -12,10 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package entities
+package tfsec
 
-type Location struct {
-	Filename  string `json:"filename"`
-	StartLine int    `json:"start_line"`
-	EndLine   int    `json:"end_line"`
+type tfsecVulnerabilities struct {
+	Results []tfsecResult `json:"results"`
 }


### PR DESCRIPTION
This commit add some new asserts on successful parsing tfsec results
to verify that all fields of Vulnerability was filled.

Some code organization was also made, and the entities packages was
removed and the tfsec schema output was moved to tfsec package.

Updates #718

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
