### PR TITLE
formatters:chore - remove unused methods from IService

### DIFF
--- a/internal/services/formatters/default_engine_formatter.go
+++ b/internal/services/formatters/default_engine_formatter.go
@@ -15,6 +15,8 @@
 package formatters
 
 import (
+	"path/filepath"
+
 	"github.com/ZupIT/horusec-devkit/pkg/enums/languages"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
@@ -65,7 +67,7 @@ func (f *DefaultFormatter) execEngineAndParseResults(src string) error {
 }
 
 func (f *DefaultFormatter) execEngineAnalysis(src string) ([]engine.Finding, error) {
-	textUnit, err := f.manager.GetTextUnitByRulesExt(f.svc.GetProjectPathWithWorkdir(src))
+	textUnit, err := f.manager.GetTextUnitByRulesExt(filepath.Join(f.svc.GetConfigProjectPath(), src))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/formatters/default_engine_formatter_test.go
+++ b/internal/services/formatters/default_engine_formatter_test.go
@@ -87,7 +87,7 @@ func TestStartAnalysis(t *testing.T) {
 				service.On("SetToolFinishedAnalysis")
 				service.On("SetAnalysisError")
 				service.On("ToolIsToIgnore").Return(false)
-				service.On("GetProjectPathWithWorkdir").Return(".")
+				service.On("GetConfigProjectPath").Return(".")
 				service.On("ParseFindingsToVulnerabilities").Return(nil)
 				service.On("GetCustomRulesByLanguage").Return([]engine.Rule{})
 
@@ -105,7 +105,7 @@ func TestStartAnalysis(t *testing.T) {
 				service.On("SetToolFinishedAnalysis")
 				service.On("SetAnalysisError")
 				service.On("ToolIsToIgnore").Return(false)
-				service.On("GetProjectPathWithWorkdir").Return("!!!")
+				service.On("GetConfigProjectPath").Return(".")
 				service.On("ParseFindingsToVulnerabilities").Return(nil)
 				service.On("GetCustomRulesByLanguage").Return([]engine.Rule{})
 

--- a/internal/services/formatters/interface.go
+++ b/internal/services/formatters/interface.go
@@ -20,7 +20,6 @@ import (
 	"github.com/ZupIT/horusec-devkit/pkg/enums/tools"
 	engine "github.com/ZupIT/horusec-engine"
 
-	commitauthor "github.com/ZupIT/horusec/internal/entities/commit_author"
 	"github.com/ZupIT/horusec/internal/entities/docker"
 )
 
@@ -48,9 +47,6 @@ type IService interface {
 	// generate the error and the error itself.
 	GetAnalysisIDErrorMessage(tool tools.Tool, output string) string
 
-	// GetCommitAuthor return commit author info to a given line and filepath.
-	GetCommitAuthor(line, filePath string) commitauthor.CommitAuthor
-
 	// AddWorkDirInCmd replace {{WORK_DIR}} from cmd with a `cd` into projectSubPath.
 	AddWorkDirInCmd(cmd string, projectSubPath string, tool tools.Tool) string
 
@@ -74,9 +70,6 @@ type IService interface {
 	// GetFilepathFromFilename return the relative file path inside projectSubpath
 	// to a given filename
 	GetFilepathFromFilename(filename, projectSubPath string) string
-
-	// GetProjectPathWithWorkdir return the project path inside working directory.
-	GetProjectPathWithWorkdir(projectSubPath string) string
 
 	// SetCommitAuthor set commit author info on vulnerability.
 	SetCommitAuthor(vulnerability *vulnerability.Vulnerability) *vulnerability.Vulnerability

--- a/internal/services/formatters/service.go
+++ b/internal/services/formatters/service.go
@@ -86,10 +86,6 @@ func (s *Service) GetAnalysisIDErrorMessage(tool tools.Tool, output string) stri
 	return msg
 }
 
-func (s *Service) GetCommitAuthor(line, filePath string) commitauthor.CommitAuthor {
-	return s.git.CommitAuthor(line, filePath)
-}
-
 func (s *Service) GetConfigProjectPath() string {
 	return filepath.Join(s.config.ProjectPath, ".horusec", s.analysis.ID.String())
 }
@@ -196,7 +192,7 @@ func (s *Service) GetFilepathFromFilename(filename, projectSubPath string) strin
 }
 
 func (s *Service) SetCommitAuthor(vuln *vulnerability.Vulnerability) *vulnerability.Vulnerability {
-	author := s.GetCommitAuthor(vuln.Line, vuln.File)
+	author := s.git.CommitAuthor(vuln.Line, vuln.File)
 
 	vuln.CommitAuthor = author.Author
 	vuln.CommitEmail = author.Email
@@ -265,12 +261,6 @@ func (s *Service) GetConfigCMDByFileExtension(projectSubPath, imageCmd, ext stri
 	}
 
 	return s.AddWorkDirInCmd(imageCmd, projectSubPath, tool)
-}
-
-// NOTE(iancardosozup): i think this functions below could be erased from service interface
-// since they only get a value that could be accessed directly
-func (s *Service) GetProjectPathWithWorkdir(projectSubPath string) string {
-	return filepath.Join(s.GetConfigProjectPath(), projectSubPath)
 }
 
 func (s *Service) IsDockerDisabled() bool {

--- a/internal/services/formatters/service_test.go
+++ b/internal/services/formatters/service_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ZupIT/horusec/config"
-	commitauthor "github.com/ZupIT/horusec/internal/entities/commit_author"
 	dockerentities "github.com/ZupIT/horusec/internal/entities/docker"
 	"github.com/ZupIT/horusec/internal/entities/toolsconfig"
 	"github.com/ZupIT/horusec/internal/entities/workdir"
@@ -107,7 +106,6 @@ func TestMock_AddWorkDirInCmd(t *testing.T) {
 		mock.On("SetAnalysisError").Return()
 		mock.On("ExecuteContainer").Return("", nil)
 		mock.On("GetAnalysisIDErrorMessage").Return("")
-		mock.On("GetCommitAuthor").Return(commitauthor.CommitAuthor{})
 		mock.On("AddWorkDirInCmd").Return("")
 		mock.On("GetConfigProjectPath").Return("")
 		mock.On("GetAnalysis").Return(&analysis.Analysis{})
@@ -120,7 +118,6 @@ func TestMock_AddWorkDirInCmd(t *testing.T) {
 		_ = mock.GetAnalysisID()
 		_, _ = mock.ExecuteContainer(&dockerentities.AnalysisData{})
 		_ = mock.GetAnalysisIDErrorMessage("", "")
-		_ = mock.GetCommitAuthor("", "")
 		_ = mock.AddWorkDirInCmd("", "", "")
 		_ = mock.GetConfigProjectPath()
 		mock.SetAnalysisError(errors.New(""), "", "", "")
@@ -168,40 +165,6 @@ func TestGetAnalysisIDErrorMessage(t *testing.T) {
 		assert.NotEmpty(t, result)
 		assert.Equal(t, "{HORUSEC_CLI} Something error went wrong in Bandit tool"+
 			" | analysisID -> 00000000-0000-0000-0000-000000000000 | output -> test", result)
-	})
-}
-
-func TestGetCommitAuthor(t *testing.T) {
-	t.Run("should get commit author default values when .git folder is not found", func(t *testing.T) {
-		monitorController := NewFormatterService(&analysis.Analysis{}, testutil.NewDockerMock(), &config.Config{})
-
-		result := monitorController.GetCommitAuthor("", "")
-		assert.Equal(t, "-", result.Author)
-		assert.Equal(t, "-", result.CommitHash)
-		assert.Equal(t, "-", result.Date)
-		assert.Equal(t, "-", result.Email)
-		assert.Equal(t, "-", result.Message)
-		assert.NotEmpty(t, result)
-	})
-	t.Run("should get commit author values when .git folder is found", func(t *testing.T) {
-		cfg := &config.Config{
-			StartOptions: config.StartOptions{
-				ProjectPath:        testutil.ExamplesPath,
-				EnableCommitAuthor: true,
-			},
-		}
-		monitorController := NewFormatterService(&analysis.Analysis{}, testutil.NewDockerMock(), cfg)
-
-		result := monitorController.GetCommitAuthor("15", filepath.Join(testutil.GoExample1, "api", "server.go"))
-		notExpected := commitauthor.CommitAuthor{
-			Author:     "-",
-			Email:      "-",
-			CommitHash: "-",
-			Message:    "-",
-			Date:       "-",
-		}
-		assert.NotEmpty(t, result)
-		assert.NotEqual(t, notExpected, result)
 	})
 }
 

--- a/internal/utils/testutil/formatter_mock.go
+++ b/internal/utils/testutil/formatter_mock.go
@@ -22,7 +22,6 @@ import (
 	engine "github.com/ZupIT/horusec-engine"
 	"github.com/stretchr/testify/mock"
 
-	commitauthor "github.com/ZupIT/horusec/internal/entities/commit_author"
 	dockerentities "github.com/ZupIT/horusec/internal/entities/docker"
 )
 
@@ -51,11 +50,6 @@ func (m *FormatterMock) ExecuteContainer(_ *dockerentities.AnalysisData) (output
 func (m *FormatterMock) GetAnalysisIDErrorMessage(_ tools.Tool, _ string) string {
 	args := m.MethodCalled("GetAnalysisIDErrorMessage")
 	return args.Get(0).(string)
-}
-
-func (m *FormatterMock) GetCommitAuthor(_, _ string) (author commitauthor.CommitAuthor) {
-	args := m.MethodCalled("GetCommitAuthor")
-	return args.Get(0).(commitauthor.CommitAuthor)
 }
 
 func (m *FormatterMock) AddWorkDirInCmd(_, _ string, _ tools.Tool) string {
@@ -89,11 +83,6 @@ func (m *FormatterMock) ToolIsToIgnore(_ tools.Tool) bool {
 
 func (m *FormatterMock) GetFilepathFromFilename(_, _ string) string {
 	args := m.MethodCalled("GetFilepathFromFilename")
-	return args.Get(0).(string)
-}
-
-func (m *FormatterMock) GetProjectPathWithWorkdir(_ string) string {
-	args := m.MethodCalled("GetProjectPathWithWorkdir")
 	return args.Get(0).(string)
 }
 


### PR DESCRIPTION
Since the `GetCommitAuthor` was just being used internally by
IService implementation there's no reason to keep this method, and as
pointed by @iancardosozup, on `GetProjectPathWithWorkDir` docs, their
usage can be simple changed by a `filepath.Join` call, so this method was
removed too.

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
