### PR TITLE
analyzer:bugfix - separate warnings from errors

### DIFF
--- a/internal/controllers/printresults/print_results.go
+++ b/internal/controllers/printresults/print_results.go
@@ -376,16 +376,8 @@ func (pr *PrintResults) checkIfExistsErrorsInAnalysis() {
 	}
 }
 
-func (pr *PrintResults) printErrors(errorMessage string) {
-	if strings.Contains(errorMessage, messages.MsgErrorPacketJSONNotFound) ||
-		strings.Contains(errorMessage, messages.MsgErrorYarnLockNotFound) ||
-		strings.Contains(errorMessage, messages.MsgErrorGemLockNotFound) ||
-		strings.Contains(errorMessage, messages.MsgErrorNotFoundRequirementsTxt) {
-		logger.LogWarnWithLevel(strings.ReplaceAll(errorMessage, ";", ""))
-		return
-	}
-
-	logger.LogStringAsError(strings.ReplaceAll(errorMessage, ";", ""))
+func (pr *PrintResults) printErrors(err string) {
+	logger.LogStringAsError(strings.ReplaceAll(err, ";", ""))
 }
 
 func (pr *PrintResults) printResponseAnalysis() {


### PR DESCRIPTION
Both errors and warnings are handled using the same field, this causes a
lot of confusion and a very complex code.
This pull request removes warnings from the errors field, and adds them
to the specific field for warnings. In the future with the refactoring
of formaters this code can be removed, but for now it is a necessary
workaround.

Signed-off-by: Nathan Martins <nathan.martins@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
