### PR TITLE
trivy:bugfix - adding func to avoid hash changes in trivy formatter

### DIFF
--- a/internal/services/formatters/generic/trivy/formatter.go
+++ b/internal/services/formatters/generic/trivy/formatter.go
@@ -169,9 +169,22 @@ func (f *Formatter) addVulnerabilitiesOutput(vulnerabilities []*trivyVulnerabili
 		addVuln.File = target
 		addVuln.Details = vuln.getDetails()
 		addVuln.Severity = severities.GetSeverityByString(vuln.Severity)
-		addVuln = vulnhash.Bind(addVuln)
+		addVuln.VulnHash = f.getOldHash(vuln.PkgName, *addVuln)
 		f.AddNewVulnerabilityIntoAnalysis(addVuln)
 	}
+}
+
+// getOldHash func necessary to avoid a breaking change in the trivy hash generation. Since the pull request
+// https://github.com/ZupIT/horusec/pull/882 some changes were made in the line and code, and this data influences
+// directly the hash generation. This func will avoid this hash change by using the same data as before, but for the
+// users the data will be showed with the fixes made in the pull request 882, leading to no braking changes and keeping
+// the fixes.
+// nolint:gocritic // it has to be without pointer
+func (f *Formatter) getOldHash(pkgName string, vuln vulnerability.Vulnerability) string {
+	vuln.Line = "0"
+	vuln.Code = pkgName
+
+	return vulnhash.Bind(&vuln).VulnHash
 }
 
 func (f *Formatter) addMisconfigurationOutput(result []*trivyMisconfiguration, target string) {


### PR DESCRIPTION
Since the pull request https://github.com/ZupIT/horusec/pull/882 some
changes were made in the line and code of the trivy formatter,
and this data influences directly the hash generation.
This pr will avoid this hash change by using the same data as
before, but for the users the data will be showed with the fixes
made in the pull request 882, leading to no braking changes
and keeping the fixes.

Signed-off-by: Nathan Martins <nathan.martins@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
