### PR TITLE
formatters/tfsec:bugfix - vulnerabilities were being ignored due missing severity

### DIFF
--- a/internal/services/formatters/hcl/tfsec/result.go
+++ b/internal/services/formatters/hcl/tfsec/result.go
@@ -45,14 +45,12 @@ func (r *tfsecResult) getFilename() string {
 	return r.Location.Filename
 }
 
+// getSeverity this func will get the TfSec severity and parse to the Horusec severity. TfSec can return the following
+// severities: CRITICAL, HIGH, MEDIUM, LOW and NONE which is represented by an empty string.
 func (r *tfsecResult) getSeverity() severities.Severity {
-	return r.mapSeverityValues()[r.Severity]
-}
-
-func (r *tfsecResult) mapSeverityValues() map[string]severities.Severity {
-	return map[string]severities.Severity{
-		"ERROR":   severities.High,
-		"WARNING": severities.Medium,
-		"":        severities.Low,
+	if r.Severity == "" {
+		return severities.Unknown
 	}
+
+	return severities.Severity(r.Severity)
 }


### PR DESCRIPTION
Tfsec func resposable por getting the severeties of the vulnerabilities
was in a wrong format, leading to vulnerablities without severity and
this vulnerabilities were being ignored. This pull request fixes this
error by updating the func to match the correct tfsec severities
https://github.com/aquasecurity/tfsec/blob/master/pkg/severity/severity.go.

Signed-off-by: Nathan Martins <nathan.martins@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
