### PR TITLE
dockerfiles:bugfix - updating docker base image

### DIFF
--- a/deployments/Dockerfile
+++ b/deployments/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM golang:1.17-alpine AS builder
 
-RUN apk update && apk add --no-cache git
+RUN apk add --no-cache git
 
 ADD . /horusec
 WORKDIR /horusec
@@ -23,9 +23,9 @@ RUN go mod download
 
 RUN env GOOS=linux go build -ldflags '-s -w' -o /bin/horusec ./cmd/app/main.go
 
-FROM docker:20.10-git
+FROM docker:20.10-dind
 
-RUN apk update --no-cache && apk upgrade --no-cache
+RUN apk add git --no-cache
 
 COPY --from=builder /bin/horusec /usr/local/bin
 RUN chmod +x /usr/local/bin/horusec

--- a/deployments/Dockerfile-gorelease-amd64
+++ b/deployments/Dockerfile-gorelease-amd64
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker:20.10-git
+FROM docker:20.10-dind
 
-RUN apk update --no-cache && apk upgrade --no-cache
+RUN apk add git --no-cache
 
 COPY /horusec_linux_amd64 /usr/local/bin/horusec
 

--- a/deployments/Dockerfile-gorelease-arm64
+++ b/deployments/Dockerfile-gorelease-arm64
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker:20.10-git
+FROM docker:20.10-dind
 
-RUN apk update --no-cache && apk upgrade --no-cache
+RUN apk add git --no-cache
 
 COPY /horusec_linux_arm64 /usr/local/bin/horusec
 


### PR DESCRIPTION
With the apk update && apk upgrade commands for some reason goreleaser
was't hable to build the images. This pr updates the dockerfiles to use
a diferent base image of the docker that doesn't contains the expat
vulnerabilities.

Signed-off-by: Nathan Martins <nathan.martins@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
