### PR TITLE
bundler:chore - improve tests and code cleaning

### DIFF
--- a/internal/services/formatters/ruby/bundler/criticality.go
+++ b/internal/services/formatters/ruby/bundler/criticality.go
@@ -12,27 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package enums
+package bundler
 
-type CriticalityType string
+type bundlerCriticalityType string
 
 const (
-	High   CriticalityType = "High"
-	Medium CriticalityType = "Medium"
-	Low    CriticalityType = "Low"
+	High   bundlerCriticalityType = "High"
+	Medium bundlerCriticalityType = "Medium"
+	Low    bundlerCriticalityType = "Low"
 )
 
-func (c CriticalityType) ToString() string {
+func (c bundlerCriticalityType) String() string {
 	return string(c)
 }
 
-func GetCriticalityTypeByString(criticalityType string) CriticalityType {
+func getCriticalityTypeByString(criticalityType string) bundlerCriticalityType {
 	switch criticalityType {
-	case High.ToString():
+	case High.String():
 		return High
-	case Medium.ToString():
+	case Medium.String():
 		return Medium
-	case Low.ToString():
+	case Low.String():
 		return Low
 	}
 	return Low

--- a/internal/services/formatters/ruby/bundler/output.go
+++ b/internal/services/formatters/ruby/bundler/output.go
@@ -12,29 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package entities
+package bundler
 
 import (
 	"fmt"
 	"strings"
 
-	"github.com/ZupIT/horusec-devkit/pkg/enums/confidence"
 	"github.com/ZupIT/horusec-devkit/pkg/enums/severities"
-
-	"github.com/ZupIT/horusec/internal/services/formatters/ruby/bundler/entities/enums"
 )
 
-type Output struct {
+type bundlerOutput struct {
 	Name        string
 	Version     string
 	Advisory    string
-	Criticality enums.CriticalityType
+	Criticality bundlerCriticalityType
 	URL         string
 	Title       string
 	Solution    string
 }
 
-func (o *Output) SetOutputData(output *Output, value string) {
+func (o *bundlerOutput) setOutputData(output *bundlerOutput, value string) {
 	o.setName(output, value)
 	o.setVersion(output, value)
 	o.setAdvisory(output, value)
@@ -44,49 +41,49 @@ func (o *Output) SetOutputData(output *Output, value string) {
 	o.setSolution(output, value)
 }
 
-func (o *Output) setName(output *Output, value string) {
+func (o *bundlerOutput) setName(output *bundlerOutput, value string) {
 	if !strings.Contains(value, ":") {
 		output.Name = strings.TrimSpace(value)
 	}
 }
 
-func (o *Output) setVersion(output *Output, value string) {
+func (o *bundlerOutput) setVersion(output *bundlerOutput, value string) {
 	if strings.Contains(value, "Version:") {
 		output.Version = strings.TrimSpace(o.getContent(value))
 	}
 }
 
-func (o *Output) setAdvisory(output *Output, value string) {
+func (o *bundlerOutput) setAdvisory(output *bundlerOutput, value string) {
 	if strings.Contains(value, "Advisory:") {
 		output.Advisory = strings.TrimSpace(o.getContent(value))
 	}
 }
 
-func (o *Output) setCriticality(output *Output, value string) {
+func (o *bundlerOutput) setCriticality(output *bundlerOutput, value string) {
 	if strings.Contains(value, "Criticality:") {
-		output.Criticality = enums.GetCriticalityTypeByString(strings.TrimSpace(o.getContent(value)))
+		output.Criticality = getCriticalityTypeByString(strings.TrimSpace(o.getContent(value)))
 	}
 }
 
-func (o *Output) setURL(output *Output, value string) {
+func (o *bundlerOutput) setURL(output *bundlerOutput, value string) {
 	if strings.Contains(value, "URL:") {
 		output.URL = strings.TrimSpace(o.getContent(value))
 	}
 }
 
-func (o *Output) setTitle(output *Output, value string) {
+func (o *bundlerOutput) setTitle(output *bundlerOutput, value string) {
 	if strings.Contains(value, "Title:") {
 		output.Title = strings.TrimSpace(o.getContent(value))
 	}
 }
 
-func (o *Output) setSolution(output *Output, value string) {
+func (o *bundlerOutput) setSolution(output *bundlerOutput, value string) {
 	if strings.Contains(value, "Solution:") {
 		output.Solution = strings.TrimSpace(o.getContent(value))
 	}
 }
 
-func (o *Output) getContent(output string) string {
+func (o *bundlerOutput) getContent(output string) string {
 	index := strings.Index(output, ":")
 	if index < 0 {
 		return ""
@@ -95,32 +92,19 @@ func (o *Output) getContent(output string) string {
 	return output[index+1:]
 }
 
-func (o *Output) GetSeverity() severities.Severity {
+func (o *bundlerOutput) getSeverity() severities.Severity {
 	switch o.Criticality {
-	case enums.High:
+	case High:
 		return severities.High
-	case enums.Medium:
+	case Medium:
 		return severities.Medium
-	case enums.Low:
+	case Low:
 		return severities.Low
 	}
 
 	return severities.Unknown
 }
 
-func (o *Output) GetConfidence() confidence.Confidence {
-	switch o.Criticality {
-	case enums.High:
-		return confidence.High
-	case enums.Medium:
-		return confidence.Medium
-	case enums.Low:
-		return confidence.Low
-	}
-
-	return confidence.Low
-}
-
-func (o *Output) GetDetails() string {
+func (o *bundlerOutput) getDetails() string {
 	return fmt.Sprintf("%s (%s - %s) %s (%s - %s)", o.Title, o.Name, o.Version, o.Solution, o.Advisory, o.URL)
 }


### PR DESCRIPTION
This commit add some new asserts on successful parsing bundler results
to verify that all fields of Vulnerability was filled.

Some code organization was also made, and the entities and enum packages
was removed and the bundler schema output was moved to bundler package.

This commit also fix a bug when parsing invalid output from Bundler.
The `strings.Split(output, "Name:")` on `parseOutput` return a list with
one element when the split fails, so when Bundler return an output that
is not expected we still try to parse this invalid output which results
invalid vulnerabilities. To fix this a validation was added before the
split to check if output contains the `Name:` field.

Updates #718

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
