### PR TITLE
hash:feature - new hash format and handle the future depreciations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ZupIT/horusec
 go 1.17
 
 require (
-	github.com/ZupIT/horusec-devkit v1.0.22
+	github.com/ZupIT/horusec-devkit v1.0.23
 	github.com/ZupIT/horusec-engine v1.0.0
 	github.com/bmatcuk/doublestar/v4 v4.0.2
 	github.com/briandowns/spinner v1.18.0
@@ -60,14 +60,14 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
-	golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce // indirect
+	golang.org/x/crypto v0.0.0-20220214200702-86341886e292 // indirect
 	golang.org/x/net v0.0.0-20220114011407-0dd24b26b47d // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba // indirect
 	google.golang.org/genproto v0.0.0-20220114231437-d2e6a121cae0 // indirect
-	google.golang.org/grpc v1.43.0 // indirect
+	google.golang.org/grpc v1.44.0 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/ini.v1 v1.66.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,9 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
-github.com/ZupIT/horusec-devkit v1.0.22 h1:RW7ZzZWEOdFqlCN6ZBYzSg0UMtOnaaZQ95iaLCqn+1g=
 github.com/ZupIT/horusec-devkit v1.0.22/go.mod h1:QiWTanEkeMikccopaW1ZG/ie74ODZekOUu2i8kgkARo=
+github.com/ZupIT/horusec-devkit v1.0.23 h1:CBL5ya45zLMXYYgmdAtShAm3VC1F7KQGiRaIU3WGTow=
+github.com/ZupIT/horusec-devkit v1.0.23/go.mod h1:01lg6tLZkqwJE/Nn8Prnq7bFjq9Agf4zwbuV47sxMno=
 github.com/ZupIT/horusec-engine v1.0.0 h1:Mu0wrlK1L7n1+nv/vzeDc8AD0HOgavgK8X5N4qHwJSA=
 github.com/ZupIT/horusec-engine v1.0.0/go.mod h1:UCehiH9hiNYX2jDVdB8Anxv44Rz4BOFTKov2kyPAgK8=
 github.com/agiledragon/gomonkey/v2 v2.3.1/go.mod h1:ap1AmDzcVOAz1YpeJ3TCzIgstoaWLA6jbbgxfB4w2iY=
@@ -673,8 +674,9 @@ github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3N
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
 github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
-github.com/migueleliasweb/go-github-mock v0.0.6 h1:JYB8HK7PvchVaCpO4YbstTaaZz8WFwqAQ2UT7ugjiOU=
 github.com/migueleliasweb/go-github-mock v0.0.6/go.mod h1:mD5w+9J3oBBMLr7uD6owEYlYBAL8tZd+BA7iGjI4EU8=
+github.com/migueleliasweb/go-github-mock v0.0.7 h1:4/uRfgFh/urIyXD0W6TP09323PBqNYCUpJftc4dePmI=
+github.com/migueleliasweb/go-github-mock v0.0.7/go.mod h1:mD5w+9J3oBBMLr7uD6owEYlYBAL8tZd+BA7iGjI4EU8=
 github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
 github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXxx3xhI=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -792,6 +794,7 @@ github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQ
 github.com/prometheus/client_golang v1.4.0/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3OK1iX/F2sw+iXX5zU=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
+github.com/prometheus/client_golang v1.12.1/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
 github.com/prometheus/client_model v0.0.0-20171117100541-99fa1f4be8e5/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -899,8 +902,10 @@ github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69
 github.com/swaggo/files v0.0.0-20190704085106-630677cd5c14/go.mod h1:gxQT6pBGRuIGunNf/+tSOB5OHvguWi8Tbt82WOkf35E=
 github.com/swaggo/files v0.0.0-20210815190702-a29dd2bc99b2/go.mod h1:lKJPbtWzJ9JhsTN1k1gZgleJWY/cqq0psdoMmaThG3w=
 github.com/swaggo/http-swagger v1.1.2/go.mod h1:mX5nhypDmoSt4iw2mc5aKXxRFvp1CLLcCiog2B9M+Ro=
+github.com/swaggo/http-swagger v1.2.5/go.mod h1:CcoICgY3yVDk2u1LQUCMHbAj0fjlxIX+873psXlIKNA=
 github.com/swaggo/swag v1.7.0/go.mod h1:BdPIL73gvS9NBsdi7M1JOxLvlbfvNRaBP8m6WT6Aajo=
 github.com/swaggo/swag v1.7.8/go.mod h1:gZ+TJ2w/Ve1RwQsA2IRoSOTidHz6DX+PIG8GWvbnoLU=
+github.com/swaggo/swag v1.7.9/go.mod h1:gZ+TJ2w/Ve1RwQsA2IRoSOTidHz6DX+PIG8GWvbnoLU=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
@@ -991,8 +996,9 @@ golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce h1:Roh6XWxHFKrPgC/EQhVubSAGQ6Ozk6IdxHSzt1mR0EI=
 golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20220214200702-86341886e292 h1:f+lwQ+GtmgoY+A2YaQxlSOnDjXcQ7ZRLWOHbC6HtRqE=
+golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -1468,8 +1474,9 @@ google.golang.org/grpc v1.39.1/go.mod h1:PImNr+rS9TWYb2O4/emRugxiyHZ5JyHW5F+RPnD
 google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
 google.golang.org/grpc v1.40.1/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
 google.golang.org/grpc v1.42.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
-google.golang.org/grpc v1.43.0 h1:Eeu7bZtDZ2DpRCsLhUlcrLnvYaMK1Gz86a+hMVvELmM=
 google.golang.org/grpc v1.43.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
+google.golang.org/grpc v1.44.0 h1:weqSxi/TMs1SqFRMHCtBgXRs8k3X39QIDEZ0pRcttUg=
+google.golang.org/grpc v1.44.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=

--- a/internal/controllers/analyzer/analyzer_test.go
+++ b/internal/controllers/analyzer/analyzer_test.go
@@ -90,7 +90,7 @@ func TestAnalyzerSetFalsePositivesAndRiskAcceptInVulnerabilities(t *testing.T) {
 		{
 			name:          "ChangeBreakingHashToFalsePositive",
 			vulnerability: vuln,
-			hashes:        []string{vuln.VulnHashInvalid},
+			hashes:        vuln.DeprecatedHashes,
 			expectedType:  vulnerabilityenum.FalsePositive,
 		},
 		{
@@ -102,7 +102,7 @@ func TestAnalyzerSetFalsePositivesAndRiskAcceptInVulnerabilities(t *testing.T) {
 		{
 			name:          "ChangeBreakingHashToRiskAccept",
 			vulnerability: vuln,
-			hashes:        []string{vuln.VulnHashInvalid},
+			hashes:        vuln.DeprecatedHashes,
 			expectedType:  vulnerabilityenum.RiskAccepted,
 		},
 	}
@@ -133,7 +133,6 @@ func TestAnalyzerSetFalsePositivesAndRiskAcceptInVulnerabilities(t *testing.T) {
 
 			analyzer.SetFalsePositivesAndRiskAcceptInVulnerabilities(falsePositiveHashes, riskAcceptHashes)
 
-			require.Len(t, analyzer.analysis.AnalysisVulnerabilities, len(tt.hashes))
 			for _, vuln := range analyzer.analysis.AnalysisVulnerabilities {
 				assert.Equal(t, tt.expectedType, vuln.Vulnerability.Type)
 			}

--- a/internal/controllers/printresults/print_results.go
+++ b/internal/controllers/printresults/print_results.go
@@ -91,6 +91,7 @@ func (pr *PrintResults) Print() (totalVulns int, err error) {
 	pr.verifyRepositoryAuthorizationToken()
 	pr.printResponseAnalysis()
 	pr.checkIfExistsErrorsInAnalysis()
+	pr.printWarnings()
 	if pr.config.IsTimeout {
 		logger.LogWarnWithLevel(messages.MsgWarnTimeoutOccurs)
 	}
@@ -432,4 +433,11 @@ func (pr *PrintResults) createTxtOutputFile() error {
 	}
 
 	return file.CreateAndWriteFile(pr.textOutput, pr.config.JSONOutputFilePath)
+}
+
+// printWarnings print all necessary warnings in the end of the analysis
+func (pr *PrintResults) printWarnings() {
+	for _, warning := range pr.analysis.Warnings {
+		logger.LogWarnWithLevel(warning)
+	}
 }

--- a/internal/controllers/printresults/print_results_test.go
+++ b/internal/controllers/printresults/print_results_test.go
@@ -301,7 +301,11 @@ const (
         "commitHash": "",
         "commitMessage": "",
         "commitDate": "",
-        "vulnHash": ""
+        "rule_id": "",
+        "vulnHash": "",
+        "deprecatedHashes": null,
+        "securityToolVersion": "",
+        "securityToolInfoUri": ""
       }
     }
   ]
@@ -322,7 +326,7 @@ File: cert.pem
 Code: -----BEGIN CERTIFICATE-----
 Details: Found SSH and/or x.509 Cerficates GoSec
 Type: Vulnerability
-ReferenceHash: e85cdcb9de69717b2c63f2367ae75c3cc0162acefc6714986eab55e6a52b0bab
+ReferenceHash: 03405f909c9ed621e2bccd9e50d237dbe9374e4c67f89c1018d70fa9a4912d71
 
 ==================================================================================
 
@@ -336,7 +340,7 @@ File: cert.pem
 Code: -----BEGIN CERTIFICATE-----
 Details: Found SSH and/or x.509 Cerficates SecurityCodeScan
 Type: Vulnerability
-ReferenceHash: 3889442bd5280ea3b7bd89408d478f3d7fcfb6b78bc1e2e53e726344fc47f9bf
+ReferenceHash: 03405f909c9ed621e2bccd9e50d237dbe9374e4c67f89c1018d70fa9a4912d71
 
 ==================================================================================
 
@@ -350,7 +354,7 @@ File: cert.pem
 Code: -----BEGIN CERTIFICATE-----
 Details: Found SSH and/or x.509 Cerficates Brakeman
 Type: Vulnerability
-ReferenceHash: fc9fd74b92f16d962a4758fa2b05bca09e0912e49c01d2dc5faf11a798b62480
+ReferenceHash: 03405f909c9ed621e2bccd9e50d237dbe9374e4c67f89c1018d70fa9a4912d71
 
 ==================================================================================
 
@@ -364,7 +368,7 @@ File: cert.pem
 Code: -----BEGIN CERTIFICATE-----
 Details: Found SSH and/or x.509 Cerficates NpmAudit
 Type: Vulnerability
-ReferenceHash: a4774674dcff66efdafe4c58df5e2cc72f768330e79187f79e93838dc7875a9e
+ReferenceHash: 03405f909c9ed621e2bccd9e50d237dbe9374e4c67f89c1018d70fa9a4912d71
 
 ==================================================================================
 
@@ -378,7 +382,7 @@ File: cert.pem
 Code: -----BEGIN CERTIFICATE-----
 Details: Found SSH and/or x.509 Cerficates YarnAudit
 Type: Vulnerability
-ReferenceHash: 2821233bffb27450b1e24453c491a36834db50417fc70eb9d7d0af057a455126
+ReferenceHash: 03405f909c9ed621e2bccd9e50d237dbe9374e4c67f89c1018d70fa9a4912d71
 
 ==================================================================================
 
@@ -392,7 +396,7 @@ File: cert.pem
 Code: -----BEGIN CERTIFICATE-----
 Details: Found SSH and/or x.509 Cerficates Bandit
 Type: Vulnerability
-ReferenceHash: dcff5a09607c641c7b127bf53d6efc38533f7fb601f0b00862e0d7738b25aa5d
+ReferenceHash: 03405f909c9ed621e2bccd9e50d237dbe9374e4c67f89c1018d70fa9a4912d71
 
 ==================================================================================
 
@@ -406,7 +410,7 @@ File: cert.pem
 Code: -----BEGIN CERTIFICATE-----
 Details: Found SSH and/or x.509 Cerficates Safety
 Type: Vulnerability
-ReferenceHash: 1322569065b57231b2c21981a74f61710060ca967aa824c1634a791241bc5b86
+ReferenceHash: 03405f909c9ed621e2bccd9e50d237dbe9374e4c67f89c1018d70fa9a4912d71
 
 ==================================================================================
 
@@ -420,7 +424,7 @@ File: cert.pem
 Code: -----BEGIN CERTIFICATE-----
 Details: Found SSH and/or x.509 Cerficates HorusecLeaks
 Type: Vulnerability
-ReferenceHash: 5829ce1578d6b902c2f545181f4b8e836f29da72702fa53c0bd2caad77e869dd
+ReferenceHash: 03405f909c9ed621e2bccd9e50d237dbe9374e4c67f89c1018d70fa9a4912d71
 
 ==================================================================================
 
@@ -434,7 +438,7 @@ File: cert.pem
 Code: -----BEGIN CERTIFICATE-----
 Details: Found SSH and/or x.509 Cerficates GitLeaks
 Type: Vulnerability
-ReferenceHash: 1cb3d3e481f1b28514f06631d31a10bab589509e3fac4354fbf210e980535f72
+ReferenceHash: 03405f909c9ed621e2bccd9e50d237dbe9374e4c67f89c1018d70fa9a4912d71
 
 ==================================================================================
 
@@ -448,7 +452,7 @@ File: cert.pem
 Code: -----BEGIN CERTIFICATE-----
 Details: Found SSH and/or x.509 Cerficates HorusecJava
 Type: Vulnerability
-ReferenceHash: b7684b5d431ba356f65e8dbe3c62ee24cd97412094b5ae205c99670ed54f883d
+ReferenceHash: 03405f909c9ed621e2bccd9e50d237dbe9374e4c67f89c1018d70fa9a4912d71
 
 ==================================================================================
 
@@ -462,7 +466,7 @@ File: cert.pem
 Code: -----BEGIN CERTIFICATE-----
 Details: Found SSH and/or x.509 Cerficates HorusecKotlin
 Type: Vulnerability
-ReferenceHash: 9824269893d4df5e66a4fe7f53a715117bb722910228152b04831b6d2ad19a5b
+ReferenceHash: 03405f909c9ed621e2bccd9e50d237dbe9374e4c67f89c1018d70fa9a4912d71
 
 ==================================================================================
 
@@ -470,7 +474,6 @@ In this analysis, a total of 11 possible vulnerabilities were found and we class
 Total of Vulnerability HIGH is: 3
 Total of Vulnerability MEDIUM is: 1
 Total of Vulnerability LOW is: 7
-
 `
 
 	// expectedSonarqubeJsonResult is the expected json result

--- a/internal/helpers/messages/warn.go
+++ b/internal/helpers/messages/warn.go
@@ -48,4 +48,11 @@ const (
 	MsgWarnGitRepositoryIsNotFullCloned = "{HORUSEC_CLI} Repository is not fully cloned." +
 		"Commit author can result wrong authors. Check the documentation for more info." +
 		"https://docs.horusec.io/docs/cli/installation/#2-installation-via-pipeline"
+
+	// TODO: Remove MsgWarnUpdateOutdatedHash before release v2.10.0
+	MsgWarnUpdateOutdatedHash = "{HORUSEC_CLI} Update hash %s to %s"
+
+	// TODO: Remove MsgWarnAnalysisContainsOutdatedHash before release v2.10.0
+	MsgWarnAnalysisContainsOutdatedHash = "{HORUSEC_CLI} YOUR CONFIGURATION FILE CONTAINS SOME HASHES THAT WILL NO " +
+		"LONGER BE VALID AS OF v2.10.0 IS RELEASED. PLEASE UPDATE YOUR CONFIGURATION FILE WITH THE FOLLOWING HASHES:"
 )

--- a/internal/services/formatters/csharp/dotnet_cli/formatter_test.go
+++ b/internal/services/formatters/csharp/dotnet_cli/formatter_test.go
@@ -58,7 +58,7 @@ func TestParseOutput(t *testing.T) {
 			assert.NotEmpty(t, vuln.Code, "Expected not empty code")
 			assert.Equal(
 				t,
-				filepath.Join(cfg.ProjectPath, "NetCoreVulnerabilities", "NetCoreVulnerabilities.csproj"),
+				filepath.Join("NetCoreVulnerabilities", "NetCoreVulnerabilities.csproj"),
 				vuln.File,
 				"Expected equals file name",
 			)

--- a/internal/services/formatters/generic/trivy/formatter.go
+++ b/internal/services/formatters/generic/trivy/formatter.go
@@ -177,22 +177,24 @@ func (f *Formatter) addVulnerabilitiesOutput(vulnerabilities []*trivyVulnerabili
 		addVuln.File = target
 		addVuln.Details = vuln.getDetails()
 		addVuln.Severity = severities.GetSeverityByString(vuln.Severity)
-		addVuln.VulnHash = f.getOldHash(vuln.PkgName, *addVuln)
+		addVuln.DeprecatedHashes = f.getDeprecatedHashes(vuln.PkgName, *addVuln)
+		addVuln = vulnhash.Bind(addVuln)
 		f.AddNewVulnerabilityIntoAnalysis(f.SetCommitAuthor(addVuln))
 	}
 }
 
-// getOldHash func necessary to avoid a breaking change in the trivy hash generation. Since the pull request
+// getDeprecatedHashes func necessary to avoid a breaking change in the trivy hash generation. Since the pull request
 // https://github.com/ZupIT/horusec/pull/882 some changes were made in the line and code, and this data influences
 // directly the hash generation. This func will avoid this hash change by using the same data as before, but for the
 // users the data will be showed with the fixes made in the pull request 882, leading to no braking changes and keeping
 // the fixes.
+// TODO: This will be removed after the release v2.10.0 be released
 // nolint:gocritic // it has to be without pointer
-func (f *Formatter) getOldHash(pkgName string, vuln vulnerability.Vulnerability) string {
+func (f *Formatter) getDeprecatedHashes(pkgName string, vuln vulnerability.Vulnerability) []string {
 	vuln.Line = "0"
 	vuln.Code = pkgName
 
-	return vulnhash.Bind(&vuln).VulnHash
+	return vulnhash.Bind(&vuln).DeprecatedHashes
 }
 
 func (f *Formatter) addMisconfigurationOutput(result []*trivyMisconfiguration, target string) {

--- a/internal/services/formatters/service_test.go
+++ b/internal/services/formatters/service_test.go
@@ -87,8 +87,11 @@ func TestParseFindingsToVulnerabilities(t *testing.T) {
 			CommitHash:    "-",
 			CommitMessage: "-",
 			// NOTE: We hard coded vulnerability hash here to assert that we are not breaking existing hashes
-			VulnHash:        "b9ffd6959275a840254c9ddc9ab0cc5edd6f7950f1b71103d772ac5a17ca988d",
-			VulnHashInvalid: "7ebe9a1e2b39735edcae2f576f31ea4779b5eb9300064e3ebb351069fdd01ed3",
+			VulnHash: "54a8a3798eaaf1d6ae7e5f1e8ea21af7b65c00d15ce52bac5e457aeb4961eb30",
+			DeprecatedHashes: []string{
+				"7ebe9a1e2b39735edcae2f576f31ea4779b5eb9300064e3ebb351069fdd01ed3",
+				"b9ffd6959275a840254c9ddc9ab0cc5edd6f7950f1b71103d772ac5a17ca988d",
+			},
 		},
 	}
 

--- a/internal/utils/vuln_hash/vuln_hash_test.go
+++ b/internal/utils/vuln_hash/vuln_hash_test.go
@@ -32,8 +32,9 @@ func TestBind(t *testing.T) {
 
 	Bind(&vuln)
 
-	assert.Equal(t, "278facfff87828631a37b27d76d1a926bed37466b05cab7d365d7f5c7345ac6d", vuln.VulnHash)
-	assert.Equal(t, "751cf1c4e4f0fbf59777eea1d14c062b913a57fd3c0e457400ec134577c89686", vuln.VulnHashInvalid)
+	assert.Equal(t, "468865c64851037b2f8b9a8954de9d884d08cdf14e6f841072b85f7ac03ecc5e", vuln.VulnHash)
+	assert.Equal(t, "751cf1c4e4f0fbf59777eea1d14c062b913a57fd3c0e457400ec134577c89686", vuln.DeprecatedHashes[0])
+	assert.Equal(t, "278facfff87828631a37b27d76d1a926bed37466b05cab7d365d7f5c7345ac6d", vuln.DeprecatedHashes[1])
 }
 
 func TestToOneLine(t *testing.T) {


### PR DESCRIPTION
Currently cli generates very volatile hashes, any commit, description
changes will change the hash, wich is a problem to the vulnerabilities
management. This pull request changes the way that we generate the hash
to use only the code, line and file, this way we expect that the hash
will be more estable. In this pull request we also added a tratative to
handle with the future depreciation of the old hashes that we still
consider valid. So all users should update the oldated hashes, the cli
is going to show a warning with the necessary hashes to update and the
new ones.

Signed-off-by: Nathan Martins <nathan.martins@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
