### PR TITLE
bundler:fix - correctly parse output error

### DIFF
--- a/internal/services/formatters/ruby/bundler/formatter.go
+++ b/internal/services/formatters/ruby/bundler/formatter.go
@@ -37,10 +37,12 @@ import (
 	vulnhash "github.com/ZupIT/horusec/internal/utils/vuln_hash"
 )
 
-// ErrGemLockNotFound occurs when bundles does not find gemfile.lock.
+// ErrGemLockNotFound occurs when project path does not have the Gemfile.lock file.
 //
-// nolint: lll
-var ErrGemLockNotFound = errors.New("project doesn't have a gemfile.lock file, it would be a good idea to commit it so horusec can check for vulnerabilities")
+// nolint: stylecheck
+// We actually want that this error message be capitalized since the file name that was
+// not found is capitalized.
+var ErrGemLockNotFound = errors.New("Gemfile.lock file is required to execute Bundler analysis")
 
 type Formatter struct {
 	formatters.IService
@@ -80,8 +82,11 @@ func (f *Formatter) startBundlerAudit(projectSubPath string) (string, error) {
 
 func (f *Formatter) getDockerConfig(projectSubPath string) *dockerEntities.AnalysisData {
 	analysisData := &dockerEntities.AnalysisData{
-		CMD: f.AddWorkDirInCmd(CMD, file.GetSubPathByExtension(
-			f.GetConfigProjectPath(), projectSubPath, "Gemfile.lock"), tools.SecurityCodeScan),
+		CMD: f.AddWorkDirInCmd(
+			CMD,
+			file.GetSubPathByExtension(f.GetConfigProjectPath(), projectSubPath, "Gemfile.lock"),
+			tools.SecurityCodeScan,
+		),
 		Language: languages.Ruby,
 	}
 
@@ -89,7 +94,7 @@ func (f *Formatter) getDockerConfig(projectSubPath string) *dockerEntities.Analy
 }
 
 func (f *Formatter) verifyGemLockError(output string) error {
-	if strings.Contains(output, "No such file or directory") && strings.Contains(output, "Errno::ENOENT") {
+	if strings.Contains(output, `Could not find "Gemfile.lock"`) {
 		return ErrGemLockNotFound
 	}
 


### PR DESCRIPTION
Previously when a project path does not have a Gemfile.lock file, the
Bundler return an error `Could not find "Gemfile.lock"` that was being
interpreted as a vulnerability. This was happening because the commit
https://github.com/rubysec/bundler-audit/commit/021f85f change the error
message from a generic error like "Errno::ENOENT" and "No such file or
directory" to a more detailed error `Could not find "Gemfile.lock"`.

Fixes #919

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
