### PR TITLE
nancy:chore - remove logs when running without GITHUB_TOKEN env

### DIFF
--- a/internal/services/formatters/go/nancy/formatter.go
+++ b/internal/services/formatters/go/nancy/formatter.go
@@ -53,17 +53,13 @@ func NewFormatter(service formatters.IService) formatters.IFormatter {
 }
 
 func (f *Formatter) StartAnalysis(projectSubPath string) {
-	if f.ToolIsToIgnore(tools.Nancy) || f.IsDockerDisabled() {
+	if f.ToolIsToIgnore(tools.Nancy) || f.IsDockerDisabled() || os.Getenv("GITHUB_TOKEN") == "" {
 		logger.LogDebugWithLevel(messages.MsgDebugToolIgnored + tools.Nancy.ToString())
 		return
 	}
 
-	if os.Getenv("GITHUB_TOKEN") == "" {
-		logger.LogWarnWithLevel(messages.MsgErrorNancyRateLimit)
-	} else {
-		output, err := f.startNancy(projectSubPath)
-		f.SetAnalysisError(err, tools.Nancy, output, projectSubPath)
-	}
+	output, err := f.startNancy(projectSubPath)
+	f.SetAnalysisError(err, tools.Nancy, output, projectSubPath)
 
 	f.LogDebugWithReplace(messages.MsgDebugToolFinishAnalysis, tools.Nancy, languages.Go)
 }


### PR DESCRIPTION
Previously for each analysis a warning log was being printed informing
an error of Github API rate limit from Nancy. This commit change this
behaviour to just log in debug level that Nancy was ignored because the
GITHUB_TOKEN env is not set.

Fixes #920

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
