### PR TITLE
[docker]:[feature] - Validate Docker version from the Docker API

### DIFF
--- a/internal/controllers/requirements/docker/docker.go
+++ b/internal/controllers/requirements/docker/docker.go
@@ -48,7 +48,7 @@ func Validate() error {
 }
 
 func validateIfDockerIsInstalled() (string, error) {
-	response, err := execDockerVersion()
+	response, err := getDockerVersion()
 	if err != nil {
 		logger.LogInfo(messages.MsgInfoHowToInstallDocker)
 		return "", err
@@ -64,7 +64,7 @@ func validateIfDockerIsSupported(version string) error {
 	return nil
 }
 
-func execDockerVersion() (string, error) {
+func getDockerVersion() (string, error) {
 	dockerClient := client.NewDockerClient()
 	version, err := dockerClient.ServerVersion(context.Background())
 	if err != nil {

--- a/internal/controllers/requirements/docker/docker.go
+++ b/internal/controllers/requirements/docker/docker.go
@@ -77,7 +77,7 @@ func execDockerVersion() (string, error) {
 }
 
 func validateIfDockerIsRunningInMinVersion(response string) error {
-	version, subversion, err := extractDockerVersionFromString(response)
+	version, subversion, err := getVersionAndSubVersion(response)
 	if err != nil {
 		logger.LogErrorWithLevel(messages.MsgErrorWhenDockerIsLowerVersion, ErrMinVersion)
 		return err
@@ -89,10 +89,6 @@ func validateIfDockerIsRunningInMinVersion(response string) error {
 	}
 
 	return nil
-}
-
-func extractDockerVersionFromString(response string) (int, int, error) {
-	return getVersionAndSubVersion(response)
 }
 
 func getVersionAndSubVersion(fullVersion string) (int, int, error) {

--- a/internal/controllers/requirements/docker/docker.go
+++ b/internal/controllers/requirements/docker/docker.go
@@ -68,9 +68,7 @@ func getDockerVersion() (string, error) {
 	dockerClient := client.NewDockerClient()
 	version, err := dockerClient.ServerVersion(context.Background())
 	if err != nil {
-		logger.LogErrorWithLevel(
-			messages.MsgErrorWhenCheckRequirementsDocker, errors.New(err.Error()),
-		)
+		logger.LogErrorWithLevel(messages.MsgErrorWhenCheckRequirementsDocker, err)
 		return "", err
 	}
 	return version.Version, nil

--- a/internal/controllers/requirements/docker/docker.go
+++ b/internal/controllers/requirements/docker/docker.go
@@ -40,11 +40,11 @@ var (
 )
 
 func Validate() error {
-	response, err := validateIfDockerIsInstalled()
+	version, err := validateIfDockerIsInstalled()
 	if err != nil {
 		return err
 	}
-	return validateIfDockerIsSupported(response)
+	return validateIfDockerIsRunningInMinVersion(version)
 }
 
 func validateIfDockerIsInstalled() (string, error) {
@@ -54,14 +54,6 @@ func validateIfDockerIsInstalled() (string, error) {
 		return "", err
 	}
 	return response, nil
-}
-
-func validateIfDockerIsSupported(version string) error {
-	err := validateIfDockerIsRunningInMinVersion(version)
-	if err != nil {
-		return err
-	}
-	return nil
 }
 
 func getDockerVersion() (string, error) {


### PR DESCRIPTION
Signed-off-by: Luis Guilherme de A <luisguilhermepdea@gmail.com>

**- What I did**

I changed the way the version of docker is retrieved, from a shell command execution to Docker API.
This pull-request solves the issue    #757 

**- How to verify it**

With the docker running, run the horusec and it will validate the Docker version, from the Docker API.

**- Description for the changelog**
The log error message of an error with the docker validation had changed. Now few steps of preprocessing are necessary to retrieve the version.