### PR TITLE
[feature][ghaction] Added support for scanning Github Workflow files.

### DIFF
--- a/internal/services/engines/kubernetes/rule_manager.go
+++ b/internal/services/engines/kubernetes/rule_manager.go
@@ -45,5 +45,8 @@ func Rules() []engine.Rule {
 
 		// Or rules
 		NewSeccompUnconfined(),
+
+		// Github Actions Rules
+		NewGHActionsSensitiveInformationExposureWithEcho(),
 	}
 }

--- a/internal/services/engines/kubernetes/rules.go
+++ b/internal/services/engines/kubernetes/rules.go
@@ -197,3 +197,21 @@ func NewHostNetwork() *text.Rule {
 		},
 	}
 }
+
+func NewGHActionsSensitiveInformationExposureWithEcho() *text.Rule {
+	return &text.Rule{
+		Metadata: engine.Metadata{
+			ID:            "HS-GHACTION-1",
+			Name:          "Logging of sensitive information",
+			Description:   "Sensitive information could be exposed on action Logs.",
+			Severity:      severities.Critical.ToString(),
+			Confidence:    confidence.High.ToString(),
+			SafeExample:   SampleSafeHSGHACTION1,
+			UnsafeExample: SampleVulnerableHSGHACTION1,
+		},
+		Type: text.Regular,
+		Expressions: []*regexp.Regexp{
+			regexp.MustCompile(`(echo|print)\D*\${{(\D*secrets.\D*)}}`),
+		},
+	}
+}

--- a/internal/services/engines/kubernetes/rules_test.go
+++ b/internal/services/engines/kubernetes/rules_test.go
@@ -170,6 +170,22 @@ func TestRulesVulnerableCode(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name:     "HS-GHACTION-1",
+			Rule:     NewGHActionsSensitiveInformationExposureWithEcho(),
+			Src:      SampleVulnerableHSGHACTION1,
+			Filename: filepath.Join(tempDir, "HS-GHACTION-1.test"),
+			Findings: []engine.Finding{
+				{
+					CodeSample: `run: echo ${{ secrets.TOKEN }}`,
+					SourceLocation: engine.Location{
+						Filename: filepath.Join(tempDir, "HS-GHACTION-1.test"),
+						Line:     14,
+						Column:   13,
+					},
+				},
+			},
+		},
 	}
 
 	testutil.TestVulnerableCode(t, testcases)
@@ -231,6 +247,12 @@ func TestRulesSafeCode(t *testing.T) {
 			Rule:     NewHostNetwork(),
 			Src:      SampleSafeHSKUBERNETES9,
 			Filename: filepath.Join(tempDir, "HS-KUBERNETES-9.test"),
+		},
+		{
+			Name:     "HS-GHACTION-1",
+			Rule:     NewGHActionsSensitiveInformationExposureWithEcho(),
+			Src:      SampleSafeHSGHACTION1,
+			Filename: filepath.Join(tempDir, "HS-GHACTION-1.test"),
 		},
 	}
 

--- a/internal/services/engines/kubernetes/samples.go
+++ b/internal/services/engines/kubernetes/samples.go
@@ -318,4 +318,34 @@ spec:
     max: 65535
   hostNetwork: false
 `
+	SampleVulnerableHSGHACTION1 = `
+name: Github Workflow
+on:
+  push:
+    branches: [ production ]
+jobs:
+  # Deploy to production
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Database logs
+        run: echo ${{ secrets.TOKEN }}
+`
+	SampleSafeHSGHACTION1 = `
+name: Github Workflow
+on:
+  push:
+    branches: [ production ]
+jobs:
+  # Deploy to production
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Database logs
+        run: echo "Don't log secret value"
+`
 )

--- a/internal/services/engines/rules_test.go
+++ b/internal/services/engines/rules_test.go
@@ -57,7 +57,7 @@ func TestGetRules(t *testing.T) {
 		{
 			engine:             "Kubernetes",
 			manager:            kubernetes.NewRules(),
-			expectedTotalRules: 9,
+			expectedTotalRules: 10,
 		},
 		{
 			engine:             "Kotlin",


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
Created a whole new category of rules for Github Actions. They use YAML just like Kubernetes and have a single rule to point out the use of **echo** to print values from **github secrets**.

**- How to verify it**
Create a test-folder.

```
mkdir test-horusec
cd test-horusec
```

Create a github workflow folder:

```
mkdir .github/workflows/
touch .github/workflows/workflow.yaml
```

Add this block to the workflow.yaml file:

```
name: Github Workflow
on:
  push:
    branches: [ production ]
jobs:
  # Deploy to production
  build:
    name: Build
    runs-on: ubuntu-latest
    
    steps:
      - name: Database logs
        run: echo ${{ secrets.TOKEN }}
     - name: Another step
       run: some command.
```
Executing horusec should point out one vulnerability HS-GHACTION-1.

**- Description for the changelog**
Created the github action rules, rules_manager, sample, test, formatter and edited the language_detect.go and runner.go files to support this modification.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
