### PR TITLE
engines/jvm:fix - false positives on base64 encode/decode

### DIFF
--- a/internal/services/engines/jvm/rules.go
+++ b/internal/services/engines/jvm/rules.go
@@ -459,10 +459,10 @@ func NewBase64Decode() *text.Rule {
 			Severity:    severities.Low.ToString(),
 			Confidence:  confidence.Low.ToString(),
 		},
-		Type: text.AndMatch,
+		Type: text.OrMatch,
 		Expressions: []*regexp.Regexp{
 			regexp.MustCompile(`android.util.Base64`),
-			regexp.MustCompile(`.decode`),
+			regexp.MustCompile(`\.decode\(`),
 		},
 	}
 }
@@ -707,8 +707,8 @@ func NewBase64Encode() *text.Rule {
 		Type: text.OrMatch,
 		Expressions: []*regexp.Regexp{
 			regexp.MustCompile(`android.util.Base64`),
-			regexp.MustCompile(`.encodeToString`),
-			regexp.MustCompile(`.encode`),
+			regexp.MustCompile(`\.encodeToString\(`),
+			regexp.MustCompile(`\.encode\(`),
 		},
 	}
 }

--- a/internal/services/engines/jvm/rules_test.go
+++ b/internal/services/engines/jvm/rules_test.go
@@ -15,19 +15,84 @@
 package jvm
 
 import (
+	"path/filepath"
 	"testing"
 
+	engine "github.com/ZupIT/horusec-engine"
 	"github.com/ZupIT/horusec/internal/utils/testutil"
 )
 
 func TestRulesVulnerableCode(t *testing.T) {
-	testcases := []*testutil.RuleTestCase{}
+	tempDir := t.TempDir()
+
+	testcases := []*testutil.RuleTestCase{
+		{
+			Name:     "HS-JVM-24",
+			Rule:     NewBase64Decode(),
+			Src:      SampleVulnerableHSJVM24,
+			Filename: filepath.Join(tempDir, "HS-JVM-24.test"),
+			Findings: []engine.Finding{
+				{
+					CodeSample: `byte[] decodedValue = Base64.getDecoder().decode(value);`,
+					SourceLocation: engine.Location{
+						Filename: filepath.Join(tempDir, "HS-JVM-24.test"),
+						Line:     4,
+						Column:   43,
+					},
+				},
+			},
+		},
+		{
+			Name:     "HS-JVM-38",
+			Rule:     NewBase64Encode(),
+			Src:      SampleVulnerableHSJVM38,
+			Filename: filepath.Join(tempDir, "HS-JVM-38.test"),
+			Findings: []engine.Finding{
+				{
+					CodeSample: `Base64.getEncoder().encodeToString(input.getBytes());`,
+					SourceLocation: engine.Location{
+						Filename: filepath.Join(tempDir, "HS-JVM-38.test"),
+						Line:     5,
+						Column:   21,
+					},
+				},
+				{
+					CodeSample: `String encodedString = new String(base64.encode(input.getBytes()));`,
+					SourceLocation: engine.Location{
+						Filename: filepath.Join(tempDir, "HS-JVM-38.test"),
+						Line:     8,
+						Column:   42,
+					},
+				},
+			},
+		},
+	}
 
 	testutil.TestVulnerableCode(t, testcases)
 }
 
 func TestRulesSafeCode(t *testing.T) {
-	testcases := []*testutil.RuleTestCase{}
+	tempDir := t.TempDir()
+	testcases := []*testutil.RuleTestCase{
+		{
+			Name:     "HS-JVM-38",
+			Rule:     NewBase64Encode(),
+			Src:      SampleSafeHSJVM38,
+			Filename: filepath.Join(tempDir, "HS-JVM-38.test"),
+		},
+		{
+			Name:     "HS-JVM-38",
+			Rule:     NewBase64Encode(),
+			Src:      Sample2SafeHSJVM38,
+			Filename: filepath.Join(tempDir, "HS-JVM-38.test"),
+		},
+		{
+			Name:     "HS-JVM-24",
+			Rule:     NewBase64Decode(),
+			Src:      SampleSafeHSJVM24,
+			Filename: filepath.Join(tempDir, "HS-JVM-24.test"),
+		},
+	}
 
 	testutil.TestSafeCode(t, testcases)
 }

--- a/internal/services/engines/jvm/samples_test.go
+++ b/internal/services/engines/jvm/samples_test.go
@@ -13,3 +13,53 @@
 // limitations under the License.
 
 package jvm
+
+const (
+	SampleVulnerableHSJVM38 = `
+class T {
+	void f() {
+		String input = "test input";
+		Base64.getEncoder().encodeToString(input.getBytes());
+
+		Base64 base64 = new Base64();
+		String encodedString = new String(base64.encode(input.getBytes()));
+	}
+}
+	`
+
+	SampleVulnerableHSJVM24 = `
+class T {
+	void f(String value) {
+		byte[] decodedValue = Base64.getDecoder().decode(value);
+	}
+}
+	`
+)
+
+const (
+	SampleSafeHSJVM38 = `
+class T {
+	void f() {
+		obj.addContentType("application/x-www-form-urlencoded")
+	}
+}
+	`
+	Sample2SafeHSJVM38 = `
+<encoder class="net.logstash.logback.encoder.AccessEventCompositeJsonEncoder">"
+<encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+
+<encoder>
+</encoder>
+`
+
+	SampleSafeHSJVM24 = `
+class T {
+	void f() {
+		this.decodeSomeRandomValue("value);
+		console.log.println("foo.decode");
+	}
+
+	void decodeSomeRandomValue(String value) {}
+}
+`
+)


### PR DESCRIPTION
Previously the rules of encode/decode Base64 was reporting any string
that had the value encode/decode which was generating a lot of false
positive. This commit improve the regex of these rules to catch only
the method call that match encode or decode on name.

The type of rule HS-JVM-24 was changed from AndMatch to OrMatch to
follow the same behaviour of HS-JVM-28.

Fixes #816

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
