### PR TITLE
formatters/ruby:chore - removing unnecessary error messages

### DIFF
--- a/internal/controllers/analyzer/analyzer.go
+++ b/internal/controllers/analyzer/analyzer.go
@@ -448,9 +448,12 @@ func (a *Analyzer) removeWarningsFromErrors() {
 }
 
 // isWarning workaround to check if the message it's form a warning until the formatters are refactored
+// nolint:gocyclo // necessary complexity, but will be removed in the future
 func (a *Analyzer) isWarning(err string) bool {
 	return strings.Contains(err, messages.MsgErrorPackageLockJSONNotFound) ||
 		strings.Contains(err, messages.MsgErrorYarnLockNotFound) ||
 		strings.Contains(err, messages.MsgErrorNotFoundRequirementsTxt) ||
-		strings.Contains(err, messages.MsgWarnPathIsInvalidGitRepository)
+		strings.Contains(err, messages.MsgWarnPathIsInvalidGitRepository) ||
+		strings.Contains(err, messages.MsgWarnBrakemanNotRubyOnRailsProject) ||
+		strings.Contains(err, messages.MsgWarnGemfileIsRequiredForBundler)
 }

--- a/internal/helpers/messages/warn.go
+++ b/internal/helpers/messages/warn.go
@@ -55,5 +55,7 @@ const (
 	// TODO: Remove MsgWarnAnalysisContainsOutdatedHash before release v2.10.0
 	MsgWarnAnalysisContainsOutdatedHash = "{HORUSEC_CLI} YOUR CONFIGURATION FILE CONTAINS SOME HASHES THAT WILL NO " +
 		"LONGER BE VALID AS OF v2.10.0 IS RELEASED. PLEASE UPDATE YOUR CONFIGURATION FILE WITH THE FOLLOWING HASHES:"
-	MsgWarnPathIsInvalidGitRepository = "{HORUSEC_CLI} The current path it's not a valid git repository"
+	MsgWarnPathIsInvalidGitRepository    = "{HORUSEC_CLI} The current path it's not a valid git repository"
+	MsgWarnBrakemanNotRubyOnRailsProject = "brakeman only works on Ruby On Rails project"
+	MsgWarnGemfileIsRequiredForBundler   = "Gemfile.lock file is required to execute Bundler analysis"
 )

--- a/internal/services/formatters/ruby/brakeman/formatter.go
+++ b/internal/services/formatters/ruby/brakeman/formatter.go
@@ -42,7 +42,7 @@ const (
 	notFoundError = "please supply the path to a rails application"
 )
 
-var ErrNotFoundRailsProject = errors.New("brakeman only works on Ruby On Rails project")
+var ErrNotFoundRailsProject = errors.New(messages.MsgWarnBrakemanNotRubyOnRailsProject)
 
 type Formatter struct {
 	formatters.IService

--- a/internal/services/formatters/ruby/bundler/formatter.go
+++ b/internal/services/formatters/ruby/bundler/formatter.go
@@ -41,7 +41,7 @@ import (
 // nolint: stylecheck
 // We actually want that this error message be capitalized since the file name that was
 // not found is capitalized.
-var ErrGemLockNotFound = errors.New("Gemfile.lock file is required to execute Bundler analysis")
+var ErrGemLockNotFound = errors.New(messages.MsgWarnGemfileIsRequiredForBundler)
 
 type Formatter struct {
 	formatters.IService


### PR DESCRIPTION
Previously if the project had ruby between programming languages but is
not a ruby on rails project or does not have a Gemfile.lock an error
would be reported for each scenario.

This pull request changes these error messages introduced in commits
cd839ef and 9245d7d to be considered just warnings, as there is no
need to point them out as errors, since it is only intended to
inform the user.

Signed-off-by: Nathan Martins <nathan.martins@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
