### PR TITLE
nancy:chore - Error not handled by Horusec in Nancy tool

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -30,6 +30,7 @@ jobs:
           fetch-depth: 0
       - name: security
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HORUSEC_CLI_REPOSITORY_AUTHORIZATION: ${{ secrets.HORUSEC_CLI_REPOSITORY_AUTHORIZATION }}
           HORUSEC_CLI_HORUSEC_API_URI: ${{ secrets.HORUSEC_CLI_HORUSEC_API_URI }}
           HORUSEC_CLI_REPOSITORY_NAME: ${{ secrets.HORUSEC_CLI_REPOSITORY_NAME }}

--- a/internal/enums/images/images.go
+++ b/internal/enums/images/images.go
@@ -22,7 +22,7 @@ const (
 	Csharp          = "horuszup/horusec-csharp:v1.1.0"
 	Elixir          = "horuszup/horusec-elixir:v1.1.0"
 	Generic         = "horuszup/horusec-generic:v1.1.0"
-	Go              = "horuszup/horusec-go:v1.2.0"
+	Go              = "horuszup/horusec-go:v1.2.1"
 	HCL             = "horuszup/horusec-hcl:v1.1.0"
 	Javascript      = "horuszup/horusec-js:v1.2.0"
 	Leaks           = "horuszup/horusec-leaks:v1.1.0"

--- a/internal/helpers/messages/error.go
+++ b/internal/helpers/messages/error.go
@@ -39,6 +39,13 @@ const (
 	MsgErrorGemLockNotFound = "{HORUSEC_CLI} Error It looks like your project doesn't have a gemfile.lock file, " +
 		"it would be a good idea to commit it so horusec can check for vulnerabilities"
 	MsgErrorGetFilenameByExt = "Could not get filename by extension: "
+	MsgErrorNancyRateLimit   = `{HORUSEC_CLI} Nancy tool failed to query the GitHub API for updates.
+This is most likely due to GitHub rate-limiting on unauthenticated requests.
+To make authenticated requests please:
+  1. Generate a token at https://github.com/settings/tokens
+  2. Set the token by setting the GITHUB_TOKEN environment variable.
+Instructions for generating a token can be found at:
+https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line. `
 )
 
 // Block of messages usage into log of the level error

--- a/internal/services/formatters/go/deployments/Dockerfile
+++ b/internal/services/formatters/go/deployments/Dockerfile
@@ -16,7 +16,7 @@ FROM golang:1.17.5-alpine
 
 RUN apk add curl
 
-RUN curl -fsSL https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.28/nancy-v1.0.28-linux-amd64 -o /bin/nancy
+RUN curl -fsSL https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.29/nancy-v1.0.29-linux-amd64 -o /bin/nancy
 RUN chmod +x /bin/nancy
 
 RUN wget -O - -q https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s v2.8.1


### PR DESCRIPTION
**- What I did**
The nancy tool requires access to the Github API's, but when accessed several times without an identification
it is blocked until the user identifies himself using an authentication token that can be generated via Github,
so I created a validation for this scenario and the user can add this environment variable before starting an analysis.
**- How to verify it**
Run many times GoLang project and see follow error:
```bash
Invalid character 'E' looking for beginning of value
```
**- Description for the changelog**
Error not handled by Horusec in Nancy tool [#905](https://github.com/ZupIT/horusec/issues/905)

Signed-off-by: wilian <wilian.silva@zup.com.br>
