### PR TITLE
sarif:bugfix - removing version prefix

### DIFF
--- a/internal/services/sarif/sarif.go
+++ b/internal/services/sarif/sarif.go
@@ -121,7 +121,7 @@ func (s *Sarif) newTool(vulnerabilityy *vulnerability.Vulnerability) ScanTool {
 		Driver: ScanToolDriver{
 			Name:               vulnerabilityy.SecurityTool.ToString(),
 			MoreInformationURI: "https://docs.horusec.io/docs/cli/analysis-tools/overview/",
-			Version:            version.Version,
+			Version:            s.getVersionWithoutPrefix(),
 		},
 	}
 }
@@ -189,4 +189,8 @@ func (s *Sarif) getSarifSeverityMap() map[severities.Severity]string {
 		severities.Unknown:  Note,
 		severities.Info:     Note,
 	}
+}
+
+func (s *Sarif) getVersionWithoutPrefix() string {
+	return strings.ReplaceAll(version.Version, "v", "")
 }


### PR DESCRIPTION
Sarif validator reports an error if the version contains the v prefix.
This pull request remove this prefix for the sarif output.

Signed-off-by: Nathan Martins <nathan.martins@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
