### PR TITLE
deps:chore - update dependency mcr.microsoft.com/dotnet/sdk to v6

### DIFF
--- a/internal/services/engines/jvm/rules_test.go
+++ b/internal/services/engines/jvm/rules_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	engine "github.com/ZupIT/horusec-engine"
+
 	"github.com/ZupIT/horusec/internal/utils/testutil"
 )
 

--- a/internal/services/formatters/csharp/deployments/Dockerfile
+++ b/internal/services/formatters/csharp/deployments/Dockerfile
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine
+FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine
 
 RUN apk add jq
 
-RUN dotnet tool install --global security-scan --version 5.2.2
+RUN dotnet tool install --global security-scan --version 5.6.0
 
 ENV PATH="$PATH:/root/.dotnet/tools"

--- a/internal/services/formatters/csharp/scs/config.go
+++ b/internal/services/formatters/csharp/scs/config.go
@@ -14,10 +14,11 @@
 
 package scs
 
+// nolint:lll // necessary to be long
 const CMD = `
 		{{WORK_DIR}}
 		dotnet restore > /tmp/restore-output-ANALYSISID.txt
-		security-scan {{SLN_NAME}} --export=output-ANALYSISID.json > /tmp/scs-run-output-ANALYSISID.txt
+		security-scan {{SLN_NAME}} --ignore-msbuild-errors --export=output-ANALYSISID.json &> /tmp/scs-run-output-ANALYSISID.txt
 		cat output-ANALYSISID.json
 		chmod -R 777 .
   `


### PR DESCRIPTION
Originally this pr was open by renovate to update the dotnet to the
version 7.0, but the security code scan sill don't support it. So
I had downgraded it to 6.0. Also added a new flag --ignore-msbuild-errors
to avoid some uncessary errors during the analysis.

Signed-off-by: Nathan Martins <nathan.martins@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
