### PR TITLE
goreleaser:bugfix - adding release auto

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -101,6 +101,7 @@ checksum:
   name_template: 'checksums.txt'
 release:
   draft: false
+  prerelease: auto
   mode: append
   footer: |
     ## Docker images


### PR DESCRIPTION
Before every release was released as a draft, in this way it was
possible to define which releases should be published as a pre release
and which not. After pull request 578e883, all releases are published
directly without the possibility to define betas and rcs as pre
releases.

This pull request changes the goreleaser configuration file to
automatically define which ones should be published as pre releases.
For this the pre release:auto attribute was added, for more information
follow the documentation link
https://goreleaser.com/customization/release/?h=release#release.

Signed-off-by: Nathan Martins <nathan.martins@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
