### PR TITLE
fix:semgrep - Disable collect metrics and fix log message

### DIFF
--- a/internal/services/formatters/generic/semgrep/config.go
+++ b/internal/services/formatters/generic/semgrep/config.go
@@ -16,5 +16,5 @@ package semgrep
 
 const CMD = `
 	    {{WORK_DIR}}
-		semgrep --config=p/r2c-ci -q --json .
+		semgrep --disable-metrics --config=p/r2c-ci -q --json .
   `

--- a/internal/services/formatters/generic/semgrep/formatter.go
+++ b/internal/services/formatters/generic/semgrep/formatter.go
@@ -49,7 +49,7 @@ func (f *Formatter) StartAnalysis(projectSubPath string) {
 	}
 
 	output, err := f.startSemgrep(projectSubPath)
-	f.SetAnalysisError(err, tools.SecurityCodeScan, output, projectSubPath)
+	f.SetAnalysisError(err, tools.Semgrep, output, projectSubPath)
 	f.LogDebugWithReplace(messages.MsgDebugToolFinishAnalysis, tools.Semgrep, languages.Generic)
 }
 


### PR DESCRIPTION
In this commit I change semgrep tool to not collect information
of the your analysis. And I found an error in Log when semgrep
fails was showing the tool name wrong.

Signed-off-by: wilian <wilian.silva@zup.com.br>
