### PR TITLE
formatters:fix - not show which tool generate the error

### DIFF
--- a/internal/services/formatters/go/gosec/formatter_test.go
+++ b/internal/services/formatters/go/gosec/formatter_test.go
@@ -76,7 +76,7 @@ func TestGosecStartAnalysis(t *testing.T) {
 
 		gosec.StartAnalysis("")
 		assert.True(t, entity.HasErrors(), "Expected errors for analysis")
-		assert.Equal(t, "some error", entity.Errors)
+		assert.Equal(t, "Error while running tool GoSec: some error", entity.Errors)
 	})
 
 	t.Run("Should run analysis and return error for an invalid output", func(t *testing.T) {

--- a/internal/services/formatters/go/nancy/formatter_test.go
+++ b/internal/services/formatters/go/nancy/formatter_test.go
@@ -147,7 +147,7 @@ func TestParseOutput(t *testing.T) {
 		formatter.StartAnalysis("")
 
 		assert.True(t, analysis.HasErrors(), "Expected errors on analysis")
-		assert.Equal(t, messages.MsgErrorNancyRateLimit, analysis.Errors)
+		assert.Contains(t, analysis.Errors, messages.MsgErrorNancyRateLimit)
 	})
 
 	t.Run("should add error on analysis when something went wrong executing container", func(t *testing.T) {

--- a/internal/services/formatters/service.go
+++ b/internal/services/formatters/service.go
@@ -15,6 +15,7 @@
 package formatters
 
 import (
+	"bytes"
 	"fmt"
 	"path/filepath"
 	"runtime"
@@ -124,12 +125,12 @@ func (s *Service) SetAnalysisError(err error, tool tools.Tool, output, projectSu
 
 func (s *Service) addAnalysisError(tool tools.Tool, err error) {
 	if err != nil {
-		toAppend := ""
+		buf := bytes.NewBufferString("")
 		if len(s.analysis.Errors) > 0 {
-			s.analysis.Errors += fmt.Sprintf("; Error while running %s tool: %s", tool.ToString(), err.Error())
-			return
+			fmt.Fprintf(buf, "; ")
 		}
-		s.analysis.Errors += toAppend + err.Error()
+		fmt.Fprintf(buf, "Error while running tool %s: %v", tool, err)
+		s.analysis.Errors += buf.String()
 	}
 }
 

--- a/internal/services/formatters/service_test.go
+++ b/internal/services/formatters/service_test.go
@@ -98,6 +98,18 @@ func TestParseFindingsToVulnerabilities(t *testing.T) {
 	}
 }
 
+func TestSetAnalysisError(t *testing.T) {
+	analysis := new(analysis.Analysis)
+	svc := NewFormatterService(analysis, testutil.NewDockerMock(), config.New())
+
+	svc.SetAnalysisError(errors.New("some error"), tools.HorusecEngine, "testing", "")
+	svc.SetAnalysisError(errors.New("other error"), tools.HorusecEngine, "testing 2", "")
+
+	expectedErrors := "Error while running tool HorusecEngine: some error; Error while running tool HorusecEngine: other error"
+
+	assert.Equal(t, expectedErrors, analysis.Errors)
+}
+
 func TestMock_AddWorkDirInCmd(t *testing.T) {
 	mock := testutil.NewFormatterMock()
 	t.Run("Should mock with success", func(t *testing.T) {


### PR DESCRIPTION
Previously if some tool generate an error and this was first error that
occurred in the analysis the error message does not show the tool that
generate this error, only from the second error the tool was informed.

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
