### PR TITLE
yarnaudit:chore - improve tests and code cleaning

### DIFF
--- a/internal/services/formatters/javascript/npmaudit/formatter_test.go
+++ b/internal/services/formatters/javascript/npmaudit/formatter_test.go
@@ -69,7 +69,7 @@ func TestNpmAuditParseOutput(t *testing.T) {
 		assert.False(t, analysis.HasErrors(), "Expected no errors on analysis")
 	})
 
-	t.Run("Should add error on analysos when parse output with not found error", func(t *testing.T) {
+	t.Run("Should add error on analysis when parse output with not found error", func(t *testing.T) {
 		analysis := new(analysis.Analysis)
 
 		dockerAPIControllerMock := testutil.NewDockerMock()

--- a/internal/services/formatters/javascript/yarnaudit/finding.go
+++ b/internal/services/formatters/javascript/yarnaudit/finding.go
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package entities
+package yarnaudit
 
-type Output struct {
-	Advisories []Issue  `json:"advisories"`
-	Metadata   Metadata `json:"metadata"`
+type finding struct {
+	Version string `json:"version"`
 }

--- a/internal/services/formatters/javascript/yarnaudit/formatter_test.go
+++ b/internal/services/formatters/javascript/yarnaudit/formatter_test.go
@@ -18,149 +18,314 @@ import (
 	"errors"
 	"testing"
 
-	entitiesAnalysis "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
+	"github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
+	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 	"github.com/stretchr/testify/assert"
 
-	cliConfig "github.com/ZupIT/horusec/config"
+	"github.com/ZupIT/horusec/config"
 	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
-	"github.com/ZupIT/horusec/internal/entities/workdir"
 	"github.com/ZupIT/horusec/internal/services/formatters"
 	"github.com/ZupIT/horusec/internal/utils/testutil"
 )
 
-func TestParseOutputYarn(t *testing.T) {
-	t.Run("Should run analysis with no errors", func(t *testing.T) {
-		analysis := &entitiesAnalysis.Analysis{}
+func TestYarnAuditParseOutput(t *testing.T) {
+	t.Run("should add 1 vulnerabilities on analysis with no errors", func(t *testing.T) {
+		analysis := new(analysis.Analysis)
+
 		dockerAPIControllerMock := testutil.NewDockerMock()
 		dockerAPIControllerMock.On("SetAnalysisID")
-
-		config := &cliConfig.Config{}
-		config.WorkDir = &workdir.WorkDir{}
-
-		output := "{\"advisories\":[{\"findings\":[{\"version\":\"4.0.0\",\"paths\":[\"express\"]}],\"id\":8,\"created\":\"2015-10-17T19:41:46.382Z\",\"updated\":\"2018-02-22T21:55:47.925Z\",\"deleted\":null,\"title\":\"No Charset in Content-Type Header\",\"found_by\":{\"name\":\"Pawe\u0142 Ha\u0142drzy\u0144ski\"},\"reported_by\":{\"name\":\"Pawe\u0142 Ha\u0142drzy\u0144ski\"},\"module_name\":\"express\",\"cves\":[\"CVE-2014-6393\"],\"vulnerable_versions\":\"<3.11 || >= 4 <4.5\",\"patched_versions\":\">=3.11 <4 || >=4.5\",\"overview\":\"Vulnerable versions of express do not specify a charset field in the content-type header while displaying 400 level response messages. The lack of enforcing user's browser to set correct charset, could be leveraged by an attacker to perform a cross-site scripting attack, using non-standard encodings, like UTF-7.\",\"recommendation\":\"For express 3.x, update express to version 3.11 or later.\\nFor express 4.x, update express to version 4.5 or later. \",\"references\":\"\",\"access\":\"public\",\"severity\":\"low\",\"cwe\":\"CWE-79\",\"metadata\":{\"module_type\":\"Network.Library\",\"exploitability\":2,\"affected_components\":\"\"},\"url\":\"https://npmjs.com/advisories/8\"},{\"findings\":[{\"version\":\"4.0.0\",\"paths\":[\"express\"]}],\"id\":8,\"created\":\"2015-10-17T19:41:46.382Z\",\"updated\":\"2018-02-22T21:55:47.925Z\",\"deleted\":null,\"title\":\"No Charset in Content-Type Header\",\"found_by\":{\"name\":\"Pawe\u0142 Ha\u0142drzy\u0144ski\"},\"reported_by\":{\"name\":\"Pawe\u0142 Ha\u0142drzy\u0144ski\"},\"module_name\":\"express\",\"cves\":[\"CVE-2014-6393\"],\"vulnerable_versions\":\"<3.11 || >= 4 <4.5\",\"patched_versions\":\">=3.11 <4 || >=4.5\",\"overview\":\"Vulnerable versions of express do not specify a charset field in the content-type header while displaying 400 level response messages. The lack of enforcing user's browser to set correct charset, could be leveraged by an attacker to perform a cross-site scripting attack, using non-standard encodings, like UTF-7.\",\"recommendation\":\"For express 3.x, update express to version 3.11 or later.\\nFor express 4.x, update express to version 4.5 or later. \",\"references\":\"\",\"access\":\"public\",\"severity\":\"moderate\",\"cwe\":\"CWE-79\",\"metadata\":{\"module_type\":\"Network.Library\",\"exploitability\":2,\"affected_components\":\"\"},\"url\":\"https://npmjs.com/advisories/8\"},{\"findings\":[{\"version\":\"4.0.0\",\"paths\":[\"express\"]}],\"id\":8,\"created\":\"2015-10-17T19:41:46.382Z\",\"updated\":\"2018-02-22T21:55:47.925Z\",\"deleted\":null,\"title\":\"No Charset in Content-Type Header\",\"found_by\":{\"name\":\"Pawe\u0142 Ha\u0142drzy\u0144ski\"},\"reported_by\":{\"name\":\"Pawe\u0142 Ha\u0142drzy\u0144ski\"},\"module_name\":\"express\",\"cves\":[\"CVE-2014-6393\"],\"vulnerable_versions\":\"<3.11 || >= 4 <4.5\",\"patched_versions\":\">=3.11 <4 || >=4.5\",\"overview\":\"Vulnerable versions of express do not specify a charset field in the content-type header while displaying 400 level response messages. The lack of enforcing user's browser to set correct charset, could be leveraged by an attacker to perform a cross-site scripting attack, using non-standard encodings, like UTF-7.\",\"recommendation\":\"For express 3.x, update express to version 3.11 or later.\\nFor express 4.x, update express to version 4.5 or later. \",\"references\":\"\",\"access\":\"public\",\"severity\":\"high\",\"cwe\":\"CWE-79\",\"metadata\":{\"module_type\":\"Network.Library\",\"exploitability\":2,\"affected_components\":\"\"},\"url\":\"https://npmjs.com/advisories/8\"},{\"findings\":[{\"version\":\"4.0.0\",\"paths\":[\"express\"]}],\"id\":8,\"created\":\"2015-10-17T19:41:46.382Z\",\"updated\":\"2018-02-22T21:55:47.925Z\",\"deleted\":null,\"title\":\"No Charset in Content-Type Header\",\"found_by\":{\"name\":\"Pawe\u0142 Ha\u0142drzy\u0144ski\"},\"reported_by\":{\"name\":\"Pawe\u0142 Ha\u0142drzy\u0144ski\"},\"module_name\":\"express\",\"cves\":[\"CVE-2014-6393\"],\"vulnerable_versions\":\"<3.11 || >= 4 <4.5\",\"patched_versions\":\">=3.11 <4 || >=4.5\",\"overview\":\"Vulnerable versions of express do not specify a charset field in the content-type header while displaying 400 level response messages. The lack of enforcing user's browser to set correct charset, could be leveraged by an attacker to perform a cross-site scripting attack, using non-standard encodings, like UTF-7.\",\"recommendation\":\"For express 3.x, update express to version 3.11 or later.\\nFor express 4.x, update express to version 4.5 or later. \",\"references\":\"\",\"access\":\"public\",\"severity\":\"test\",\"cwe\":\"CWE-79\",\"metadata\":{\"module_type\":\"Network.Library\",\"exploitability\":2,\"affected_components\":\"\"},\"url\":\"https://npmjs.com/advisories/8\"}],\"metadata\":{\"vulnerabilities\":{\"info\":0,\"low\":6,\"moderate\":6,\"high\":7,\"critical\":0},\"dependencies\":27,\"devDependencies\":0,\"optionalDependencies\":0,\"totalDependencies\":27}}"
-
 		dockerAPIControllerMock.On("CreateLanguageAnalysisContainer").Return(output, nil)
 
-		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, config)
+		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, newTestConfig(t, analysis))
 
 		formatter := NewFormatter(service)
-
 		formatter.StartAnalysis("")
+
 		assert.Len(t, analysis.AnalysisVulnerabilities, 1)
+
+		for _, v := range analysis.AnalysisVulnerabilities {
+			vuln := v.Vulnerability
+
+			assert.Equal(t, tools.YarnAudit, vuln.SecurityTool)
+			assert.Equal(t, languages.Javascript, vuln.Language)
+			assert.NotEmpty(t, vuln.Details, "Expected not empty details")
+			assert.NotEmpty(t, vuln.Code, "Expected not empty code")
+			assert.NotEmpty(t, vuln.File, "Expected not empty file name")
+			assert.NotEmpty(t, vuln.Line, "Expected not empty line")
+			assert.NotEmpty(t, vuln.Severity, "Expected not empty severity")
+
+		}
 	})
 
-	t.Run("Should run analysis with output empty", func(t *testing.T) {
-		analysis := &entitiesAnalysis.Analysis{}
+	t.Run("Should parse output empty with no errors", func(t *testing.T) {
+		analysis := new(analysis.Analysis)
+
 		dockerAPIControllerMock := testutil.NewDockerMock()
 		dockerAPIControllerMock.On("SetAnalysisID")
+		dockerAPIControllerMock.On("CreateLanguageAnalysisContainer").Return("", nil)
 
-		config := &cliConfig.Config{}
-		config.WorkDir = &workdir.WorkDir{}
-
-		output := ""
-
-		dockerAPIControllerMock.On("CreateLanguageAnalysisContainer").Return(output, nil)
-
-		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, config)
+		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, newTestConfig(t, analysis))
 
 		formatter := NewFormatter(service)
-
 		formatter.StartAnalysis("")
+
 		assert.Len(t, analysis.AnalysisVulnerabilities, 0)
+		assert.False(t, analysis.HasErrors(), "Expected no errors on analysis")
 	})
 
-	t.Run("Should parse output with not found error", func(t *testing.T) {
-		analysis := &entitiesAnalysis.Analysis{}
+	t.Run("Should add error on analysis with not found error", func(t *testing.T) {
+		analysis := new(analysis.Analysis)
+
 		dockerAPIControllerMock := testutil.NewDockerMock()
 		dockerAPIControllerMock.On("SetAnalysisID")
+		dockerAPIControllerMock.On("CreateLanguageAnalysisContainer").Return("ERROR_YARN_LOCK_NOT_FOUND", nil)
 
-		config := &cliConfig.Config{}
-		config.WorkDir = &workdir.WorkDir{}
-
-		output := "ERROR_YARN_LOCK_NOT_FOUND"
-
-		dockerAPIControllerMock.On("CreateLanguageAnalysisContainer").Return(output, nil)
-
-		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, config)
-
+		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, newTestConfig(t, analysis))
 		formatter := NewFormatter(service)
-
 		formatter.StartAnalysis("")
+
 		assert.Len(t, analysis.AnalysisVulnerabilities, 0)
+		assert.True(t, analysis.HasErrors(), "Expected errors on analysis")
 	})
 
-	t.Run("Should parse output with audit error", func(t *testing.T) {
-		analysis := &entitiesAnalysis.Analysis{}
+	t.Run("Should add error on analysis with audit error", func(t *testing.T) {
+		analysis := new(analysis.Analysis)
+
 		dockerAPIControllerMock := testutil.NewDockerMock()
 		dockerAPIControllerMock.On("SetAnalysisID")
+		dockerAPIControllerMock.On("CreateLanguageAnalysisContainer").Return("ERROR_RUNNING_YARN_AUDIT", nil)
 
-		config := &cliConfig.Config{}
-		config.WorkDir = &workdir.WorkDir{}
-
-		output := "ERROR_RUNNING_YARN_AUDIT"
-
-		dockerAPIControllerMock.On("CreateLanguageAnalysisContainer").Return(output, nil)
-
-		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, config)
-
+		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, newTestConfig(t, analysis))
 		formatter := NewFormatter(service)
-
 		formatter.StartAnalysis("")
+
 		assert.Len(t, analysis.AnalysisVulnerabilities, 0)
+		assert.True(t, analysis.HasErrors(), "Expected errors on analysis")
 	})
 
-	t.Run("Should return error when executing container", func(t *testing.T) {
-		analysis := &entitiesAnalysis.Analysis{}
+	t.Run("Should add error on analysis when parse invalid output", func(t *testing.T) {
+		analysis := new(analysis.Analysis)
+
+		dockerAPIControllerMock := testutil.NewDockerMock()
+		dockerAPIControllerMock.On("SetAnalysisID")
+		dockerAPIControllerMock.On("CreateLanguageAnalysisContainer").Return("invalid", nil)
+
+		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, newTestConfig(t, analysis))
+		formatter := NewFormatter(service)
+		formatter.StartAnalysis("")
+
+		assert.True(t, analysis.HasErrors(), "Expected no errors on analysis")
+	})
+
+	t.Run("should add error of executing container on analysis", func(t *testing.T) {
+		analysis := new(analysis.Analysis)
+
 		dockerAPIControllerMock := testutil.NewDockerMock()
 		dockerAPIControllerMock.On("SetAnalysisID")
 		dockerAPIControllerMock.On("CreateLanguageAnalysisContainer").Return("", errors.New("test"))
 
-		config := &cliConfig.Config{}
-		config.WorkDir = &workdir.WorkDir{}
-
-		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, config)
-
+		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, newTestConfig(t, analysis))
 		formatter := NewFormatter(service)
-
 		formatter.StartAnalysis("")
+
 		assert.Len(t, analysis.AnalysisVulnerabilities, 0)
+		assert.True(t, analysis.HasErrors(), "Expected errors on analysis")
 	})
 	t.Run("Should not execute tool because it's ignored", func(t *testing.T) {
-		analysis := &entitiesAnalysis.Analysis{}
+		analysis := new(analysis.Analysis)
 		dockerAPIControllerMock := testutil.NewDockerMock()
 
-		config := &cliConfig.Config{}
-		config.ToolsConfig = toolsconfig.ToolsConfig{
+		cfg := newTestConfig(t, analysis)
+		cfg.ToolsConfig = toolsconfig.ToolsConfig{
 			tools.YarnAudit: toolsconfig.Config{
 				IsToIgnore: true,
 			},
 		}
-		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, config)
+		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, cfg)
 		formatter := NewFormatter(service)
-
 		formatter.StartAnalysis("")
 	})
 }
 
-func TestParseOutputNpm(t *testing.T) {
-	t.Run("Should return error when invalid output", func(t *testing.T) {
-		analysis := &entitiesAnalysis.Analysis{}
-		dockerAPIControllerMock := testutil.NewDockerMock()
-		dockerAPIControllerMock.On("SetAnalysisID")
-
-		config := &cliConfig.Config{}
-		config.WorkDir = &workdir.WorkDir{}
-
-		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, config)
-
-		formatter := Formatter{
-			service,
-			map[string]bool{},
-		}
-
-		err := formatter.parseOutput("invalid output", "")
-		assert.Error(t, err)
-		assert.Len(t, analysis.AnalysisVulnerabilities, 0)
-	})
+func newTestConfig(t *testing.T, analysiss *analysis.Analysis) *config.Config {
+	cfg := config.New()
+	cfg.ProjectPath = testutil.CreateHorusecAnalysisDirectory(t, analysiss, testutil.JavaScriptExample2)
+	return cfg
 }
+
+const output = `
+{
+  "advisories": [
+    {
+      "findings": [
+        {
+          "version": "4.0.0",
+          "paths": [
+            "express"
+          ]
+        }
+      ],
+      "id": 8,
+      "created": "2015-10-17T19:41:46.382Z",
+      "updated": "2018-02-22T21:55:47.925Z",
+      "deleted": null,
+      "title": "No Charset in Content-Type Header",
+      "found_by": {
+        "name": "Paweł Hałdrzyński"
+      },
+      "reported_by": {
+        "name": "Paweł Hałdrzyński"
+      },
+      "module_name": "express",
+      "cves": [
+        "CVE-2014-6393"
+      ],
+      "vulnerable_versions": "<3.11 || >= 4 <4.5",
+      "patched_versions": ">=3.11 <4 || >=4.5",
+      "overview": "Vulnerable versions of express do not specify a charset field in the content-type header while displaying 400 level response messages. The lack of enforcing user's browser to set correct charset, could be leveraged by an attacker to perform a cross-site scripting attack, using non-standard encodings, like UTF-7.",
+      "recommendation": "For express 3.x, update express to version 3.11 or later.\nFor express 4.x, update express to version 4.5 or later. ",
+      "references": "",
+      "access": "public",
+      "severity": "low",
+      "cwe": "CWE-79",
+      "metadata": {
+        "module_type": "Network.Library",
+        "exploitability": 2,
+        "affected_components": ""
+      },
+      "url": "https://npmjs.com/advisories/8"
+    },
+    {
+      "findings": [
+        {
+          "version": "4.0.0",
+          "paths": [
+            "express"
+          ]
+        }
+      ],
+      "id": 8,
+      "created": "2015-10-17T19:41:46.382Z",
+      "updated": "2018-02-22T21:55:47.925Z",
+      "deleted": null,
+      "title": "No Charset in Content-Type Header",
+      "found_by": {
+        "name": "Paweł Hałdrzyński"
+      },
+      "reported_by": {
+        "name": "Paweł Hałdrzyński"
+      },
+      "module_name": "express",
+      "cves": [
+        "CVE-2014-6393"
+      ],
+      "vulnerable_versions": "<3.11 || >= 4 <4.5",
+      "patched_versions": ">=3.11 <4 || >=4.5",
+      "overview": "Vulnerable versions of express do not specify a charset field in the content-type header while displaying 400 level response messages. The lack of enforcing user's browser to set correct charset, could be leveraged by an attacker to perform a cross-site scripting attack, using non-standard encodings, like UTF-7.",
+      "recommendation": "For express 3.x, update express to version 3.11 or later.\nFor express 4.x, update express to version 4.5 or later. ",
+      "references": "",
+      "access": "public",
+      "severity": "moderate",
+      "cwe": "CWE-79",
+      "metadata": {
+        "module_type": "Network.Library",
+        "exploitability": 2,
+        "affected_components": ""
+      },
+      "url": "https://npmjs.com/advisories/8"
+    },
+    {
+      "findings": [
+        {
+          "version": "4.0.0",
+          "paths": [
+            "express"
+          ]
+        }
+      ],
+      "id": 8,
+      "created": "2015-10-17T19:41:46.382Z",
+      "updated": "2018-02-22T21:55:47.925Z",
+      "deleted": null,
+      "title": "No Charset in Content-Type Header",
+      "found_by": {
+        "name": "Paweł Hałdrzyński"
+      },
+      "reported_by": {
+        "name": "Paweł Hałdrzyński"
+      },
+      "module_name": "express",
+      "cves": [
+        "CVE-2014-6393"
+      ],
+      "vulnerable_versions": "<3.11 || >= 4 <4.5",
+      "patched_versions": ">=3.11 <4 || >=4.5",
+      "overview": "Vulnerable versions of express do not specify a charset field in the content-type header while displaying 400 level response messages. The lack of enforcing user's browser to set correct charset, could be leveraged by an attacker to perform a cross-site scripting attack, using non-standard encodings, like UTF-7.",
+      "recommendation": "For express 3.x, update express to version 3.11 or later.\nFor express 4.x, update express to version 4.5 or later. ",
+      "references": "",
+      "access": "public",
+      "severity": "high",
+      "cwe": "CWE-79",
+      "metadata": {
+        "module_type": "Network.Library",
+        "exploitability": 2,
+        "affected_components": ""
+      },
+      "url": "https://npmjs.com/advisories/8"
+    },
+    {
+      "findings": [
+        {
+          "version": "4.0.0",
+          "paths": [
+            "express"
+          ]
+        }
+      ],
+      "id": 8,
+      "created": "2015-10-17T19:41:46.382Z",
+      "updated": "2018-02-22T21:55:47.925Z",
+      "deleted": null,
+      "title": "No Charset in Content-Type Header",
+      "found_by": {
+        "name": "Paweł Hałdrzyński"
+      },
+      "reported_by": {
+        "name": "Paweł Hałdrzyński"
+      },
+      "module_name": "express",
+      "cves": [
+        "CVE-2014-6393"
+      ],
+      "vulnerable_versions": "<3.11 || >= 4 <4.5",
+      "patched_versions": ">=3.11 <4 || >=4.5",
+      "overview": "Vulnerable versions of express do not specify a charset field in the content-type header while displaying 400 level response messages. The lack of enforcing user's browser to set correct charset, could be leveraged by an attacker to perform a cross-site scripting attack, using non-standard encodings, like UTF-7.",
+      "recommendation": "For express 3.x, update express to version 3.11 or later.\nFor express 4.x, update express to version 4.5 or later. ",
+      "references": "",
+      "access": "public",
+      "severity": "test",
+      "cwe": "CWE-79",
+      "metadata": {
+        "module_type": "Network.Library",
+        "exploitability": 2,
+        "affected_components": ""
+      },
+      "url": "https://npmjs.com/advisories/8"
+    }
+  ],
+  "metadata": {
+    "vulnerabilities": {
+      "info": 0,
+      "low": 6,
+      "moderate": 6,
+      "high": 7,
+      "critical": 0
+    },
+    "dependencies": 27,
+    "devDependencies": 0,
+    "optionalDependencies": 0,
+    "totalDependencies": 27
+  }
+}
+`

--- a/internal/services/formatters/javascript/yarnaudit/issue.go
+++ b/internal/services/formatters/javascript/yarnaudit/issue.go
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package entities
+package yarnaudit
 
 import (
 	"github.com/ZupIT/horusec-devkit/pkg/enums/severities"
 )
 
-type Issue struct {
-	Findings           []Finding `json:"findings"`
+type issue struct {
+	Findings           []finding `json:"findings"`
 	ID                 int       `json:"id"`
 	ModuleName         string    `json:"module_name"`
 	VulnerableVersions string    `json:"vulnerable_versions"`
@@ -27,11 +27,11 @@ type Issue struct {
 	Overview           string    `json:"overview"`
 }
 
-func (i *Issue) GetSeverity() severities.Severity {
+func (i *issue) getSeverity() severities.Severity {
 	return i.mapSeverities()[i.Severity]
 }
 
-func (i *Issue) mapSeverities() map[string]severities.Severity {
+func (i *issue) mapSeverities() map[string]severities.Severity {
 	return map[string]severities.Severity{
 		"critical": severities.Critical,
 		"high":     severities.High,
@@ -42,7 +42,7 @@ func (i *Issue) mapSeverities() map[string]severities.Severity {
 	}
 }
 
-func (i *Issue) GetVersion() string {
+func (i *issue) getVersion() string {
 	if len(i.Findings) > 0 {
 		return i.Findings[0].Version
 	}

--- a/internal/services/formatters/javascript/yarnaudit/issue_test.go
+++ b/internal/services/formatters/javascript/yarnaudit/issue_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package entities
+package yarnaudit
 
 import (
 	"testing"
@@ -23,61 +23,61 @@ import (
 
 func TestGetVersion(t *testing.T) {
 	t.Run("should return finding version", func(t *testing.T) {
-		issue := Issue{
-			Findings: []Finding{
+		issue := issue{
+			Findings: []finding{
 				{
 					Version: "test",
 				},
 			},
 		}
 
-		assert.Equal(t, "test", issue.GetVersion())
+		assert.Equal(t, "test", issue.getVersion())
 	})
 
 	t.Run("should return no version", func(t *testing.T) {
-		issue := Issue{}
-		assert.Empty(t, issue.GetVersion())
+		issue := issue{}
+		assert.Empty(t, issue.getVersion())
 	})
 }
 
 func TestGetSeverity(t *testing.T) {
 	t.Run("should return a low severity", func(t *testing.T) {
-		issue := Issue{
+		issue := issue{
 			Severity: "low",
 		}
 
-		assert.Equal(t, severities.Low, issue.GetSeverity())
+		assert.Equal(t, severities.Low, issue.getSeverity())
 	})
 
 	t.Run("should return a medium severity", func(t *testing.T) {
-		issue := Issue{
+		issue := issue{
 			Severity: "moderate",
 		}
 
-		assert.Equal(t, severities.Medium, issue.GetSeverity())
+		assert.Equal(t, severities.Medium, issue.getSeverity())
 	})
 
 	t.Run("should return a critical severity", func(t *testing.T) {
-		issue := Issue{
+		issue := issue{
 			Severity: "critical",
 		}
 
-		assert.Equal(t, severities.Critical, issue.GetSeverity())
+		assert.Equal(t, severities.Critical, issue.getSeverity())
 	})
 
 	t.Run("should return a info severity", func(t *testing.T) {
-		issue := Issue{
+		issue := issue{
 			Severity: "info",
 		}
 
-		assert.Equal(t, severities.Info, issue.GetSeverity())
+		assert.Equal(t, severities.Info, issue.getSeverity())
 	})
 
 	t.Run("should return a unknown severity", func(t *testing.T) {
-		issue := Issue{
+		issue := issue{
 			Severity: "",
 		}
 
-		assert.Equal(t, severities.Unknown, issue.GetSeverity())
+		assert.Equal(t, severities.Unknown, issue.getSeverity())
 	})
 }

--- a/internal/services/formatters/javascript/yarnaudit/metadata.go
+++ b/internal/services/formatters/javascript/yarnaudit/metadata.go
@@ -12,12 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package entities
+package yarnaudit
 
-type Vulnerabilities struct {
-	Info     int `json:"info"`
-	Low      int `json:"low"`
-	Moderate int `json:"moderate"`
-	High     int `json:"high"`
-	Critical int `json:"critical"`
+type metadata struct {
+	Vulnerabilities vulnerabilities `json:"vulnerabilities"`
 }

--- a/internal/services/formatters/javascript/yarnaudit/output.go
+++ b/internal/services/formatters/javascript/yarnaudit/output.go
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package entities
+package yarnaudit
 
-type Metadata struct {
-	Vulnerabilities Vulnerabilities `json:"vulnerabilities"`
+type yarnOutput struct {
+	Advisories []issue  `json:"advisories"`
+	Metadata   metadata `json:"metadata"`
 }

--- a/internal/services/formatters/javascript/yarnaudit/vulnerabilities.go
+++ b/internal/services/formatters/javascript/yarnaudit/vulnerabilities.go
@@ -12,8 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package entities
+package yarnaudit
 
-type Finding struct {
-	Version string `json:"version"`
+type vulnerabilities struct {
+	Info     int `json:"info"`
+	Low      int `json:"low"`
+	Moderate int `json:"moderate"`
+	High     int `json:"high"`
+	Critical int `json:"critical"`
 }


### PR DESCRIPTION
This commit add some new asserts on successful parsing yarn results
to verify that all fields of Vulnerability was filled.

Note that the test cases from `TestParseOutputNpm`(yes, it was
misspelled) was moved to `TestYarnAuditParseOutput` to centralize
all tests as it is done in the other tests of the other formatters.

Some code organization was also made, and the entities packages was
removed and the yarn schema output was moved to yarnaudit package.

Updates #718

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
