### PR TITLE
commitAuthors:bugfix - fix when pass invalid line to SetCommitAuthors

### DIFF
--- a/internal/helpers/messages/error.go
+++ b/internal/helpers/messages/error.go
@@ -50,6 +50,8 @@ https://help.github.com/articles/creating-a-personal-access-token-for-the-comman
 )
 
 // Block of messages usage into log of the level error
+//
+// nolint:lll
 const (
 	MsgErrorFalsePositiveNotValid        = "False positive is not valid because is duplicated in risk accept:"
 	MsgErrorRiskAcceptNotValid           = "Risk Accept is not valid because is duplicated in false positive:"
@@ -72,13 +74,15 @@ const (
 	MsgErrorGitCommitAuthorsParseOutput  = "{HORUSEC_CLI} Error when to parse output to commit author struct: "
 	MsgErrorParseStringToWorkDir         = "{HORUSEC_CLI} Error when try parse workdir string to entity." +
 		"Returning default values"
-	MsgErrorDeferFileClose           = "{HORUSEC_CLI} Error defer file close: "
-	MsgErrorSetHeadersOnConfig       = "{HORUSEC-CLI} Error on set headers on configurations"
-	MsgErrorReplayWrong              = "{HORUSEC-CLI} Error on set reply, Please type Y or N. Your current response was: "
-	MsgErrorErrorOnCreateConfigFile  = "{HORUSEC-CLI} Error on create config file: "
-	MsgErrorErrorOnReadConfigFile    = "{HORUSEC-CLI} Error on read config file on path: "
-	MsgErrorFailedToPullImage        = "{HORUSEC_CLI} Failed to pull docker image"
-	MsgErrorWhileParsingCustomImages = "{HORUSEC_CLI} Error when parsing custom images config. Using default values"
-	MsgErrorSettingLogFile           = "{HORUSEC_CLI} Error when setting log file"
-	MsgErrorGetRelativePathFromFile  = "{HORUSEC_CLI} Error when get relative path of file"
+	MsgErrorDeferFileClose                   = "{HORUSEC_CLI} Error defer file close: "
+	MsgErrorSetHeadersOnConfig               = "{HORUSEC-CLI} Error on set headers on configurations"
+	MsgErrorReplayWrong                      = "{HORUSEC-CLI} Error on set reply, Please type Y or N. Your current response was: "
+	MsgErrorErrorOnCreateConfigFile          = "{HORUSEC-CLI} Error on create config file: "
+	MsgErrorErrorOnReadConfigFile            = "{HORUSEC-CLI} Error on read config file on path: "
+	MsgErrorFailedToPullImage                = "{HORUSEC_CLI} Failed to pull docker image"
+	MsgErrorWhileParsingCustomImages         = "{HORUSEC_CLI} Error when parsing custom images config. Using default values"
+	MsgErrorSettingLogFile                   = "{HORUSEC_CLI} Error when setting log file"
+	MsgErrorGetRelativePathFromFile          = "{HORUSEC_CLI} Error when get relative path of file"
+	MsgErrorGetDependencyCodeFilepathAndLine = "{HORUSEC_CLI} Error when get dependency code filepath and line"
+	MsgErrorGetDependencyInfo                = "{HORUSEC_CLI} Error when get dependency code info"
 )

--- a/internal/services/formatters/csharp/scs/formatter.go
+++ b/internal/services/formatters/csharp/scs/formatter.go
@@ -99,11 +99,20 @@ func (f *Formatter) parseOutput(output string) error {
 
 	f.setSeveritiesAndVulnsByID(analysis)
 
-	for _, result := range analysis.getRun().Results {
-		f.AddNewVulnerabilityIntoAnalysis(f.newVulnerability(result))
-	}
+	f.addVulnIntoAnalysis(analysis)
 
 	return nil
+}
+
+func (f *Formatter) addVulnIntoAnalysis(analysis *scsAnalysis) {
+	for _, result := range analysis.getRun().Results {
+		vuln, err := f.newVulnerability(result)
+		if err != nil {
+			f.SetAnalysisError(err, tools.SecurityCodeScan, err.Error(), "")
+			continue
+		}
+		f.AddNewVulnerabilityIntoAnalysis(vuln)
+	}
 }
 
 func (f *Formatter) setSeveritiesAndVulnsByID(analysis *scsAnalysis) {
@@ -111,9 +120,12 @@ func (f *Formatter) setSeveritiesAndVulnsByID(analysis *scsAnalysis) {
 	f.vulnerabilitiesByID = analysis.vulnerabilitiesByID()
 }
 
-func (f *Formatter) newVulnerability(result *scsResult) *vulnerability.Vulnerability {
-	code, _ := fileutils.GetCode(f.GetConfigProjectPath(), result.getFile(), result.getLine())
-
+// nolint: funlen // needs to be bigger
+func (f *Formatter) newVulnerability(result *scsResult) (*vulnerability.Vulnerability, error) {
+	code, err := fileutils.GetCode(f.GetConfigProjectPath(), result.getFile(), result.getLine())
+	if err != nil {
+		return nil, err
+	}
 	vuln := &vulnerability.Vulnerability{
 		SecurityTool: tools.SecurityCodeScan,
 		Language:     languages.CSharp,
@@ -125,7 +137,7 @@ func (f *Formatter) newVulnerability(result *scsResult) *vulnerability.Vulnerabi
 		Code:         code,
 	}
 
-	return f.SetCommitAuthor(vulnHash.Bind(vuln))
+	return f.SetCommitAuthor(vulnHash.Bind(vuln)), err
 }
 
 // nolint: funlen

--- a/internal/services/formatters/generic/trivy/formatter_test.go
+++ b/internal/services/formatters/generic/trivy/formatter_test.go
@@ -15,6 +15,8 @@
 package trivy
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
@@ -29,6 +31,16 @@ import (
 )
 
 func TestTrivyParseOutput(t *testing.T) {
+	dirName := filepath.Join(".horusec", "00000000-0000-0000-0000-000000000000")
+	err := os.MkdirAll(dirName, 0o777)
+	assert.NoError(t, err)
+	file, err := os.Create(filepath.Join(dirName, "go.sum"))
+	defer file.Close()
+	assert.NoError(t, err)
+	t.Cleanup(func() {
+		err = os.RemoveAll(".horusec")
+		assert.NoError(t, err)
+	})
 	t.Run("Should add 2 vulnerabilities on analysis without errors", func(t *testing.T) {
 		dockerAPIControllerMock := testutil.NewDockerMock()
 		dockerAPIControllerMock.On("SetAnalysisID")
@@ -41,7 +53,6 @@ func TestTrivyParseOutput(t *testing.T) {
 		service := formatters.NewFormatterService(analysis, dockerAPIControllerMock, cfg)
 		formatter := NewFormatter(service)
 		formatter.StartAnalysis("")
-
 		assert.Len(t, analysis.AnalysisVulnerabilities, 2)
 
 		for _, v := range analysis.AnalysisVulnerabilities {

--- a/internal/services/formatters/interface.go
+++ b/internal/services/formatters/interface.go
@@ -69,7 +69,7 @@ type IService interface {
 
 	// GetFilepathFromFilename return the relative file path inside projectSubpath
 	// to a given filename
-	GetFilepathFromFilename(filename, projectSubPath string) string
+	GetFilepathFromFilename(filename, projectSubPath string) (string, error)
 
 	// SetCommitAuthor set commit author info on vulnerability.
 	SetCommitAuthor(vulnerability *vulnerability.Vulnerability) *vulnerability.Vulnerability

--- a/internal/services/formatters/php/phpcs/formatter.go
+++ b/internal/services/formatters/php/phpcs/formatter.go
@@ -96,13 +96,18 @@ func (f *Formatter) parseResults(results map[string]interface{}) {
 func (f *Formatter) parseMessages(filepath string, result interface{}) {
 	for _, message := range f.parseToResult(result).Messages {
 		if message.IsAllowedMessage() && message.IsNotFailedToScan() {
-			vuln := f.setVulnerabilityData(filepath, message)
+			vuln, err := f.setVulnerabilityData(filepath, message)
+			if err != nil {
+				f.SetAnalysisError(err, tools.PhpCS, err.Error(), "")
+				continue
+			}
 			f.AddNewVulnerabilityIntoAnalysis(vuln)
 		}
 	}
 }
 
-func (f *Formatter) setVulnerabilityData(filepath string, result entities.Message) *vulnerability.Vulnerability {
+// nolint: funlen,lll // needs to be bigger
+func (f *Formatter) setVulnerabilityData(filepath string, result entities.Message) (*vulnerability.Vulnerability, error) {
 	vuln := f.getDefaultVulnerabilitySeverity()
 	vuln.Severity = result.GetSeverity()
 	vuln.Details = result.Message
@@ -110,12 +115,23 @@ func (f *Formatter) setVulnerabilityData(filepath string, result entities.Messag
 	vuln.Column = result.GetColumn()
 	vuln.File = f.RemoveSrcFolderFromPath(filepath)
 	vuln = vulnhash.Bind(vuln)
-
+	code, err := f.getCode(vuln, result)
+	if err != nil {
+		return nil, err
+	}
 	// NOTE: code and details were set after the vulnhash.Bind to avoid changes in the hash generation
-	vuln.Code, _ = fileutils.GetCode(f.GetConfigProjectPath(), vuln.File, result.GetLine())
+	vuln.Code = code
 	vuln.Details += fmt.Sprintf("\n %s", result.Source)
 
-	return f.SetCommitAuthor(vuln)
+	return f.SetCommitAuthor(vuln), err
+}
+
+func (f *Formatter) getCode(vuln *vulnerability.Vulnerability, result entities.Message) (string, error) {
+	code, err := fileutils.GetCode(f.GetConfigProjectPath(), vuln.File, result.GetLine())
+	if err != nil {
+		return "", err
+	}
+	return code, err
 }
 
 func (f *Formatter) getDefaultVulnerabilitySeverity() *vulnerability.Vulnerability {

--- a/internal/services/formatters/php/phpcs/formatter_test.go
+++ b/internal/services/formatters/php/phpcs/formatter_test.go
@@ -16,6 +16,8 @@ package phpcs
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	entitiesAnalysis "github.com/ZupIT/horusec-devkit/pkg/entities/analysis"
@@ -31,6 +33,25 @@ import (
 )
 
 func TestStartPHPCodeSniffer(t *testing.T) {
+	dirName := filepath.Join(".horusec", "00000000-0000-0000-0000-000000000000", "src", "tool-examples")
+	err := os.MkdirAll(dirName, 0o777)
+	assert.NoError(t, err)
+	srcFiles := []string{"sql-injection.php", "sql-injection_2.php", "basic-collection.php", "cross-site-scripting-xss.php"}
+	toolExamplesFiles := []string{"progpilot.php", "phpcs-security-audit.php", "php-security-scanner.php"}
+	for _, file := range srcFiles {
+		newFile, err := os.Create(filepath.Join(".horusec", "00000000-0000-0000-0000-000000000000", "src", file))
+		defer newFile.Close()
+		assert.NoError(t, err)
+	}
+	for _, file := range toolExamplesFiles {
+		newFile, err := os.Create(filepath.Join(dirName, file))
+		defer newFile.Close()
+		assert.NoError(t, err)
+	}
+	t.Cleanup(func() {
+		err = os.RemoveAll(".horusec")
+		assert.NoError(t, err)
+	})
 	t.Run("should success execute container and process output", func(t *testing.T) {
 		dockerAPIControllerMock := testutil.NewDockerMock()
 		analysis := &entitiesAnalysis.Analysis{}

--- a/internal/services/formatters/python/safety/formatter.go
+++ b/internal/services/formatters/python/safety/formatter.go
@@ -103,24 +103,31 @@ func (f *Formatter) parseOutputToSafetyOutput(output string) (safetyOutput entit
 
 func (f *Formatter) setSafetyOutPutInHorusecAnalysis(issues []entities.Issue, projectSubPath string) {
 	for index := range issues {
-		vuln := f.setupVulnerabilitiesSeveritiesSafety(issues, index, projectSubPath)
+		vuln, err := f.setupVulnerabilitiesSeveritiesSafety(issues, index, projectSubPath)
+		if err != nil {
+			f.SetAnalysisError(err, tools.NpmAudit, err.Error(), "")
+			continue
+		}
 		f.AddNewVulnerabilityIntoAnalysis(vuln)
 	}
 }
 
 func (f *Formatter) setupVulnerabilitiesSeveritiesSafety(
-	issues []entities.Issue, index int, projectSubPath string) *vulnerability.Vulnerability {
+	issues []entities.Issue, index int, projectSubPath string) (*vulnerability.Vulnerability, error) {
 	lineContent := fmt.Sprintf("%s=%s", issues[index].Dependency, issues[index].InstalledVersion)
-	vuln := f.getDefaultVulnerabilitySeverityInSafety(projectSubPath)
+	vuln, err := f.getDefaultVulnerabilitySeverityInSafety(projectSubPath)
+	if err != nil {
+		return nil, err
+	}
 	vuln.Details = issues[index].Description
 	vuln.Code = f.GetCodeWithMaxCharacters(issues[index].Dependency, 0)
 	vuln.Line = f.getVulnerabilityLineByName(lineContent, vuln.File)
 	vuln = vulnhash.Bind(vuln)
-	return f.SetCommitAuthor(vuln)
+	return f.SetCommitAuthor(vuln), err
 }
 
 func (f *Formatter) getVulnerabilityLineByName(line, fileName string) string {
-	path := filepath.Join(f.GetConfigProjectPath(), fileName)
+	path := filepath.Join(f.GetConfigProjectPath(), filepath.Clean(fileName))
 	fileOpened, err := os.Open(path)
 	if err != nil {
 		return "-"
@@ -146,13 +153,18 @@ func (f *Formatter) getLine(name string, scanner *bufio.Scanner) string {
 	return "-"
 }
 
-func (f *Formatter) getDefaultVulnerabilitySeverityInSafety(projectSubPath string) *vulnerability.Vulnerability {
+// nolint: funlen,lll // needs to be bigger
+func (f *Formatter) getDefaultVulnerabilitySeverityInSafety(projectSubPath string) (*vulnerability.Vulnerability, error) {
 	vulnerabilitySeverity := &vulnerability.Vulnerability{}
 	vulnerabilitySeverity.Language = languages.Python
 	vulnerabilitySeverity.Severity = severities.High
 	vulnerabilitySeverity.SecurityTool = tools.Safety
 	vulnerabilitySeverity.Confidence = "-"
 	vulnerabilitySeverity.Column = "0"
-	vulnerabilitySeverity.File = f.GetFilepathFromFilename("requirements.txt", projectSubPath)
-	return vulnerabilitySeverity
+	filePath, err := f.GetFilepathFromFilename("requirements.txt", projectSubPath)
+	if err != nil {
+		return nil, err
+	}
+	vulnerabilitySeverity.File = filePath
+	return vulnerabilitySeverity, err
 }

--- a/internal/services/formatters/ruby/brakeman/formatter.go
+++ b/internal/services/formatters/ruby/brakeman/formatter.go
@@ -66,8 +66,11 @@ func (f *Formatter) StartAnalysis(projectSubPath string) {
 
 func (f *Formatter) startBrakeman(projectSubPath string) (string, error) {
 	f.LogDebugWithReplace(messages.MsgDebugToolStartAnalysis, tools.Brakeman, languages.Ruby)
-
-	output, err := f.ExecuteContainer(f.getDockerConfig(projectSubPath))
+	dockerConfig, err := f.getDockerConfig(projectSubPath)
+	if err != nil {
+		return "", err
+	}
+	output, err := f.ExecuteContainer(dockerConfig)
 	if err != nil {
 		return output, err
 	}
@@ -85,12 +88,21 @@ func (f *Formatter) parseOutput(containerOutput, projectSubPath string) error {
 		return err
 	}
 
-	for _, warning := range brakemanOutput.Warnings {
-		value := warning
-		f.AddNewVulnerabilityIntoAnalysis(f.newVulnerability(&value, projectSubPath))
-	}
+	f.addVulnIntoAnalysis(brakemanOutput, projectSubPath)
 
 	return nil
+}
+
+func (f *Formatter) addVulnIntoAnalysis(brakemanOutput brakemanOutput, projectSubPath string) {
+	for _, warning := range brakemanOutput.Warnings {
+		value := warning
+		vuln, err := f.newVulnerability(&value, projectSubPath)
+		if err != nil {
+			f.SetAnalysisError(err, tools.Brakeman, err.Error(), "")
+			continue
+		}
+		f.AddNewVulnerabilityIntoAnalysis(vuln)
+	}
 }
 
 func (f *Formatter) newContainerOutputFromString(containerOutput string) (output brakemanOutput, err error) {
@@ -102,7 +114,12 @@ func (f *Formatter) newContainerOutputFromString(containerOutput string) (output
 	return output, err
 }
 
-func (f *Formatter) newVulnerability(output *warning, projectSubPath string) *vulnerability.Vulnerability {
+// nolint: funlen // needs to be bigger
+func (f *Formatter) newVulnerability(output *warning, projectSubPath string) (*vulnerability.Vulnerability, error) {
+	filePath, err := f.GetFilepathFromFilename(filepath.FromSlash(output.File), projectSubPath)
+	if err != nil {
+		return nil, err
+	}
 	vuln := &vulnerability.Vulnerability{
 		SecurityTool: tools.Brakeman,
 		Language:     languages.Ruby,
@@ -110,24 +127,28 @@ func (f *Formatter) newVulnerability(output *warning, projectSubPath string) *vu
 		Confidence:   output.getConfidence(),
 		Details:      output.getDetails(),
 		Line:         output.getLine(),
-		File:         f.GetFilepathFromFilename(filepath.FromSlash(output.File), projectSubPath),
+		File:         filePath,
 		Code:         f.GetCodeWithMaxCharacters(output.Code, 0),
 	}
 
-	return f.SetCommitAuthor(vulnhash.Bind(vuln))
+	return f.SetCommitAuthor(vulnhash.Bind(vuln)), err
 }
 
-func (f *Formatter) getDockerConfig(projectSubPath string) *docker.AnalysisData {
+func (f *Formatter) getDockerConfig(projectSubPath string) (*docker.AnalysisData, error) {
+	subpath, err := fileutils.GetSubPathByFilename(f.GetConfigProjectPath(), projectSubPath, "Gemfile")
+	if err != nil {
+		return nil, err
+	}
 	analysisData := &docker.AnalysisData{
 		CMD: f.AddWorkDirInCmd(
 			CMD,
-			fileutils.GetSubPathByFilename(f.GetConfigProjectPath(), projectSubPath, "Gemfile"),
+			subpath,
 			tools.Brakeman,
 		),
 		Language: languages.Ruby,
 	}
 
-	return analysisData.SetImage(f.GetCustomImageByLanguage(languages.Ruby), images.Ruby)
+	return analysisData.SetImage(f.GetCustomImageByLanguage(languages.Ruby), images.Ruby), err
 }
 
 func (f *Formatter) isNotFoundRailsProject(output string) bool {

--- a/internal/services/formatters/ruby/bundler/formatter.go
+++ b/internal/services/formatters/ruby/bundler/formatter.go
@@ -75,7 +75,10 @@ func (f *Formatter) startBundlerAudit(projectSubPath string) (string, error) {
 	if errGemLock := f.verifyGemLockError(output); errGemLock != nil {
 		return output, errGemLock
 	}
-	f.parseOutput(f.removeOutputEsc(output), projectSubPath)
+	err = f.parseOutput(f.removeOutputEsc(output), projectSubPath)
+	if err != nil {
+		return "", err
+	}
 	return "", nil
 }
 
@@ -109,23 +112,39 @@ func (f *Formatter) removeOutputEsc(output string) string {
 	return output
 }
 
-func (f *Formatter) parseOutput(output, projectSubPath string) {
+func (f *Formatter) parseOutput(output, projectSubPath string) error {
+	isInvalid, err := f.isValidOutput(output)
+	if isInvalid {
+		return err
+	}
+
+	for _, outputSplit := range strings.Split(output, "Name:") {
+		err := f.processOutput(outputSplit, projectSubPath)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *Formatter) isValidOutput(output string) (bool, error) {
 	// If the output does not have the "Name:" string when we split on this string
 	// the strings.Split function will return a list with a single element and this
 	// single element will be the entire invalid output, so we do this strings.Contains
 	// validation to avoid parse an invalid output data.
 	if strings.Contains(output, "No vulnerabilities found") || !strings.Contains(output, "Name:") {
-		return
+		if strings.Contains(output, "No vulnerabilities found") {
+			return true, nil
+		}
+		return true, errors.New("invalid output data")
 	}
-
-	for _, outputSplit := range strings.Split(output, "Name:") {
-		f.processOutput(outputSplit, projectSubPath)
-	}
+	return false, nil
 }
 
-func (f *Formatter) processOutput(outputData, projectSubPath string) {
+// nolint: funlen,gocyclo // needs to be bigger
+func (f *Formatter) processOutput(outputData, projectSubPath string) error {
 	if outputData == "" {
-		return
+		return nil
 	}
 
 	var output bundlerOutput
@@ -136,26 +155,38 @@ func (f *Formatter) processOutput(outputData, projectSubPath string) {
 
 		output.setOutputData(&output, value)
 	}
-
-	f.AddNewVulnerabilityIntoAnalysis(f.newVulnerability(&output, projectSubPath))
+	vuln, err := f.newVulnerability(&output, projectSubPath)
+	if err != nil {
+		return err
+	}
+	f.AddNewVulnerabilityIntoAnalysis(vuln)
+	return err
 }
 
-func (f *Formatter) newVulnerability(output *bundlerOutput, projectSubPath string) *vulnerability.Vulnerability {
+// nolint: funlen // needs to be bigger
+func (f *Formatter) newVulnerability(output *bundlerOutput,
+	projectSubPath string) (*vulnerability.Vulnerability, error,
+) {
+	filePath, err := f.GetFilepathFromFilename("Gemfile.lock", projectSubPath)
+	if err != nil {
+		return nil, err
+	}
 	vuln := &vulnerability.Vulnerability{
 		SecurityTool: tools.BundlerAudit,
 		Language:     languages.Ruby,
 		Confidence:   confidence.Low,
 		Severity:     output.getSeverity(),
 		Details:      output.getDetails(),
-		File:         f.GetFilepathFromFilename("Gemfile.lock", projectSubPath),
+		File:         filePath,
 		Code:         f.GetCodeWithMaxCharacters(output.Name, 0),
 	}
 	vuln.Line = f.getVulnerabilityLineByName(vuln.Code, vuln.File)
-	return f.SetCommitAuthor(vulnhash.Bind(vuln))
+	return f.SetCommitAuthor(vulnhash.Bind(vuln)), err
 }
 
 func (f *Formatter) getVulnerabilityLineByName(module, fileName string) string {
-	fileExisting, err := os.Open(filepath.Join(f.GetConfigProjectPath(), fileName))
+	filePath := filepath.Join(f.GetConfigProjectPath(), filepath.Clean(fileName))
+	fileExisting, err := os.Open(filePath)
 	if err != nil {
 		return ""
 	}

--- a/internal/services/formatters/ruby/bundler/formatter_test.go
+++ b/internal/services/formatters/ruby/bundler/formatter_test.go
@@ -56,7 +56,7 @@ func TestParseOutput(t *testing.T) {
 		}
 	})
 
-	t.Run("should add no error and no vulnerabilities on analysis when parse invalid output", func(t *testing.T) {
+	t.Run("should add error and no vulnerabilities on analysis when parse invalid output", func(t *testing.T) {
 		analysis := new(analysis.Analysis)
 
 		dockerAPIControllerMock := testutil.NewDockerMock()
@@ -67,7 +67,7 @@ func TestParseOutput(t *testing.T) {
 		formatter := NewFormatter(service)
 		formatter.StartAnalysis("")
 
-		assert.False(t, analysis.HasErrors(), "Expected no errors on analysis")
+		assert.True(t, analysis.HasErrors(), "Expected no errors on analysis")
 		assert.Len(t, analysis.AnalysisVulnerabilities, 0)
 	})
 

--- a/internal/services/formatters/service.go
+++ b/internal/services/formatters/service.go
@@ -179,11 +179,14 @@ func (s *Service) truncatedCode(code string, column int) string {
 	return codeFromColumn
 }
 
-func (s *Service) GetFilepathFromFilename(filename, projectSubPath string) string {
+func (s *Service) GetFilepathFromFilename(filename, projectSubPath string) (string, error) {
 	basePath := filepath.Join(s.GetConfigProjectPath(), projectSubPath)
-	filepathWithFileName := file.GetPathFromFilename(filename, basePath)
+	filepathWithFileName, err := file.GetPathFromFilename(filename, basePath)
+	if err != nil {
+		return "", err
+	}
 
-	return filepath.Join(projectSubPath, filepathWithFileName)
+	return filepath.Join(projectSubPath, filepathWithFileName), err
 }
 
 func (s *Service) SetCommitAuthor(vuln *vulnerability.Vulnerability) *vulnerability.Vulnerability {

--- a/internal/services/formatters/service_test.go
+++ b/internal/services/formatters/service_test.go
@@ -438,7 +438,7 @@ func TestGetFilepathFromFilename(t *testing.T) {
 		assert.NotNil(t, file)
 		assert.NoError(t, err)
 
-		result := monitorController.GetFilepathFromFilename(filename, "")
+		result, err := monitorController.GetFilepathFromFilename(filename, "")
 
 		assert.Equal(t, filepath.Join(relativeFilePath, filename), result)
 		t.Cleanup(func() {
@@ -455,8 +455,8 @@ func TestGetFilepathFromFilename(t *testing.T) {
 		monitorController := NewFormatterService(&analysis.Analysis{}, testutil.NewDockerMock(), cfg)
 		filename := "server.go"
 
-		result := monitorController.GetFilepathFromFilename(filename, "")
-
+		result, err := monitorController.GetFilepathFromFilename(filename, "")
+		assert.Error(t, err)
 		assert.Equal(t, "", result)
 	})
 }

--- a/internal/utils/file/file_test.go
+++ b/internal/utils/file/file_test.go
@@ -31,20 +31,23 @@ func TestGetFilePathIntoBasePath(t *testing.T) {
 	t.Run("Should return path correctly", func(t *testing.T) {
 		filePath := filepath.Join("file", "file_test.go")
 		volume := testutil.RootPath
-		response := file.GetPathFromFilename(filePath, volume)
+		response, err := file.GetPathFromFilename(filePath, volume)
+		assert.NoError(t, err)
 		assert.NotEqual(t, response, filePath)
 		assert.Equal(t, filepath.Join("internal", "utils", "file", "file_test.go"), response)
 	})
 	t.Run("Should return filePath because not found", func(t *testing.T) {
 		filePath := "some_other_not_existing_file.go"
 		volume := testutil.RootPath
-		response := file.GetPathFromFilename(filePath, volume)
+		response, err := file.GetPathFromFilename(filePath, volume)
+		assert.NoError(t, err)
 		assert.Equal(t, "", response)
 	})
 	t.Run("Should return filePath because base path is wrong", func(t *testing.T) {
 		filePath := "some_other_not_existing_file.go"
 		volume := "S0M3 N0T E3X1$t"
-		response := file.GetPathFromFilename(filePath, volume)
+		response, err := file.GetPathFromFilename(filePath, volume)
+		assert.Error(t, err)
 		assert.Equal(t, "", response)
 	})
 }
@@ -107,31 +110,33 @@ func TestCreateAndWriteFile(t *testing.T) {
 
 func TestGetDependencyCodeFilepathAndLine(t *testing.T) {
 	t.Run("Should run with success", func(t *testing.T) {
-		code, file, line := file.GetDependencyCodeFilepathAndLine(
+		code, file, line, err := file.GetDependencyCodeFilepathAndLine(
 			testutil.CsharpExample1, "", "Microsoft.AspNetCore.Http", dotnetcli.CsProjExt,
 		)
 
 		expectedCode := "<PackageReference Include=\"Microsoft.AspNetCore.Http\" Version=\"2.2.2\"/>"
 		expectedFile := filepath.Join(testutil.CsharpExample1, "NetCoreVulnerabilities", "NetCoreVulnerabilities.csproj")
 		expectedLine := "7"
+		assert.NoError(t, err)
 		assert.Equal(t, expectedLine, line)
 		assert.Equal(t, expectedFile, file)
 		assert.Equal(t, expectedCode, code)
 	})
 	t.Run("Should return empty when path is invalid", func(t *testing.T) {
-		code, file, line := file.GetDependencyCodeFilepathAndLine(
+		code, file, line, err := file.GetDependencyCodeFilepathAndLine(
 			"invalidPath", "", "Microsoft.AspNetCore.Http", dotnetcli.CsProjExt,
 		)
 
+		assert.Error(t, err)
 		assert.Zero(t, code)
 		assert.Zero(t, file)
 		assert.Zero(t, line)
 	})
 	t.Run("Should return empty when path is valid but has no files", func(t *testing.T) {
-		code, file, line := file.GetDependencyCodeFilepathAndLine(
+		code, file, line, err := file.GetDependencyCodeFilepathAndLine(
 			t.TempDir(), "", "Microsoft.AspNetCore.Http", dotnetcli.CsProjExt,
 		)
-
+		assert.NoError(t, err)
 		assert.Zero(t, code)
 		assert.Zero(t, file)
 		assert.Zero(t, line)

--- a/internal/utils/testutil/formatter_mock.go
+++ b/internal/utils/testutil/formatter_mock.go
@@ -81,9 +81,9 @@ func (m *FormatterMock) ToolIsToIgnore(_ tools.Tool) bool {
 	return args.Get(0).(bool)
 }
 
-func (m *FormatterMock) GetFilepathFromFilename(_, _ string) string {
+func (m *FormatterMock) GetFilepathFromFilename(_, _ string) (string, error) {
 	args := m.MethodCalled("GetFilepathFromFilename")
-	return args.Get(0).(string)
+	return args.Get(0).(string), mockutils.ReturnNilOrError(args, 1)
 }
 
 func (m *FormatterMock) SetCommitAuthor(_ *vulnerability.Vulnerability) *vulnerability.Vulnerability {


### PR DESCRIPTION
Fix a bug in internal/utils/file.go where line value wasn't being restored to 0 when loop restarted, adding error return to GetDependencyCodeFilepathAndLine and GetDependencyInfo and some logging messages when this error is found. Removed unused function ReplacePathSeparator. Also changed some LogError to LogErrorWithLevel and setting errors to analysisError to be print on analysis end

Signed-off-by: Ian Cardoso <ian.cardoso@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
