### PR TITLE
makefile:chore - bump gci tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ format: install-format-dependencies
 install-format-dependencies:
 	$(GO) install golang.org/x/tools/cmd/goimports@latest
 	$(GO) install mvdan.cc/gofumpt@latest
-	$(GO) install github.com/daixiang0/gci@latest
+	$(GO) install github.com/daixiang0/gci@v0.2.9
 
 license:
 	$(GO) install github.com/google/addlicense@latest


### PR DESCRIPTION
The latest release of gci formatter come with a bug[1] that generate an
error to format files that use dot imports. This commit fix the previous
version to avoid errors on make format until the bug is fixed.

[1] https://github.com/daixiang0/gci/issues/44

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
