### PR TITLE
Feature/privacy leaks

### DIFF
--- a/internal/services/engines/leaks/rule_manager.go
+++ b/internal/services/engines/leaks/rule_manager.go
@@ -60,5 +60,13 @@ func Rules() []engine.Rule {
 		NewHardCodedPassword(),
 		NewPasswordExposedInHardcodedURL(),
 		NewWPConfig(),
+
+		// privacy rules
+
+		// Regular rules
+		BrPrivacyLawHardCodedUserData(),
+
+		// Or rules
+		BrPrivacyLawExposureOfUserData(),
 	}
 }

--- a/internal/services/engines/leaks/rule_manager.go
+++ b/internal/services/engines/leaks/rule_manager.go
@@ -62,11 +62,7 @@ func Rules() []engine.Rule {
 		NewWPConfig(),
 
 		// privacy rules
-
-		// Regular rules
 		BrPrivacyLawHardCodedUserData(),
-
-		// Or rules
 		BrPrivacyLawExposureOfUserData(),
 	}
 }

--- a/internal/services/engines/leaks/rules.go
+++ b/internal/services/engines/leaks/rules.go
@@ -536,3 +536,40 @@ func NewWPConfig() *text.Rule {
 		},
 	}
 }
+
+func BrPrivacyLawExposureOfUserData() *text.Rule {
+	return &text.Rule{
+		Metadata: engine.Metadata{
+			ID:            "HS-PRIVACY-1",
+			Name:          "Exposure of User private Data",
+			Description:   "Brazilian Privacy Law (LGPD) prevents users IDs (cpf, rg) to be exposed in applications.",
+			Severity:      severities.High.ToString(),
+			Confidence:    confidence.Medium.ToString(),
+			SafeExample:   SampleSafeHSPRIVACY1,
+			UnsafeExample: SampleVulnerableHSPRIVACY1,
+		},
+		Type: text.Regular,
+		Expressions: []*regexp.Regexp{
+			regexp.MustCompile(`(?i)\(*[\"\']?(cpf|rg)[:]\s*[%A-Za-z]*[\"\']?\s[%+,.format(]\s(client|user)?[.]?(doc|document)`),
+		},
+	}
+}
+
+func BrPrivacyLawHardCodedUserData() *text.Rule {
+	return &text.Rule{
+		Metadata: engine.Metadata{
+			ID:            "HS-PRIVACY-2",
+			Name:          "Hardcoded User Data related to Brazilian Privacy Law",
+			Description:   "Brazilian Privacy Law (LGPD) prevents user's data to be hardcoded in applications code.",
+			Severity:      severities.High.ToString(),
+			Confidence:    confidence.Medium.ToString(),
+			SafeExample:   SampleSafeHSPRIVACY2,
+			UnsafeExample: SampleVulnerableHSPRIVACY2,
+		},
+		Type: text.Regular,
+		Expressions: []*regexp.Regexp{
+			regexp.MustCompile(`(?i)[\"\']?(cpf|rg)+[\"\']?\W?[:=]\W?[\"\']?[0-9.-]+[\"\']?`),
+		},
+	}
+
+}

--- a/internal/services/engines/leaks/rules_test.go
+++ b/internal/services/engines/leaks/rules_test.go
@@ -698,7 +698,7 @@ func TestRulesSafeCode(t *testing.T) {
 		},
 		{
 			Name:     "HS-PRIVACY-2",
-			Rule:     BrPrivacyLawExposureOfUserData(),
+			Rule:     BrPrivacyLawHardCodedUserData(),
 			Src:      SampleSafeHSPRIVACY2,
 			Filename: filepath.Join(tempDir, "HS-PRIVACY-2.test"),
 		},

--- a/internal/services/engines/leaks/rules_test.go
+++ b/internal/services/engines/leaks/rules_test.go
@@ -482,6 +482,38 @@ func TestRulesVulnerableCode(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name:     "HS-PRIVACY-1",
+			Rule:     BrPrivacyLawExposureOfUserData(),
+			Src:      SampleVulnerableHSPRIVACY1,
+			Filename: filepath.Join(tempDir, "HS-PRIVACY-1.test"),
+			Findings: []engine.Finding{
+				{
+					CodeSample: `console.log("CPF: " + client.document);`,
+					SourceLocation: engine.Location{
+						Filename: filepath.Join(tempDir, "HS-PRIVACY-1.test"),
+						Line:     2,
+						Column:   11,
+					},
+				},
+			},
+		},
+		{
+			Name:     "HS-PRIVACY-2",
+			Rule:     BrPrivacyLawHardCodedUserData(),
+			Src:      SampleVulnerableHSPRIVACY2,
+			Filename: filepath.Join(tempDir, "HS-PRIVACY-2.test"),
+			Findings: []engine.Finding{
+				{
+					CodeSample: `"cpf": "123.456.789-10"`,
+					SourceLocation: engine.Location{
+						Filename: filepath.Join(tempDir, "HS-PRIVACY-2.test"),
+						Line:     3,
+						Column:   2,
+					},
+				},
+			},
+		},
 	}
 
 	testutil.TestVulnerableCode(t, testcases)
@@ -657,6 +689,18 @@ func TestRulesSafeCode(t *testing.T) {
 			Rule:     NewWPConfig(),
 			Src:      SampleSafeHSLEAKS28,
 			Filename: filepath.Join(tempDir, "HS-LEAKS-28.test"),
+		},
+		{
+			Name:     "HS-PRIVACY-1",
+			Rule:     BrPrivacyLawExposureOfUserData(),
+			Src:      SampleSafeHSPRIVACY1,
+			Filename: filepath.Join(tempDir, "HS-PRIVACY-1.test"),
+		},
+		{
+			Name:     "HS-PRIVACY-2",
+			Rule:     BrPrivacyLawExposureOfUserData(),
+			Src:      SampleSafeHSPRIVACY2,
+			Filename: filepath.Join(tempDir, "HS-PRIVACY-2.test"),
 		},
 	}
 	testutil.TestSafeCode(t, testcases)

--- a/internal/services/engines/leaks/samples.go
+++ b/internal/services/engines/leaks/samples.go
@@ -538,7 +538,7 @@ define('AUTH_KEY', getenv("AUTH_KEY"));
 console.log("CPF: " + client.document);
 `
 
-	SampleSafeHSPRIVACY1 = `Don't log private/sensible data`
+	SampleSafeHSPRIVACY1 = `Don't log/print sensible data`
 
 	SampleVulnerableHSPRIVACY2 = `
 client = {

--- a/internal/services/engines/leaks/samples.go
+++ b/internal/services/engines/leaks/samples.go
@@ -533,4 +533,22 @@ define('DB_PASSWORD', 'wen0221!');
 <?php
 define('AUTH_KEY', getenv("AUTH_KEY"));
 `
+
+	SampleVulnerableHSPRIVACY1 = `
+console.log("CPF: " + client.document);
+`
+
+	SampleSafeHSPRIVACY1 = `Don't log private/sensible data`
+
+	SampleVulnerableHSPRIVACY2 = `
+client = {
+  "cpf": "123.456.789-10"
+}
+`
+
+	SampleSafeHSPRIVACY2 = `
+client = {
+  "doc": json.loads(r.content)['doc']
+}
+`
 )

--- a/internal/services/engines/rules_test.go
+++ b/internal/services/engines/rules_test.go
@@ -52,7 +52,7 @@ func TestGetRules(t *testing.T) {
 		{
 			engine:             "Leaks",
 			manager:            leaks.NewRules(),
-			expectedTotalRules: 28,
+			expectedTotalRules: 30,
 		},
 		{
 			engine:             "Kubernetes",

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,5035 @@
+?   	github.com/ZupIT/horusec/cmd/app	[no test files]
+=== RUN   TestGenerate_CreateCobraCmd
+=== RUN   TestGenerate_CreateCobraCmd/Should_create_file_with_default_configuration
+=== RUN   TestGenerate_CreateCobraCmd/Should_update_file_already_exists_with_default_configuration
+--- PASS: TestGenerate_CreateCobraCmd (0.01s)
+    --- PASS: TestGenerate_CreateCobraCmd/Should_create_file_with_default_configuration (0.01s)
+    --- PASS: TestGenerate_CreateCobraCmd/Should_update_file_already_exists_with_default_configuration (0.01s)
+PASS
+ok  	github.com/ZupIT/horusec/cmd/app/generate	0.043s
+=== RUN   TestNewStartCommand
+=== RUN   TestNewStartCommand/Should_run_NewStartCommand_and_return_type_correctly
+=== RUN   TestNewStartCommand/Should_run_NewStartCommand_and_return_have_expected_flags
+time="2022-07-26T18:08:39-03:00" level=warning msg="{HORUSEC_CLI} Config file not found"
+--- PASS: TestNewStartCommand (0.01s)
+    --- PASS: TestNewStartCommand/Should_run_NewStartCommand_and_return_type_correctly (0.00s)
+    --- PASS: TestNewStartCommand/Should_run_NewStartCommand_and_return_have_expected_flags (0.00s)
+=== RUN   TestStartCommand_ExecuteUnitTests
+=== RUN   TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_without_error_and_ask_to_user_if_is_to_run_in_current_directory
+time="2022-07-26T18:08:39-03:00" level=warning msg="{HORUSEC_CLI} Config file not found"
+=== RUN   TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_without_error_and_not_ask_if_is_to_run_in_current_directory
+time="2022-07-26T18:08:39-03:00" level=warning msg="{HORUSEC_CLI} Config file not found"
+=== RUN   TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_and_return_error_because_found_vulnerabilities_(-p,-e)
+time="2022-07-26T18:08:39-03:00" level=warning msg="{HORUSEC_CLI} Config file not found"
+Error: analysis finished with blocking vulnerabilities
+
+=== RUN   TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_and_return_error_because_found_error_when_ask_but_run_in_current_folder
+time="2022-07-26T18:08:39-03:00" level=warning msg="{HORUSEC_CLI} Config file not found"
+time="2022-07-26T18:08:39-03:00" level=warning msg="{HORUSEC_CLI} Error when ask if can run prompt question.: \nPlease use the command below informing the directory you want to run the analysis: \nhorusec start -p ./[some error]"
+Error: some error
+Usage:
+  start [flags]
+
+Examples:
+horusec start
+
+Flags:
+  -t, --analysis-timeout int                 The timeout threshold for the Horusec CLI wait for the analysis to complete. The minimum time is 10 (default 600)
+  -a, --authorization string                 Authorization token to use on Horusec server. Read more: https://docs.horusec.io/docs/tutorials/how-to-create-an-authorization-token (default "00000000-0000-0000-0000-000000000000")
+  -C, --certificate-path string              Path to certificate of authority. Example -C="example/ca.crt"
+  -P, --container-bind-project-path string   Project path in host to be used on Docker when running Horusec inside a container
+  -c, --custom-rules-path string             Path with custom rules that should be used by Horusec engine
+  -D, --disable-docker                       Run Horusec without docker. If enabled it will only run the following tools: horusec-csharp, horusec-kotlin, horusec-java, horusec-kubernetes, horusec-leaks, horusec-javascript, horusec-dart, horusec-nginx
+  -G, --enable-commit-author                 Enable to search commit author of vulnerabilities
+      --enable-git-history                   Run Gitleaks and search for vulnerabilities in all git history of the project https://github.com/zricethezav/gitleaks
+  -w, --enable-owasp-dependency-check        Run Owasp Dependency Check tool https://github.com/jeremylong/DependencyCheck
+  -j, --enable-shellcheck                    Run ShellCheck tool https://github.com/koalaman/shellcheck
+  -F, --false-positive strings               Ignore a vulnerability by hash and set it to be false positive. Example -F="hash1, hash2"
+      --headers stringToString               Custom headers to send on request to Horusec API. Example --headers='{"X-Auth-Service": "value"}' (default [])
+  -h, --help                                 help for start
+  -u, --horusec-url string                   The Horusec server address to send analysis results (default "http://0.0.0.0:8000")
+  -i, --ignore strings                       Paths to ignore in the analysis. Example: -i="/path/to/ignore, **/*_test.go, **/assets/**" (default [*tmp*,**/.vscode/**])
+  -s, --ignore-severity strings              The level of vulnerabilities to ignore in the output ("LOW"|"MEDIUM"|"HIGH"). Example: -s="LOW, HIGH" (default [INFO])
+  -I, --information-severity                 Enable information severity vulnerabilities. Information vulnerabilities can contain a lot of false positives
+  -S, --insecure-skip-verify                 Disable the certification validation. PLEASE, try not to use it
+  -O, --json-output-file string              Output file to write analysis result. This flag should be used with --output-format
+  -o, --output-format string                 Output format of analysis ("text"|"json"|"sarif"|"sonarqube"). For json, sarif, and sonarqube --json-output-file is required
+  -p, --project-path string                  Path to run an analysis. If this value is not passed, Horusec will ask if you want to run the analysis in the current directory (default "/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/cmd/app/start")
+  -n, --repository-name string               Send repository name to Horusec server, by default sends the actual directory name (default "start")
+  -r, --request-timeout int                  The timeout threshold for the request to the Horusec server. The minimum time is 10 (default 300)
+  -e, --return-error                         Return exit code 1 if found vulnerabilities. Default value is false (exit code 0)
+  -R, --risk-accept strings                  Ignore a vulnerability by hash and set it to be risk accept. Example -R="hash1, hash2"
+      --show-vulnerabilities-types strings   Show vulnerabilities by types ("Vulnerability"|"Risk Accepted"|"False Positive"|"Corrected"). Example --show-vulnerabilities-types="Vulnerability, Risk Accepted" (default [Vulnerability])
+
+=== RUN   TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_without_error_and_validate_if_git_is_installed(--enable-git-history)
+time="2022-07-26T18:08:39-03:00" level=warning msg="{HORUSEC_CLI} Config file not found"
+=== RUN   TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_with_error_when_validate_if_git_is_installed(--enable-git-history)
+time="2022-07-26T18:08:39-03:00" level=warning msg="{HORUSEC_CLI} Config file not found"
+Error: some error
+Usage:
+  start [flags]
+
+Examples:
+horusec start
+
+Flags:
+  -t, --analysis-timeout int                 The timeout threshold for the Horusec CLI wait for the analysis to complete. The minimum time is 10 (default 600)
+  -a, --authorization string                 Authorization token to use on Horusec server. Read more: https://docs.horusec.io/docs/tutorials/how-to-create-an-authorization-token (default "00000000-0000-0000-0000-000000000000")
+  -C, --certificate-path string              Path to certificate of authority. Example -C="example/ca.crt"
+  -P, --container-bind-project-path string   Project path in host to be used on Docker when running Horusec inside a container
+  -c, --custom-rules-path string             Path with custom rules that should be used by Horusec engine
+  -D, --disable-docker                       Run Horusec without docker. If enabled it will only run the following tools: horusec-csharp, horusec-kotlin, horusec-java, horusec-kubernetes, horusec-leaks, horusec-javascript, horusec-dart, horusec-nginx
+  -G, --enable-commit-author                 Enable to search commit author of vulnerabilities
+      --enable-git-history                   Run Gitleaks and search for vulnerabilities in all git history of the project https://github.com/zricethezav/gitleaks
+  -w, --enable-owasp-dependency-check        Run Owasp Dependency Check tool https://github.com/jeremylong/DependencyCheck
+  -j, --enable-shellcheck                    Run ShellCheck tool https://github.com/koalaman/shellcheck
+  -F, --false-positive strings               Ignore a vulnerability by hash and set it to be false positive. Example -F="hash1, hash2"
+      --headers stringToString               Custom headers to send on request to Horusec API. Example --headers='{"X-Auth-Service": "value"}' (default [])
+  -h, --help                                 help for start
+  -u, --horusec-url string                   The Horusec server address to send analysis results (default "http://0.0.0.0:8000")
+  -i, --ignore strings                       Paths to ignore in the analysis. Example: -i="/path/to/ignore, **/*_test.go, **/assets/**" (default [*tmp*,**/.vscode/**])
+  -s, --ignore-severity strings              The level of vulnerabilities to ignore in the output ("LOW"|"MEDIUM"|"HIGH"). Example: -s="LOW, HIGH" (default [INFO])
+  -I, --information-severity                 Enable information severity vulnerabilities. Information vulnerabilities can contain a lot of false positives
+  -S, --insecure-skip-verify                 Disable the certification validation. PLEASE, try not to use it
+  -O, --json-output-file string              Output file to write analysis result. This flag should be used with --output-format
+  -o, --output-format string                 Output format of analysis ("text"|"json"|"sarif"|"sonarqube"). For json, sarif, and sonarqube --json-output-file is required
+  -p, --project-path string                  Path to run an analysis. If this value is not passed, Horusec will ask if you want to run the analysis in the current directory (default "/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/cmd/app/start")
+  -n, --repository-name string               Send repository name to Horusec server, by default sends the actual directory name (default "start")
+  -r, --request-timeout int                  The timeout threshold for the request to the Horusec server. The minimum time is 10 (default 300)
+  -e, --return-error                         Return exit code 1 if found vulnerabilities. Default value is false (exit code 0)
+  -R, --risk-accept strings                  Ignore a vulnerability by hash and set it to be risk accept. Example -R="hash1, hash2"
+      --show-vulnerabilities-types strings   Show vulnerabilities by types ("Vulnerability"|"Risk Accepted"|"False Positive"|"Corrected"). Example --show-vulnerabilities-types="Vulnerability, Risk Accepted" (default [Vulnerability])
+
+=== RUN   TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_with_error_when_validate_if_docker_is_installed
+time="2022-07-26T18:08:39-03:00" level=warning msg="{HORUSEC_CLI} Config file not found"
+Error: some error
+Usage:
+  start [flags]
+
+Examples:
+horusec start
+
+Flags:
+  -t, --analysis-timeout int                 The timeout threshold for the Horusec CLI wait for the analysis to complete. The minimum time is 10 (default 600)
+  -a, --authorization string                 Authorization token to use on Horusec server. Read more: https://docs.horusec.io/docs/tutorials/how-to-create-an-authorization-token (default "00000000-0000-0000-0000-000000000000")
+  -C, --certificate-path string              Path to certificate of authority. Example -C="example/ca.crt"
+  -P, --container-bind-project-path string   Project path in host to be used on Docker when running Horusec inside a container
+  -c, --custom-rules-path string             Path with custom rules that should be used by Horusec engine
+  -D, --disable-docker                       Run Horusec without docker. If enabled it will only run the following tools: horusec-csharp, horusec-kotlin, horusec-java, horusec-kubernetes, horusec-leaks, horusec-javascript, horusec-dart, horusec-nginx
+  -G, --enable-commit-author                 Enable to search commit author of vulnerabilities
+      --enable-git-history                   Run Gitleaks and search for vulnerabilities in all git history of the project https://github.com/zricethezav/gitleaks
+  -w, --enable-owasp-dependency-check        Run Owasp Dependency Check tool https://github.com/jeremylong/DependencyCheck
+  -j, --enable-shellcheck                    Run ShellCheck tool https://github.com/koalaman/shellcheck
+  -F, --false-positive strings               Ignore a vulnerability by hash and set it to be false positive. Example -F="hash1, hash2"
+      --headers stringToString               Custom headers to send on request to Horusec API. Example --headers='{"X-Auth-Service": "value"}' (default [])
+  -h, --help                                 help for start
+  -u, --horusec-url string                   The Horusec server address to send analysis results (default "http://0.0.0.0:8000")
+  -i, --ignore strings                       Paths to ignore in the analysis. Example: -i="/path/to/ignore, **/*_test.go, **/assets/**" (default [*tmp*,**/.vscode/**])
+  -s, --ignore-severity strings              The level of vulnerabilities to ignore in the output ("LOW"|"MEDIUM"|"HIGH"). Example: -s="LOW, HIGH" (default [INFO])
+  -I, --information-severity                 Enable information severity vulnerabilities. Information vulnerabilities can contain a lot of false positives
+  -S, --insecure-skip-verify                 Disable the certification validation. PLEASE, try not to use it
+  -O, --json-output-file string              Output file to write analysis result. This flag should be used with --output-format
+  -o, --output-format string                 Output format of analysis ("text"|"json"|"sarif"|"sonarqube"). For json, sarif, and sonarqube --json-output-file is required
+  -p, --project-path string                  Path to run an analysis. If this value is not passed, Horusec will ask if you want to run the analysis in the current directory (default "/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/cmd/app/start")
+  -n, --repository-name string               Send repository name to Horusec server, by default sends the actual directory name (default "start")
+  -r, --request-timeout int                  The timeout threshold for the request to the Horusec server. The minimum time is 10 (default 300)
+  -e, --return-error                         Return exit code 1 if found vulnerabilities. Default value is false (exit code 0)
+  -R, --risk-accept strings                  Ignore a vulnerability by hash and set it to be risk accept. Example -R="hash1, hash2"
+      --show-vulnerabilities-types strings   Show vulnerabilities by types ("Vulnerability"|"Risk Accepted"|"False Positive"|"Corrected"). Example --show-vulnerabilities-types="Vulnerability, Risk Accepted" (default [Vulnerability])
+
+=== RUN   TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_without_error_and_not_ask_because_is_different_project_path(-p,_-e)
+time="2022-07-26T18:08:39-03:00" level=warning msg="{HORUSEC_CLI} Config file not found"
+=== RUN   TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_and_return_error_because_found_not_accept_proceed
+time="2022-07-26T18:08:39-03:00" level=warning msg="{HORUSEC_CLI} Config file not found"
+Error: {HORUSEC_CLI} Operation was canceled by user
+Usage:
+  start [flags]
+
+Examples:
+horusec start
+
+Flags:
+  -t, --analysis-timeout int                 The timeout threshold for the Horusec CLI wait for the analysis to complete. The minimum time is 10 (default 600)
+  -a, --authorization string                 Authorization token to use on Horusec server. Read more: https://docs.horusec.io/docs/tutorials/how-to-create-an-authorization-token (default "00000000-0000-0000-0000-000000000000")
+  -C, --certificate-path string              Path to certificate of authority. Example -C="example/ca.crt"
+  -P, --container-bind-project-path string   Project path in host to be used on Docker when running Horusec inside a container
+  -c, --custom-rules-path string             Path with custom rules that should be used by Horusec engine
+  -D, --disable-docker                       Run Horusec without docker. If enabled it will only run the following tools: horusec-csharp, horusec-kotlin, horusec-java, horusec-kubernetes, horusec-leaks, horusec-javascript, horusec-dart, horusec-nginx
+  -G, --enable-commit-author                 Enable to search commit author of vulnerabilities
+      --enable-git-history                   Run Gitleaks and search for vulnerabilities in all git history of the project https://github.com/zricethezav/gitleaks
+  -w, --enable-owasp-dependency-check        Run Owasp Dependency Check tool https://github.com/jeremylong/DependencyCheck
+  -j, --enable-shellcheck                    Run ShellCheck tool https://github.com/koalaman/shellcheck
+  -F, --false-positive strings               Ignore a vulnerability by hash and set it to be false positive. Example -F="hash1, hash2"
+      --headers stringToString               Custom headers to send on request to Horusec API. Example --headers='{"X-Auth-Service": "value"}' (default [])
+  -h, --help                                 help for start
+  -u, --horusec-url string                   The Horusec server address to send analysis results (default "http://0.0.0.0:8000")
+  -i, --ignore strings                       Paths to ignore in the analysis. Example: -i="/path/to/ignore, **/*_test.go, **/assets/**" (default [*tmp*,**/.vscode/**])
+  -s, --ignore-severity strings              The level of vulnerabilities to ignore in the output ("LOW"|"MEDIUM"|"HIGH"). Example: -s="LOW, HIGH" (default [INFO])
+  -I, --information-severity                 Enable information severity vulnerabilities. Information vulnerabilities can contain a lot of false positives
+  -S, --insecure-skip-verify                 Disable the certification validation. PLEASE, try not to use it
+  -O, --json-output-file string              Output file to write analysis result. This flag should be used with --output-format
+  -o, --output-format string                 Output format of analysis ("text"|"json"|"sarif"|"sonarqube"). For json, sarif, and sonarqube --json-output-file is required
+  -p, --project-path string                  Path to run an analysis. If this value is not passed, Horusec will ask if you want to run the analysis in the current directory (default "/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/cmd/app/start")
+  -n, --repository-name string               Send repository name to Horusec server, by default sends the actual directory name (default "start")
+  -r, --request-timeout int                  The timeout threshold for the request to the Horusec server. The minimum time is 10 (default 300)
+  -e, --return-error                         Return exit code 1 if found vulnerabilities. Default value is false (exit code 0)
+  -R, --risk-accept strings                  Ignore a vulnerability by hash and set it to be risk accept. Example -R="hash1, hash2"
+      --show-vulnerabilities-types strings   Show vulnerabilities by types ("Vulnerability"|"Risk Accepted"|"False Positive"|"Corrected"). Example --show-vulnerabilities-types="Vulnerability, Risk Accepted" (default [Vulnerability])
+
+=== RUN   TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_and_return_error_because_found_invalid_RepositoryAuthorization_field
+time="2022-07-26T18:08:39-03:00" level=warning msg="{HORUSEC_CLI} Config file not found"
+Error: repository_authorization: must be a valid UUID.
+Usage:
+  start [flags]
+
+Examples:
+horusec start
+
+Flags:
+  -t, --analysis-timeout int                 The timeout threshold for the Horusec CLI wait for the analysis to complete. The minimum time is 10 (default 600)
+  -a, --authorization string                 Authorization token to use on Horusec server. Read more: https://docs.horusec.io/docs/tutorials/how-to-create-an-authorization-token (default "00000000-0000-0000-0000-000000000000")
+  -C, --certificate-path string              Path to certificate of authority. Example -C="example/ca.crt"
+  -P, --container-bind-project-path string   Project path in host to be used on Docker when running Horusec inside a container
+  -c, --custom-rules-path string             Path with custom rules that should be used by Horusec engine
+  -D, --disable-docker                       Run Horusec without docker. If enabled it will only run the following tools: horusec-csharp, horusec-kotlin, horusec-java, horusec-kubernetes, horusec-leaks, horusec-javascript, horusec-dart, horusec-nginx
+  -G, --enable-commit-author                 Enable to search commit author of vulnerabilities
+      --enable-git-history                   Run Gitleaks and search for vulnerabilities in all git history of the project https://github.com/zricethezav/gitleaks
+  -w, --enable-owasp-dependency-check        Run Owasp Dependency Check tool https://github.com/jeremylong/DependencyCheck
+  -j, --enable-shellcheck                    Run ShellCheck tool https://github.com/koalaman/shellcheck
+  -F, --false-positive strings               Ignore a vulnerability by hash and set it to be false positive. Example -F="hash1, hash2"
+      --headers stringToString               Custom headers to send on request to Horusec API. Example --headers='{"X-Auth-Service": "value"}' (default [])
+  -h, --help                                 help for start
+  -u, --horusec-url string                   The Horusec server address to send analysis results (default "http://0.0.0.0:8000")
+  -i, --ignore strings                       Paths to ignore in the analysis. Example: -i="/path/to/ignore, **/*_test.go, **/assets/**" (default [*tmp*,**/.vscode/**])
+  -s, --ignore-severity strings              The level of vulnerabilities to ignore in the output ("LOW"|"MEDIUM"|"HIGH"). Example: -s="LOW, HIGH" (default [INFO])
+  -I, --information-severity                 Enable information severity vulnerabilities. Information vulnerabilities can contain a lot of false positives
+  -S, --insecure-skip-verify                 Disable the certification validation. PLEASE, try not to use it
+  -O, --json-output-file string              Output file to write analysis result. This flag should be used with --output-format
+  -o, --output-format string                 Output format of analysis ("text"|"json"|"sarif"|"sonarqube"). For json, sarif, and sonarqube --json-output-file is required
+  -p, --project-path string                  Path to run an analysis. If this value is not passed, Horusec will ask if you want to run the analysis in the current directory (default "/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/cmd/app/start")
+  -n, --repository-name string               Send repository name to Horusec server, by default sends the actual directory name (default "start")
+  -r, --request-timeout int                  The timeout threshold for the request to the Horusec server. The minimum time is 10 (default 300)
+  -e, --return-error                         Return exit code 1 if found vulnerabilities. Default value is false (exit code 0)
+  -R, --risk-accept strings                  Ignore a vulnerability by hash and set it to be risk accept. Example -R="hash1, hash2"
+      --show-vulnerabilities-types strings   Show vulnerabilities by types ("Vulnerability"|"Risk Accepted"|"False Positive"|"Corrected"). Example --show-vulnerabilities-types="Vulnerability, Risk Accepted" (default [Vulnerability])
+
+=== RUN   TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_and_return_success_because_found_valid_RepositoryAuthorization_field(-a)
+time="2022-07-26T18:08:39-03:00" level=warning msg="{HORUSEC_CLI} Config file not found"
+=== RUN   TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_without_error_using_json_output(-o_json,_-O)
+time="2022-07-26T18:08:39-03:00" level=warning msg="{HORUSEC_CLI} Config file not found"
+=== RUN   TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_with_error_using_unknown_type_output(-o_unknown,_-O)
+time="2022-07-26T18:08:39-03:00" level=warning msg="{HORUSEC_CLI} Config file not found"
+Error: print_output_type: must be a valid value.
+Usage:
+  start [flags]
+
+Examples:
+horusec start
+
+Flags:
+  -t, --analysis-timeout int                 The timeout threshold for the Horusec CLI wait for the analysis to complete. The minimum time is 10 (default 600)
+  -a, --authorization string                 Authorization token to use on Horusec server. Read more: https://docs.horusec.io/docs/tutorials/how-to-create-an-authorization-token (default "00000000-0000-0000-0000-000000000000")
+  -C, --certificate-path string              Path to certificate of authority. Example -C="example/ca.crt"
+  -P, --container-bind-project-path string   Project path in host to be used on Docker when running Horusec inside a container
+  -c, --custom-rules-path string             Path with custom rules that should be used by Horusec engine
+  -D, --disable-docker                       Run Horusec without docker. If enabled it will only run the following tools: horusec-csharp, horusec-kotlin, horusec-java, horusec-kubernetes, horusec-leaks, horusec-javascript, horusec-dart, horusec-nginx
+  -G, --enable-commit-author                 Enable to search commit author of vulnerabilities
+      --enable-git-history                   Run Gitleaks and search for vulnerabilities in all git history of the project https://github.com/zricethezav/gitleaks
+  -w, --enable-owasp-dependency-check        Run Owasp Dependency Check tool https://github.com/jeremylong/DependencyCheck
+  -j, --enable-shellcheck                    Run ShellCheck tool https://github.com/koalaman/shellcheck
+  -F, --false-positive strings               Ignore a vulnerability by hash and set it to be false positive. Example -F="hash1, hash2"
+      --headers stringToString               Custom headers to send on request to Horusec API. Example --headers='{"X-Auth-Service": "value"}' (default [])
+  -h, --help                                 help for start
+  -u, --horusec-url string                   The Horusec server address to send analysis results (default "http://0.0.0.0:8000")
+  -i, --ignore strings                       Paths to ignore in the analysis. Example: -i="/path/to/ignore, **/*_test.go, **/assets/**" (default [*tmp*,**/.vscode/**])
+  -s, --ignore-severity strings              The level of vulnerabilities to ignore in the output ("LOW"|"MEDIUM"|"HIGH"). Example: -s="LOW, HIGH" (default [INFO])
+  -I, --information-severity                 Enable information severity vulnerabilities. Information vulnerabilities can contain a lot of false positives
+  -S, --insecure-skip-verify                 Disable the certification validation. PLEASE, try not to use it
+  -O, --json-output-file string              Output file to write analysis result. This flag should be used with --output-format
+  -o, --output-format string                 Output format of analysis ("text"|"json"|"sarif"|"sonarqube"). For json, sarif, and sonarqube --json-output-file is required
+  -p, --project-path string                  Path to run an analysis. If this value is not passed, Horusec will ask if you want to run the analysis in the current directory (default "/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/cmd/app/start")
+  -n, --repository-name string               Send repository name to Horusec server, by default sends the actual directory name (default "start")
+  -r, --request-timeout int                  The timeout threshold for the request to the Horusec server. The minimum time is 10 (default 300)
+  -e, --return-error                         Return exit code 1 if found vulnerabilities. Default value is false (exit code 0)
+  -R, --risk-accept strings                  Ignore a vulnerability by hash and set it to be risk accept. Example -R="hash1, hash2"
+      --show-vulnerabilities-types strings   Show vulnerabilities by types ("Vulnerability"|"Risk Accepted"|"False Positive"|"Corrected"). Example --show-vulnerabilities-types="Vulnerability, Risk Accepted" (default [Vulnerability])
+
+=== RUN   TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_without_error_using_sonarqube_output_(-o_sonarqube,_-O)
+time="2022-07-26T18:08:39-03:00" level=warning msg="{HORUSEC_CLI} Config file not found"
+=== RUN   TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_without_error_showing_info_vulnerabilities_(--information-severity)
+time="2022-07-26T18:08:39-03:00" level=warning msg="{HORUSEC_CLI} Config file not found"
+=== RUN   TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_without_error_sending_to_web_application_(-u,-a)
+time="2022-07-26T18:08:39-03:00" level=warning msg="{HORUSEC_CLI} Config file not found"
+=== RUN   TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_without_error_sending_to_web_application_(-u,-a)/Should_execute_command_exec_without_error_sending_to_web_application_(-u,-a)
+=== RUN   TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_with_error_sending_to_a_invalid_url_web_application_(-u,-a)
+time="2022-07-26T18:08:39-03:00" level=warning msg="{HORUSEC_CLI} Config file not found"
+Error: horusec_api_uri: parse "*vsaf&&": invalid URI for request.
+Usage:
+  start [flags]
+
+Examples:
+horusec start
+
+Flags:
+  -t, --analysis-timeout int                 The timeout threshold for the Horusec CLI wait for the analysis to complete. The minimum time is 10 (default 600)
+  -a, --authorization string                 Authorization token to use on Horusec server. Read more: https://docs.horusec.io/docs/tutorials/how-to-create-an-authorization-token (default "00000000-0000-0000-0000-000000000000")
+  -C, --certificate-path string              Path to certificate of authority. Example -C="example/ca.crt"
+  -P, --container-bind-project-path string   Project path in host to be used on Docker when running Horusec inside a container
+  -c, --custom-rules-path string             Path with custom rules that should be used by Horusec engine
+  -D, --disable-docker                       Run Horusec without docker. If enabled it will only run the following tools: horusec-csharp, horusec-kotlin, horusec-java, horusec-kubernetes, horusec-leaks, horusec-javascript, horusec-dart, horusec-nginx
+  -G, --enable-commit-author                 Enable to search commit author of vulnerabilities
+      --enable-git-history                   Run Gitleaks and search for vulnerabilities in all git history of the project https://github.com/zricethezav/gitleaks
+  -w, --enable-owasp-dependency-check        Run Owasp Dependency Check tool https://github.com/jeremylong/DependencyCheck
+  -j, --enable-shellcheck                    Run ShellCheck tool https://github.com/koalaman/shellcheck
+  -F, --false-positive strings               Ignore a vulnerability by hash and set it to be false positive. Example -F="hash1, hash2"
+      --headers stringToString               Custom headers to send on request to Horusec API. Example --headers='{"X-Auth-Service": "value"}' (default [])
+  -h, --help                                 help for start
+  -u, --horusec-url string                   The Horusec server address to send analysis results (default "http://0.0.0.0:8000")
+  -i, --ignore strings                       Paths to ignore in the analysis. Example: -i="/path/to/ignore, **/*_test.go, **/assets/**" (default [*tmp*,**/.vscode/**])
+  -s, --ignore-severity strings              The level of vulnerabilities to ignore in the output ("LOW"|"MEDIUM"|"HIGH"). Example: -s="LOW, HIGH" (default [INFO])
+  -I, --information-severity                 Enable information severity vulnerabilities. Information vulnerabilities can contain a lot of false positives
+  -S, --insecure-skip-verify                 Disable the certification validation. PLEASE, try not to use it
+  -O, --json-output-file string              Output file to write analysis result. This flag should be used with --output-format
+  -o, --output-format string                 Output format of analysis ("text"|"json"|"sarif"|"sonarqube"). For json, sarif, and sonarqube --json-output-file is required
+  -p, --project-path string                  Path to run an analysis. If this value is not passed, Horusec will ask if you want to run the analysis in the current directory (default "/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/cmd/app/start")
+  -n, --repository-name string               Send repository name to Horusec server, by default sends the actual directory name (default "start")
+  -r, --request-timeout int                  The timeout threshold for the request to the Horusec server. The minimum time is 10 (default 300)
+  -e, --return-error                         Return exit code 1 if found vulnerabilities. Default value is false (exit code 0)
+  -R, --risk-accept strings                  Ignore a vulnerability by hash and set it to be risk accept. Example -R="hash1, hash2"
+      --show-vulnerabilities-types strings   Show vulnerabilities by types ("Vulnerability"|"Risk Accepted"|"False Positive"|"Corrected"). Example --show-vulnerabilities-types="Vulnerability, Risk Accepted" (default [Vulnerability])
+
+=== RUN   TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_without_error_and_return_vulnerabilities_but_ignore_vulnerabilities_of_type_HIGH_(-s)
+time="2022-07-26T18:08:39-03:00" level=warning msg="{HORUSEC_CLI} Config file not found"
+=== RUN   TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_with_error_and_not_return_vulnerabilities_when_set_to_ignore_unknown_type_of_vulnerability_(-s)
+time="2022-07-26T18:08:39-03:00" level=warning msg="{HORUSEC_CLI} Config file not found"
+Error: severities_to_ignore: potato Type of severity not valid. See severities enable: [CRITICAL HIGH MEDIUM LOW UNKNOWN INFO].
+Usage:
+  start [flags]
+
+Examples:
+horusec start
+
+Flags:
+  -t, --analysis-timeout int                 The timeout threshold for the Horusec CLI wait for the analysis to complete. The minimum time is 10 (default 600)
+  -a, --authorization string                 Authorization token to use on Horusec server. Read more: https://docs.horusec.io/docs/tutorials/how-to-create-an-authorization-token (default "00000000-0000-0000-0000-000000000000")
+  -C, --certificate-path string              Path to certificate of authority. Example -C="example/ca.crt"
+  -P, --container-bind-project-path string   Project path in host to be used on Docker when running Horusec inside a container
+  -c, --custom-rules-path string             Path with custom rules that should be used by Horusec engine
+  -D, --disable-docker                       Run Horusec without docker. If enabled it will only run the following tools: horusec-csharp, horusec-kotlin, horusec-java, horusec-kubernetes, horusec-leaks, horusec-javascript, horusec-dart, horusec-nginx
+  -G, --enable-commit-author                 Enable to search commit author of vulnerabilities
+      --enable-git-history                   Run Gitleaks and search for vulnerabilities in all git history of the project https://github.com/zricethezav/gitleaks
+  -w, --enable-owasp-dependency-check        Run Owasp Dependency Check tool https://github.com/jeremylong/DependencyCheck
+  -j, --enable-shellcheck                    Run ShellCheck tool https://github.com/koalaman/shellcheck
+  -F, --false-positive strings               Ignore a vulnerability by hash and set it to be false positive. Example -F="hash1, hash2"
+      --headers stringToString               Custom headers to send on request to Horusec API. Example --headers='{"X-Auth-Service": "value"}' (default [])
+  -h, --help                                 help for start
+  -u, --horusec-url string                   The Horusec server address to send analysis results (default "http://0.0.0.0:8000")
+  -i, --ignore strings                       Paths to ignore in the analysis. Example: -i="/path/to/ignore, **/*_test.go, **/assets/**" (default [*tmp*,**/.vscode/**])
+  -s, --ignore-severity strings              The level of vulnerabilities to ignore in the output ("LOW"|"MEDIUM"|"HIGH"). Example: -s="LOW, HIGH" (default [INFO])
+  -I, --information-severity                 Enable information severity vulnerabilities. Information vulnerabilities can contain a lot of false positives
+  -S, --insecure-skip-verify                 Disable the certification validation. PLEASE, try not to use it
+  -O, --json-output-file string              Output file to write analysis result. This flag should be used with --output-format
+  -o, --output-format string                 Output format of analysis ("text"|"json"|"sarif"|"sonarqube"). For json, sarif, and sonarqube --json-output-file is required
+  -p, --project-path string                  Path to run an analysis. If this value is not passed, Horusec will ask if you want to run the analysis in the current directory (default "/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/cmd/app/start")
+  -n, --repository-name string               Send repository name to Horusec server, by default sends the actual directory name (default "start")
+  -r, --request-timeout int                  The timeout threshold for the request to the Horusec server. The minimum time is 10 (default 300)
+  -e, --return-error                         Return exit code 1 if found vulnerabilities. Default value is false (exit code 0)
+  -R, --risk-accept strings                  Ignore a vulnerability by hash and set it to be risk accept. Example -R="hash1, hash2"
+      --show-vulnerabilities-types strings   Show vulnerabilities by types ("Vulnerability"|"Risk Accepted"|"False Positive"|"Corrected"). Example --show-vulnerabilities-types="Vulnerability, Risk Accepted" (default [Vulnerability])
+
+=== RUN   TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_without_error_and_not_return_vulnerabilities_when_set_valid_certificate_path_(-C_--certificate-path)
+time="2022-07-26T18:08:39-03:00" level=warning msg="{HORUSEC_CLI} Config file not found"
+=== RUN   TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_with_error_and_not_return_vulnerabilities_when_set_invalid_certificate_path_(-C_--certificate-path)
+time="2022-07-26T18:08:39-03:00" level=warning msg="{HORUSEC_CLI} Config file not found"
+Error: cert_path: invalid path: invalidPath.
+Usage:
+  start [flags]
+
+Examples:
+horusec start
+
+Flags:
+  -t, --analysis-timeout int                 The timeout threshold for the Horusec CLI wait for the analysis to complete. The minimum time is 10 (default 600)
+  -a, --authorization string                 Authorization token to use on Horusec server. Read more: https://docs.horusec.io/docs/tutorials/how-to-create-an-authorization-token (default "00000000-0000-0000-0000-000000000000")
+  -C, --certificate-path string              Path to certificate of authority. Example -C="example/ca.crt"
+  -P, --container-bind-project-path string   Project path in host to be used on Docker when running Horusec inside a container
+  -c, --custom-rules-path string             Path with custom rules that should be used by Horusec engine
+  -D, --disable-docker                       Run Horusec without docker. If enabled it will only run the following tools: horusec-csharp, horusec-kotlin, horusec-java, horusec-kubernetes, horusec-leaks, horusec-javascript, horusec-dart, horusec-nginx
+  -G, --enable-commit-author                 Enable to search commit author of vulnerabilities
+      --enable-git-history                   Run Gitleaks and search for vulnerabilities in all git history of the project https://github.com/zricethezav/gitleaks
+  -w, --enable-owasp-dependency-check        Run Owasp Dependency Check tool https://github.com/jeremylong/DependencyCheck
+  -j, --enable-shellcheck                    Run ShellCheck tool https://github.com/koalaman/shellcheck
+  -F, --false-positive strings               Ignore a vulnerability by hash and set it to be false positive. Example -F="hash1, hash2"
+      --headers stringToString               Custom headers to send on request to Horusec API. Example --headers='{"X-Auth-Service": "value"}' (default [])
+  -h, --help                                 help for start
+  -u, --horusec-url string                   The Horusec server address to send analysis results (default "http://0.0.0.0:8000")
+  -i, --ignore strings                       Paths to ignore in the analysis. Example: -i="/path/to/ignore, **/*_test.go, **/assets/**" (default [*tmp*,**/.vscode/**])
+  -s, --ignore-severity strings              The level of vulnerabilities to ignore in the output ("LOW"|"MEDIUM"|"HIGH"). Example: -s="LOW, HIGH" (default [INFO])
+  -I, --information-severity                 Enable information severity vulnerabilities. Information vulnerabilities can contain a lot of false positives
+  -S, --insecure-skip-verify                 Disable the certification validation. PLEASE, try not to use it
+  -O, --json-output-file string              Output file to write analysis result. This flag should be used with --output-format
+  -o, --output-format string                 Output format of analysis ("text"|"json"|"sarif"|"sonarqube"). For json, sarif, and sonarqube --json-output-file is required
+  -p, --project-path string                  Path to run an analysis. If this value is not passed, Horusec will ask if you want to run the analysis in the current directory (default "/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/cmd/app/start")
+  -n, --repository-name string               Send repository name to Horusec server, by default sends the actual directory name (default "start")
+  -r, --request-timeout int                  The timeout threshold for the request to the Horusec server. The minimum time is 10 (default 300)
+  -e, --return-error                         Return exit code 1 if found vulnerabilities. Default value is false (exit code 0)
+  -R, --risk-accept strings                  Ignore a vulnerability by hash and set it to be risk accept. Example -R="hash1, hash2"
+      --show-vulnerabilities-types strings   Show vulnerabilities by types ("Vulnerability"|"Risk Accepted"|"False Positive"|"Corrected"). Example --show-vulnerabilities-types="Vulnerability, Risk Accepted" (default [Vulnerability])
+
+=== RUN   TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_without_error_and_not_return_vulnerabilities_when_set_valid_analysis_timeout_(-t_--analysis-timeout)"
+time="2022-07-26T18:08:39-03:00" level=warning msg="{HORUSEC_CLI} Config file not found"
+=== RUN   TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_with_error_and_not_return_vulnerabilities_when_set_invalid_analysis_timeout_(-t_--analysis-timeout)
+Error: invalid argument "potato" for "-t, --analysis-timeout" flag: strconv.ParseInt: parsing "potato": invalid syntax
+Usage:
+  start [flags]
+
+Examples:
+horusec start
+
+Flags:
+  -t, --analysis-timeout int                 The timeout threshold for the Horusec CLI wait for the analysis to complete. The minimum time is 10 (default 600)
+  -a, --authorization string                 Authorization token to use on Horusec server. Read more: https://docs.horusec.io/docs/tutorials/how-to-create-an-authorization-token (default "00000000-0000-0000-0000-000000000000")
+  -C, --certificate-path string              Path to certificate of authority. Example -C="example/ca.crt"
+  -P, --container-bind-project-path string   Project path in host to be used on Docker when running Horusec inside a container
+  -c, --custom-rules-path string             Path with custom rules that should be used by Horusec engine
+  -D, --disable-docker                       Run Horusec without docker. If enabled it will only run the following tools: horusec-csharp, horusec-kotlin, horusec-java, horusec-kubernetes, horusec-leaks, horusec-javascript, horusec-dart, horusec-nginx
+  -G, --enable-commit-author                 Enable to search commit author of vulnerabilities
+      --enable-git-history                   Run Gitleaks and search for vulnerabilities in all git history of the project https://github.com/zricethezav/gitleaks
+  -w, --enable-owasp-dependency-check        Run Owasp Dependency Check tool https://github.com/jeremylong/DependencyCheck
+  -j, --enable-shellcheck                    Run ShellCheck tool https://github.com/koalaman/shellcheck
+  -F, --false-positive strings               Ignore a vulnerability by hash and set it to be false positive. Example -F="hash1, hash2"
+      --headers stringToString               Custom headers to send on request to Horusec API. Example --headers='{"X-Auth-Service": "value"}' (default [])
+  -h, --help                                 help for start
+  -u, --horusec-url string                   The Horusec server address to send analysis results (default "http://0.0.0.0:8000")
+  -i, --ignore strings                       Paths to ignore in the analysis. Example: -i="/path/to/ignore, **/*_test.go, **/assets/**" (default [*tmp*,**/.vscode/**])
+  -s, --ignore-severity strings              The level of vulnerabilities to ignore in the output ("LOW"|"MEDIUM"|"HIGH"). Example: -s="LOW, HIGH" (default [INFO])
+  -I, --information-severity                 Enable information severity vulnerabilities. Information vulnerabilities can contain a lot of false positives
+  -S, --insecure-skip-verify                 Disable the certification validation. PLEASE, try not to use it
+  -O, --json-output-file string              Output file to write analysis result. This flag should be used with --output-format
+  -o, --output-format string                 Output format of analysis ("text"|"json"|"sarif"|"sonarqube"). For json, sarif, and sonarqube --json-output-file is required
+  -p, --project-path string                  Path to run an analysis. If this value is not passed, Horusec will ask if you want to run the analysis in the current directory (default "/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/cmd/app/start")
+  -n, --repository-name string               Send repository name to Horusec server, by default sends the actual directory name (default "start")
+  -r, --request-timeout int                  The timeout threshold for the request to the Horusec server. The minimum time is 10 (default 300)
+  -e, --return-error                         Return exit code 1 if found vulnerabilities. Default value is false (exit code 0)
+  -R, --risk-accept strings                  Ignore a vulnerability by hash and set it to be risk accept. Example -R="hash1, hash2"
+      --show-vulnerabilities-types strings   Show vulnerabilities by types ("Vulnerability"|"Risk Accepted"|"False Positive"|"Corrected"). Example --show-vulnerabilities-types="Vulnerability, Risk Accepted" (default [Vulnerability])
+
+=== RUN   TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_without_error_and_not_return_vulnerabilities_when_set_disable_docker_(-D_--disable-docker)
+time="2022-07-26T18:08:39-03:00" level=warning msg="{HORUSEC_CLI} Config file not found"
+=== RUN   TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_without_error_and_not_return_vulnerabilities_when_set_valid_request_timeout_(-r_--request-timeout)
+time="2022-07-26T18:08:39-03:00" level=warning msg="{HORUSEC_CLI} Config file not found"
+=== RUN   TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_with_error_and_not_return_vulnerabilities_when_set_invalid_request_timeout_(-r_--request-timeout)
+Error: invalid argument "potato" for "-r, --request-timeout" flag: strconv.ParseInt: parsing "potato": invalid syntax
+Usage:
+  start [flags]
+
+Examples:
+horusec start
+
+Flags:
+  -t, --analysis-timeout int                 The timeout threshold for the Horusec CLI wait for the analysis to complete. The minimum time is 10 (default 600)
+  -a, --authorization string                 Authorization token to use on Horusec server. Read more: https://docs.horusec.io/docs/tutorials/how-to-create-an-authorization-token (default "00000000-0000-0000-0000-000000000000")
+  -C, --certificate-path string              Path to certificate of authority. Example -C="example/ca.crt"
+  -P, --container-bind-project-path string   Project path in host to be used on Docker when running Horusec inside a container
+  -c, --custom-rules-path string             Path with custom rules that should be used by Horusec engine
+  -D, --disable-docker                       Run Horusec without docker. If enabled it will only run the following tools: horusec-csharp, horusec-kotlin, horusec-java, horusec-kubernetes, horusec-leaks, horusec-javascript, horusec-dart, horusec-nginx
+  -G, --enable-commit-author                 Enable to search commit author of vulnerabilities
+      --enable-git-history                   Run Gitleaks and search for vulnerabilities in all git history of the project https://github.com/zricethezav/gitleaks
+  -w, --enable-owasp-dependency-check        Run Owasp Dependency Check tool https://github.com/jeremylong/DependencyCheck
+  -j, --enable-shellcheck                    Run ShellCheck tool https://github.com/koalaman/shellcheck
+  -F, --false-positive strings               Ignore a vulnerability by hash and set it to be false positive. Example -F="hash1, hash2"
+      --headers stringToString               Custom headers to send on request to Horusec API. Example --headers='{"X-Auth-Service": "value"}' (default [])
+  -h, --help                                 help for start
+  -u, --horusec-url string                   The Horusec server address to send analysis results (default "http://0.0.0.0:8000")
+  -i, --ignore strings                       Paths to ignore in the analysis. Example: -i="/path/to/ignore, **/*_test.go, **/assets/**" (default [*tmp*,**/.vscode/**])
+  -s, --ignore-severity strings              The level of vulnerabilities to ignore in the output ("LOW"|"MEDIUM"|"HIGH"). Example: -s="LOW, HIGH" (default [INFO])
+  -I, --information-severity                 Enable information severity vulnerabilities. Information vulnerabilities can contain a lot of false positives
+  -S, --insecure-skip-verify                 Disable the certification validation. PLEASE, try not to use it
+  -O, --json-output-file string              Output file to write analysis result. This flag should be used with --output-format
+  -o, --output-format string                 Output format of analysis ("text"|"json"|"sarif"|"sonarqube"). For json, sarif, and sonarqube --json-output-file is required
+  -p, --project-path string                  Path to run an analysis. If this value is not passed, Horusec will ask if you want to run the analysis in the current directory (default "/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/cmd/app/start")
+  -n, --repository-name string               Send repository name to Horusec server, by default sends the actual directory name (default "start")
+  -r, --request-timeout int                  The timeout threshold for the request to the Horusec server. The minimum time is 10 (default 300)
+  -e, --return-error                         Return exit code 1 if found vulnerabilities. Default value is false (exit code 0)
+  -R, --risk-accept strings                  Ignore a vulnerability by hash and set it to be risk accept. Example -R="hash1, hash2"
+      --show-vulnerabilities-types strings   Show vulnerabilities by types ("Vulnerability"|"Risk Accepted"|"False Positive"|"Corrected"). Example --show-vulnerabilities-types="Vulnerability, Risk Accepted" (default [Vulnerability])
+
+--- PASS: TestStartCommand_ExecuteUnitTests (0.18s)
+    --- PASS: TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_without_error_and_ask_to_user_if_is_to_run_in_current_directory (0.00s)
+    --- PASS: TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_without_error_and_not_ask_if_is_to_run_in_current_directory (0.01s)
+    --- PASS: TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_and_return_error_because_found_vulnerabilities_(-p,-e) (0.01s)
+    --- PASS: TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_and_return_error_because_found_error_when_ask_but_run_in_current_folder (0.00s)
+    --- PASS: TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_without_error_and_validate_if_git_is_installed(--enable-git-history) (0.00s)
+    --- PASS: TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_with_error_when_validate_if_git_is_installed(--enable-git-history) (0.01s)
+    --- PASS: TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_with_error_when_validate_if_docker_is_installed (0.01s)
+    --- PASS: TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_without_error_and_not_ask_because_is_different_project_path(-p,_-e) (0.00s)
+    --- PASS: TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_and_return_error_because_found_not_accept_proceed (0.01s)
+    --- PASS: TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_and_return_error_because_found_invalid_RepositoryAuthorization_field (0.00s)
+    --- PASS: TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_and_return_success_because_found_valid_RepositoryAuthorization_field(-a) (0.01s)
+    --- PASS: TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_without_error_using_json_output(-o_json,_-O) (0.00s)
+    --- PASS: TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_with_error_using_unknown_type_output(-o_unknown,_-O) (0.01s)
+    --- PASS: TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_without_error_using_sonarqube_output_(-o_sonarqube,_-O) (0.01s)
+    --- PASS: TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_without_error_showing_info_vulnerabilities_(--information-severity) (0.00s)
+    --- PASS: TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_without_error_sending_to_web_application_(-u,-a) (0.01s)
+        --- PASS: TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_without_error_sending_to_web_application_(-u,-a)/Should_execute_command_exec_without_error_sending_to_web_application_(-u,-a) (0.00s)
+    --- PASS: TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_with_error_sending_to_a_invalid_url_web_application_(-u,-a) (0.00s)
+    --- PASS: TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_without_error_and_return_vulnerabilities_but_ignore_vulnerabilities_of_type_HIGH_(-s) (0.00s)
+    --- PASS: TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_with_error_and_not_return_vulnerabilities_when_set_to_ignore_unknown_type_of_vulnerability_(-s) (0.01s)
+    --- PASS: TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_without_error_and_not_return_vulnerabilities_when_set_valid_certificate_path_(-C_--certificate-path) (0.00s)
+    --- PASS: TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_with_error_and_not_return_vulnerabilities_when_set_invalid_certificate_path_(-C_--certificate-path) (0.00s)
+    --- PASS: TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_without_error_and_not_return_vulnerabilities_when_set_valid_analysis_timeout_(-t_--analysis-timeout)" (0.01s)
+    --- PASS: TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_with_error_and_not_return_vulnerabilities_when_set_invalid_analysis_timeout_(-t_--analysis-timeout) (0.00s)
+    --- PASS: TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_without_error_and_not_return_vulnerabilities_when_set_disable_docker_(-D_--disable-docker) (0.00s)
+    --- PASS: TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_without_error_and_not_return_vulnerabilities_when_set_valid_request_timeout_(-r_--request-timeout) (0.01s)
+    --- PASS: TestStartCommand_ExecuteUnitTests/Should_execute_command_exec_with_error_and_not_return_vulnerabilities_when_set_invalid_request_timeout_(-r_--request-timeout) (0.01s)
+=== RUN   TestStartCommand_ExecuteIntegrationTest
+    start_test.go:592: skipping integration test
+--- SKIP: TestStartCommand_ExecuteIntegrationTest (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/cmd/app/start	0.604s
+=== RUN   TestVersionCommand_Execute
+=== RUN   TestVersionCommand_Execute/should_not_panic_when_creating_the_version_command
+=== RUN   TestVersionCommand_Execute/should_success_execute_the_version_command_without_errors
+Version:          {{VERSION_NOT_FOUND}}
+Git commit:       {{COMMIT_NOT_FOUND}}
+Built:            {{DATE_NOT_FOUND}}
+Distribution:     normal
+--- PASS: TestVersionCommand_Execute (0.00s)
+    --- PASS: TestVersionCommand_Execute/should_not_panic_when_creating_the_version_command (0.00s)
+    --- PASS: TestVersionCommand_Execute/should_success_execute_the_version_command_without_errors (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/cmd/app/version	0.028s
+=== RUN   TestNewHorusecConfig
+=== RUN   TestNewHorusecConfig/Should_return_horusec_config_with_your_default_values
+=== RUN   TestNewHorusecConfig/Should_return_horusec_config_using_new_config_file
+=== RUN   TestNewHorusecConfig/Should_return_horusec_config_using_config_file_and_override_by_environment
+=== RUN   TestNewHorusecConfig/Should_return_horusec_config_using_config_file_and_override_by_environment_and_override_by_flags
+time="2022-07-26T18:08:39-03:00" level=error msg="{HORUSEC_CLI} failed to get custom rules: " error="open custom-rules-path-test: no such file or directory"
+
+time="2022-07-26T18:08:39-03:00" level=warning msg="Horusec will return a timeout after 123 seconds. This time can be customized in the cli settings."
+
+time="2022-07-26T18:08:39-03:00" level=warning msg="{HORUSEC_CLI} PLEASE DON'T REMOVE \".horusec\" FOLDER BEFORE THE ANALYSIS FINISH! Don’t worry, we’ll remove it after the analysis ends automatically! Project sent to folder in location: [/tmp/testing-target3406649257/.horusec/8563bcc2-92cf-4eac-aa7f-4e0d586909ee]"
+
+time="2022-07-26T18:08:39-03:00" level=error msg="{HORUSEC_CLI} Error when copy project to .horusec folder" error="stat /tmp/testing-target3406649257/.git: no such file or directory"
+time="2022-07-26T18:08:39-03:00" level=warning msg="{HORUSEC_CLI} Starting the analysis with git history enabled. ATTENTION the waiting time can be longer when this option is enabled!"
+
+[K⣾ Scanning code ...[Ktime="2022-07-26T18:08:39-03:00" level=error msg="[HORUSEC] read /tmp/testing-target3406649257: is a directory"
+time="2022-07-26T18:08:39-03:00" level=warning msg="{HORUSEC_CLI} Hash not found in the list of vulnerabilities pointed out by Horusec: "
+time="2022-07-26T18:08:39-03:00" level=warning msg="{HORUSEC_CLI} Hash not found in the list of vulnerabilities pointed out by Horusec: "
+time="2022-07-26T18:08:39-03:00" level=warning msg="{HORUSEC_CLI} Hash not found in the list of vulnerabilities pointed out by Horusec: "
+time="2022-07-26T18:08:39-03:00" level=warning msg="{HORUSEC_CLI} Hash not found in the list of vulnerabilities pointed out by Horusec: "
+time="2022-07-26T18:08:39-03:00" level=warning msg="{HORUSEC_CLI} Hash not found in the list of vulnerabilities pointed out by Horusec: SOMEHASHALEATORY1"
+time="2022-07-26T18:08:39-03:00" level=warning msg="{HORUSEC_CLI} Hash not found in the list of vulnerabilities pointed out by Horusec: SOMEHASHALEATORY2"
+time="2022-07-26T18:08:39-03:00" level=warning msg="{HORUSEC_CLI} Hash not found in the list of vulnerabilities pointed out by Horusec: SOMEHASHALEATORY3"
+time="2022-07-26T18:08:39-03:00" level=warning msg="{HORUSEC_CLI} Hash not found in the list of vulnerabilities pointed out by Horusec: SOMEHASHALEATORY4"
+time="2022-07-26T18:08:39-03:00" level=info msg="{HORUSEC_CLI} Writing output JSON to file in the path: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/config/tmp/json-output-file-test.json"
+time="2022-07-26T18:08:39-03:00" level=warning msg="YOUR ANALYSIS HAD FINISHED WITHOUT ANY VULNERABILITY!"
+
+--- PASS: TestNewHorusecConfig (0.13s)
+    --- PASS: TestNewHorusecConfig/Should_return_horusec_config_with_your_default_values (0.00s)
+    --- PASS: TestNewHorusecConfig/Should_return_horusec_config_using_new_config_file (0.01s)
+    --- PASS: TestNewHorusecConfig/Should_return_horusec_config_using_config_file_and_override_by_environment (0.02s)
+    --- PASS: TestNewHorusecConfig/Should_return_horusec_config_using_config_file_and_override_by_environment_and_override_by_flags (0.09s)
+=== RUN   TestNormalizeConfigs
+=== RUN   TestNormalizeConfigs/Should_success_normalize_config
+--- PASS: TestNormalizeConfigs (0.00s)
+    --- PASS: TestNormalizeConfigs/Should_success_normalize_config (0.00s)
+=== RUN   TestConfig_Bytes
+=== RUN   TestConfig_Bytes/Should_success_when_parse_config_to_json_bytes
+=== RUN   TestConfig_Bytes/Should_have_the_predefined_schema
+--- PASS: TestConfig_Bytes (0.00s)
+    --- PASS: TestConfig_Bytes/Should_success_when_parse_config_to_json_bytes (0.00s)
+    --- PASS: TestConfig_Bytes/Should_have_the_predefined_schema (0.00s)
+=== RUN   TestSetLogOutput
+=== RUN   TestSetLogOutput/Should_success_when_log_path_is_empty
+=== RUN   TestSetLogOutput/Should_success_when_log_path_is_valid
+--- PASS: TestSetLogOutput (0.00s)
+    --- PASS: TestSetLogOutput/Should_success_when_log_path_is_empty (0.00s)
+    --- PASS: TestSetLogOutput/Should_success_when_log_path_is_valid (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/config	0.517s
+=== RUN   TestIsStandAlone
+=== RUN   TestIsStandAlone/should_return_false_when_the_distribution_is_not_a_stand_alone_distribution
+--- PASS: TestIsStandAlone (0.00s)
+    --- PASS: TestIsStandAlone/should_return_false_when_the_distribution_is_not_a_stand_alone_distribution (0.00s)
+=== RUN   TestGetVersion
+=== RUN   TestGetVersion/should_return_stand-alone_when_the_distribution_is_a_stand_alone_distribution
+=== RUN   TestGetVersion/should_return_normal_when_the_distribution_is_not_a_stand_alone_distribution
+--- PASS: TestGetVersion (0.00s)
+    --- PASS: TestGetVersion/should_return_stand-alone_when_the_distribution_is_a_stand_alone_distribution (0.00s)
+    --- PASS: TestGetVersion/should_return_normal_when_the_distribution_is_not_a_stand_alone_distribution (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/config/dist	0.028s
+=== RUN   TestAnalyzerSetFalsePositivesAndRiskAcceptInVulnerabilities
+=== RUN   TestAnalyzerSetFalsePositivesAndRiskAcceptInVulnerabilities/ChangeCorrectHashToFalsePositive
+=== RUN   TestAnalyzerSetFalsePositivesAndRiskAcceptInVulnerabilities/ChangeBreakingHashToFalsePositive
+=== RUN   TestAnalyzerSetFalsePositivesAndRiskAcceptInVulnerabilities/ChangeCorrectHashToRiskAccept
+=== RUN   TestAnalyzerSetFalsePositivesAndRiskAcceptInVulnerabilities/ChangeBreakingHashToRiskAccept
+--- PASS: TestAnalyzerSetFalsePositivesAndRiskAcceptInVulnerabilities (0.00s)
+    --- PASS: TestAnalyzerSetFalsePositivesAndRiskAcceptInVulnerabilities/ChangeCorrectHashToFalsePositive (0.00s)
+    --- PASS: TestAnalyzerSetFalsePositivesAndRiskAcceptInVulnerabilities/ChangeBreakingHashToFalsePositive (0.00s)
+    --- PASS: TestAnalyzerSetFalsePositivesAndRiskAcceptInVulnerabilities/ChangeCorrectHashToRiskAccept (0.00s)
+    --- PASS: TestAnalyzerSetFalsePositivesAndRiskAcceptInVulnerabilities/ChangeBreakingHashToRiskAccept (0.00s)
+=== RUN   TestNewAnalyzer
+=== RUN   TestNewAnalyzer/Should_return_type_os_struct_correctly
+--- PASS: TestNewAnalyzer (0.00s)
+    --- PASS: TestNewAnalyzer/Should_return_type_os_struct_correctly (0.00s)
+=== RUN   TestAnalyzerWithoutMock
+=== RUN   TestAnalyzerWithoutMock/Should_run_all_analysis_with_no_timeout_and_error
+time="2022-07-26T18:08:39-03:00" level=warning msg="{HORUSEC_CLI} When starting the analysis WE SKIP A TOTAL OF 6 FILES that are not considered to be analyzed. To see more details use flag --log-level=debug"
+
+time="2022-07-26T18:08:39-03:00" level=warning msg="Horusec will return a timeout after 600 seconds. This time can be customized in the cli settings."
+
+time="2022-07-26T18:08:39-03:00" level=warning msg="{HORUSEC_CLI} PLEASE DON'T REMOVE \".horusec\" FOLDER BEFORE THE ANALYSIS FINISH! Don’t worry, we’ll remove it after the analysis ends automatically! Project sent to folder in location: [/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/.horusec/1061f692-f0d8-4ca8-ac0d-239efb358c4c]"
+
+[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K
+
+==================================================================================
+
+HORUSEC ENDED THE ANALYSIS WITH STATUS OF "success" AND WITH THE FOLLOWING RESULTS:
+
+==================================================================================
+
+Analysis StartedAt: 2022-07-26 18:08:39
+Analysis FinishedAt: 2022-07-26 18:09:25
+
+==================================================================================
+
+Language: Leaks
+Severity: CRITICAL
+Line: 26
+Column: 1
+SecurityTool: HorusecEngine
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example2/main.go
+Code: password := "password"
+RuleID: HS-LEAKS-26
+Type: Vulnerability
+ReferenceHash: a9ce8cda7a343a56726511692ae611b79bac5e79473847759cf45ac505142a82
+Details: (1/1) * Possible vulnerability detected: Hard-coded password
+The software contains hard-coded credentials, such as a password or cryptographic key, which it uses for its own inbound authentication, outbound communication to external components, or encryption of internal data. For more information checkout the CWE-798 (https://cwe.mitre.org/data/definitions/798.html) advisory.
+
+==================================================================================
+
+Language: Leaks
+Severity: CRITICAL
+Line: 32
+Column: 20
+SecurityTool: HorusecEngine
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example2/main.go
+Code: URI := fmt.Sprint("postgresql://root:root@postgresql:5432/horusecDB?sslmode=disable")
+RuleID: HS-LEAKS-27
+Type: Vulnerability
+ReferenceHash: acb9003db490b067688e19b7b2fac02aa0d98c459e7f32fc35f10700e443648c
+Details: (1/1) * Possible vulnerability detected: Password found in a hardcoded URL
+A password was found in a hardcoded URL, this can lead to not only the leak of this password but also a failure point to some more sophisticated CSRF and SSRF attacks. Check CWE-352 (https://cwe.mitre.org/data/definitions/352.html) and CWE-918 (https://cwe.mitre.org/data/definitions/918.html) for more details.
+
+==================================================================================
+
+Language: Generic
+Severity: CRITICAL
+Line: 548
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/nats-io/jwt v0.3.2/go.mod h1:/euKqTS1ZD+zzjYrY7pseZrTtWQSjujC7xjPc8wL6eU=
+	Installed Version: "0.3.2"
+	Update to Version: "1.1.0" for fix this issue.
+RuleID: CVE-2020-26892
+Type: Vulnerability
+ReferenceHash: f99194de8dd5153529c53eab4aee8e0c6620669512feb932779432d947d07314
+Details: (1/2) * Possible vulnerability detected: The JWT library in NATS nats-server before 2.1.9 has Incorrect Access Control because of how expired credentials are handled.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2020-26892.
+Cwe Links: (https://cwe.mitre.org/data/definitions/798.html)
+         
+(2/2) * Possible vulnerability detected: The JWT library in NATS nats-server before 2.1.9 allows a denial of service (a nil dereference in Go code).
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2020-26521.
+Cwe Links: (https://cwe.mitre.org/data/definitions/476.html)
+
+==================================================================================
+
+Language: Generic
+Severity: CRITICAL
+Line: 549
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/nats-io/nats-server/v2 v2.1.2/go.mod h1:Afk+wRZqkMQs/p45uXdrVLuab3gwv3Z8C4HTBu8GD/k=
+	Installed Version: "2.1.2"
+	Update to Version: "2.1.9" for fix this issue.
+RuleID: CVE-2020-26892
+Type: Vulnerability
+ReferenceHash: 4fda2c6d714f3313ebafe40494d555c1b86f59469d21ffe6d47cbe11442dc783
+Details: (1/4) * Possible vulnerability detected: The JWT library in NATS nats-server before 2.1.9 has Incorrect Access Control because of how expired credentials are handled.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2020-26892.
+Cwe Links: (https://cwe.mitre.org/data/definitions/798.html)
+         
+(2/4) * Possible vulnerability detected: The JWT library in NATS nats-server before 2.1.9 allows a denial of service (a nil dereference in Go code).
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2020-26521.
+Cwe Links: (https://cwe.mitre.org/data/definitions/476.html)
+         
+(3/4) * Possible vulnerability detected: (This advisory is canonically https://advisories.nats.io/CVE/CVE-2020-26892.txt )## Problem DescriptionNATS nats-server through 2020-10-07 has Incorrect Access Control because of how expired credentials are handled.The NATS accounts system has expiration timestamps on credentials; the <https://github.com/nats-io/jwt> library had an API which encouraged misuse and an `IsRevoked()` method which misused its own API.A new `IsClaimRevoked()` method has correct handling and the nats-server has been updated to use this.  The old `IsRevoked()` method now always returns true and other client code will have to be updated to avoid calling it.The CVE identifier should cover any application using the old JWT API, where the nats-server is one of those applications.
+## Affected versions#### JWT library * all versions prior to 1.1.0
+ * fixed after nats-io/jwt PR 103 landed (2020-10-06)#### NATS Server * Version 2 prior to 2.1.9
+   + 2.0.0 through and including 2.1.8 are vulnerable.
+ * fixed with nats-io/nats-server PRs 1632, 1635, 1645
+## ImpactTime-based credential expiry did not work.
+## WorkaroundHave credentials which only expire after fixes can be deployed.
+## SolutionUpgrade the JWT dependency in any application using it.Upgrade the NATS server if using NATS Accounts.
+PrimaryURL: https://github.com/advisories/GHSA-2c64-vj8g-vwrq.
+         
+(4/4) * Possible vulnerability detected: (This advisory is canonically <https://advisories.nats.io/CVE/CVE-2020-26521.txt>)## Problem DescriptionThe NATS account system has an Operator trusted by the servers, which signs Accounts, and each Account can then create and sign Users within their account.  The Operator should be able to safely issue Accounts to other entities which it does not fully trust.A malicious Account could create and sign a User JWT with a state not created by the normal tooling, such that decoding by the NATS JWT library (written in Go) would attempt a nil dereference, aborting execution.The NATS Server is known to be impacted by this.
+## Affected versions#### JWT library * all versions prior to 1.1.0#### NATS Server * Version 2 prior to 2.1.9
+## Impact#### JWT library * Programs would nil dereference and panic, aborting execution by default.#### NATS server * Denial of Service caused by process termination
+## WorkaroundIf your NATS servers do not trust any accounts which are managed by untrusted entities, then malformed User credentials are unlikely to be encountered.
+## SolutionUpgrade the JWT dependency in any application using it.Upgrade the NATS server if using NATS Accounts.
+PrimaryURL: https://github.com/advisories/GHSA-hmm9-r2m2-qg9w.
+
+==================================================================================
+
+Language: Go
+Severity: HIGH
+Line: 21
+Column: 
+SecurityTool: Nancy
+Confidence: HIGH
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.mod
+Code: 	github.com/containerd/containerd v1.4.1 // indirect
+RuleID: CVE-2021-41103
+Type: Vulnerability
+ReferenceHash: 33f54c0870abd03eb16a5281f27bbf1e66f6598784dcb03aca86eb8e02ed0fb6
+Details: (1/1) * Possible vulnerability detected: [CVE-2021-41103] CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
+containerd is an open source container runtime with an emphasis on simplicity, robustness and portability. A bug was found in containerd where container root directories and some plugins had insufficiently restricted permissions, allowing otherwise unprivileged Linux users to traverse directory contents and execute programs. When containers included executable programs with extended permission bits (such as setuid), unprivileged Linux users could discover and execute those programs. When the UID of an unprivileged Linux user on the host collided with the file owner or group inside a container, the unprivileged Linux user on the host could discover, read, and modify those files. This vulnerability has been fixed in containerd 1.4.11 and containerd 1.5.7. Users should update to these version when they are released and may restart containers or update directory permissions to mitigate the vulnerability. Users unable to update should limit access to the host to trusted users. Update directory permission on container bundles directories. For more information, please checkout the following url (https://ossindex.sonatype.org/vulnerability/CVE-2021-41103?component-type=golang&component-name=github.com%2Fcontainerd%2Fcontainerd&utm_source=nancy-client&utm_medium=integration&utm_content=1.0.33).
+
+==================================================================================
+
+Language: Go
+Severity: HIGH
+Line: 32
+Column: 
+SecurityTool: Nancy
+Confidence: HIGH
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.mod
+Code: 	github.com/gin-gonic/gin v1.6.3 // indirect
+RuleID: CVE-2020-28483
+Type: Vulnerability
+ReferenceHash: c42a2b2e19d7ca74fb544a80f6e6a703ef8d415049b4ef68f57c99ea86885d78
+Details: (1/1) * Possible vulnerability detected: [CVE-2020-28483] CWE-444: Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
+This affects all versions of package github.com/gin-gonic/gin. When gin is exposed directly to the internet, a client's IP can be spoofed by setting the X-Forwarded-For header. For more information, please checkout the following url (https://ossindex.sonatype.org/vulnerability/CVE-2020-28483?component-type=golang&component-name=github.com%2Fgin-gonic%2Fgin&utm_source=nancy-client&utm_medium=integration&utm_content=1.0.33).
+
+==================================================================================
+
+Language: Go
+Severity: HIGH
+Line: 46
+Column: 
+SecurityTool: Nancy
+Confidence: HIGH
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.mod
+Code: 	github.com/gogo/protobuf v1.3.1 // indirect
+RuleID: CVE-2021-3121
+Type: Vulnerability
+ReferenceHash: 318d8e7ad6e3d2ab5df166c6521aabfac2ac5c654011c2f735aa251d4c96b414
+Details: (1/1) * Possible vulnerability detected: [CVE-2021-3121] CWE-129: Improper Validation of Array Index
+An issue was discovered in GoGo Protobuf before 1.3.2. plugin/unmarshal/unmarshal.go lacks certain index validation, aka the "skippy peanut butter" issue. For more information, please checkout the following url (https://ossindex.sonatype.org/vulnerability/CVE-2021-3121?component-type=golang&component-name=github.com%2Fgogo%2Fprotobuf&utm_source=nancy-client&utm_medium=integration&utm_content=1.0.33).
+
+==================================================================================
+
+Language: Go
+Severity: HIGH
+Line: 89
+Column: 
+SecurityTool: Nancy
+Confidence: HIGH
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.mod
+Code: 	github.com/prometheus/client_golang v1.7.1 // indirect
+RuleID: CVE-2022-21698
+Type: Vulnerability
+ReferenceHash: 6aac753014b7fa5b0f49acc766a7495523935522e6e2b11a1f0604761414621e
+Details: (1/1) * Possible vulnerability detected: [CVE-2022-21698] CWE-400: Uncontrolled Resource Consumption ('Resource Exhaustion')
+client_golang is the instrumentation library for Go applications in Prometheus, and the promhttp package in client_golang provides tooling around HTTP servers and clients. In client_golang prior to version 1.11.1, HTTP server is susceptible to a Denial of Service through unbounded cardinality, and potential memory exhaustion, when handling requests with non-standard HTTP methods. In order to be affected, an instrumented software must use any of `promhttp.InstrumentHandler*` middleware except `RequestsInFlight`; not filter any specific methods (e.g GET) before middleware; pass metric with `method` label name to our middleware; and not have any firewall/LB/proxy that filters away requests with unknown `method`. client_golang version 1.11.1 contains a patch for this issue. Several workarounds are available, including removing the `method` label name from counter/gauge used in the InstrumentHandler; turning off affected promhttp handlers; adding custom middleware before promhttp handler that will sanitize the request method given by Go http.Request; and using a reverse proxy or web application firewall, configured to only allow a limited set of methods. For more information, please checkout the following url (https://ossindex.sonatype.org/vulnerability/CVE-2022-21698?component-type=golang&component-name=github.com%2Fprometheus%2Fclient_golang&utm_source=nancy-client&utm_medium=integration&utm_content=1.0.33).
+
+==================================================================================
+
+Language: Generic
+Severity: HIGH
+Line: 85
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
+	Installed Version: "0.13.0"
+	Update to Version: "v0.14.0" for fix this issue.
+RuleID: CVE-2020-13949
+Type: Vulnerability
+ReferenceHash: c193281bcff80abb3b500643b080edb2f159793a8e218fde3e31c20960ed4e16
+Details: (1/1) * Possible vulnerability detected: In Apache Thrift 0.9.3 to 0.13.0, malicious RPC clients could send short messages which would result in a large memory allocation, potentially leading to denial of service.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2020-13949.
+Cwe Links: (https://cwe.mitre.org/data/definitions/400.html)
+
+==================================================================================
+
+Language: Generic
+Severity: HIGH
+Line: 134
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/containerd/containerd v1.4.1/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
+	Installed Version: "1.4.1"
+	Update to Version: "v1.4.11, v1.5.7" for fix this issue.
+RuleID: CVE-2021-41103
+Type: Vulnerability
+ReferenceHash: 050c6510d5cb499119ea4b969353260b957d50fa081f252caa4c9cfc5a760bfc
+Details: (1/1) * Possible vulnerability detected: containerd is an open source container runtime with an emphasis on simplicity, robustness and portability. A bug was found in containerd where container root directories and some plugins had insufficiently restricted permissions, allowing otherwise unprivileged Linux users to traverse directory contents and execute programs. When containers included executable programs with extended permission bits (such as setuid), unprivileged Linux users could discover and execute those programs. When the UID of an unprivileged Linux user on the host collided with the file owner or group inside a container, the unprivileged Linux user on the host could discover, read, and modify those files. This vulnerability has been fixed in containerd 1.4.11 and containerd 1.5.7. Users should update to these version when they are released and may restart containers or update directory permissions to mitigate the vulnerability. Users unable to update should limit access to the host to trusted users. Update directory permission on container bundles directories.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2021-41103.
+Cwe Links: (https://cwe.mitre.org/data/definitions/22.html)
+
+==================================================================================
+
+Language: Generic
+Severity: HIGH
+Line: 134
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/containerd/containerd v1.4.1/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
+	Installed Version: "1.4.1"
+	Update to Version: "1.4.13, 1.5.10, 1.6.1" for fix this issue.
+RuleID: CVE-2022-23648
+Type: Vulnerability
+ReferenceHash: bb11b724ee47a44545247ba9898bb163e6df1fbecc462dc3fc16f12433294ebe
+Details: (1/1) * Possible vulnerability detected: containerd is a container runtime available as a daemon for Linux and Windows. A bug was found in containerd prior to versions 1.6.1, 1.5.10, and 1.14.12 where containers launched through containerd’s CRI implementation on Linux with a specially-crafted image configuration could gain access to read-only copies of arbitrary files and directories on the host. This may bypass any policy-based enforcement on container setup (including a Kubernetes Pod Security Policy) and expose potentially sensitive information. Kubernetes and crictl can both be configured to use containerd’s CRI implementation. This bug has been fixed in containerd 1.6.1, 1.5.10, and 1.4.12. Users should update to these versions to resolve the issue.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2022-23648.
+Cwe Links: (https://cwe.mitre.org/data/definitions/200.html)
+
+==================================================================================
+
+Language: Generic
+Severity: HIGH
+Line: 165
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
+
+RuleID: CVE-2020-26160
+Type: Vulnerability
+ReferenceHash: 8b62f92e6d47b24dbc066a32d14ec52c74ef97f9bc1d9463efa23a0edb99bc63
+Details: (1/1) * Possible vulnerability detected: jwt-go before 4.0.0-preview1 allows attackers to bypass intended access restrictions in situations with []string{} for m["aud"] (which is allowed by the specification). Because the type assertion fails, "" is the value of aud. This is a security problem if the JWT token is presented to a service that lacks its own audience check.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2020-26160.
+Cwe Links: (https://cwe.mitre.org/data/definitions/862.html)
+
+==================================================================================
+
+Language: Generic
+Severity: HIGH
+Line: 272
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
+	Installed Version: "1.3.1"
+	Update to Version: "1.3.2" for fix this issue.
+RuleID: CVE-2021-3121
+Type: Vulnerability
+ReferenceHash: 70d87bc61cd2d5681ba3fd2a0d52a5637f4ff95251d798a6339604850bb747cc
+Details: (1/1) * Possible vulnerability detected: An issue was discovered in GoGo Protobuf before 1.3.2. plugin/unmarshal/unmarshal.go lacks certain index validation, aka the "skippy peanut butter" issue.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2021-3121.
+Cwe Links: (https://cwe.mitre.org/data/definitions/129.html)
+
+==================================================================================
+
+Language: Generic
+Severity: HIGH
+Line: 548
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/nats-io/jwt v0.3.2/go.mod h1:/euKqTS1ZD+zzjYrY7pseZrTtWQSjujC7xjPc8wL6eU=
+	Installed Version: "0.3.2"
+	Update to Version: "1.2.3-0.20210314221642-a826c77dc9d2" for fix this issue.
+RuleID: CVE-2021-3127
+Type: Vulnerability
+ReferenceHash: ab1a5556a3539136ee70e98f0749e7a51ec2f7108ed987e51a979fb206694d7a
+Details: (1/1) * Possible vulnerability detected: NATS Server 2.x before 2.2.0 and JWT library before 2.0.1 have Incorrect Access Control because Import Token bindings are mishandled.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2021-3127.
+Cwe Links: (https://cwe.mitre.org/data/definitions/755.html)
+
+==================================================================================
+
+Language: Generic
+Severity: HIGH
+Line: 549
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/nats-io/nats-server/v2 v2.1.2/go.mod h1:Afk+wRZqkMQs/p45uXdrVLuab3gwv3Z8C4HTBu8GD/k=
+	Installed Version: "2.1.2"
+	Update to Version: "v2.2.0" for fix this issue.
+RuleID: CVE-2020-28466
+Type: Vulnerability
+ReferenceHash: 136363832d5215ba67c03f266fdadc63b5305a8b170dd4b174156d4e34d00e90
+Details: (1/2) * Possible vulnerability detected: This affects all versions of package github.com/nats-io/nats-server/server. Untrusted accounts are able to crash the server using configs that represent a service export/import cycles. Disclaimer from the maintainers: Running a NATS service which is exposed to untrusted users presents a heightened risk. Any remote execution flaw or equivalent seriousness, or denial-of-service by unauthenticated users, will lead to prompt releases by the NATS maintainers. Fixes for denial of service issues with no threat of remote execution, when limited to account holders, are likely to just be committed to the main development branch with no special attention. Those who are running such services are encouraged to build regularly from git.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2020-28466.
+         
+(2/2) * Possible vulnerability detected: NATS Server 2.x before 2.2.0 and JWT library before 2.0.1 have Incorrect Access Control because Import Token bindings are mishandled.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2021-3127.
+Cwe Links: (https://cwe.mitre.org/data/definitions/755.html)
+
+==================================================================================
+
+Language: Generic
+Severity: HIGH
+Line: 549
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/nats-io/nats-server/v2 v2.1.2/go.mod h1:Afk+wRZqkMQs/p45uXdrVLuab3gwv3Z8C4HTBu8GD/k=
+	Installed Version: "2.1.2"
+	Update to Version: "2.7.2" for fix this issue.
+RuleID: CVE-2022-24450
+Type: Vulnerability
+ReferenceHash: 839b2b338993b92ea5fde6467e56206ccd7532f549b68fe3dd2cbf2bcc88ff12
+Details: (1/1) * Possible vulnerability detected: NATS nats-server before 2.7.2 has Incorrect Access Control. Any authenticated user can obtain the privileges of the System account by misusing the "dynamically provisioned sandbox accounts" feature.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2022-24450.
+Cwe Links: (https://cwe.mitre.org/data/definitions/863.html)
+
+==================================================================================
+
+Language: Generic
+Severity: HIGH
+Line: 615
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/prometheus/client_golang v1.9.0/go.mod h1:FqZLKOZnGdFAhOK4nqGHa7D66IdsO+O441Eve7ptJDU=
+	Installed Version: "1.9.0"
+	Update to Version: "1.11.1" for fix this issue.
+RuleID: CVE-2022-21698
+Type: Vulnerability
+ReferenceHash: 67822e085d54b12024a35aec055ccd91edf4fe0f80a51113e97e892fe1bc5cbd
+Details: (1/1) * Possible vulnerability detected: client_golang is the instrumentation library for Go applications in Prometheus, and the promhttp package in client_golang provides tooling around HTTP servers and clients. In client_golang prior to version 1.11.1, HTTP server is susceptible to a Denial of Service through unbounded cardinality, and potential memory exhaustion, when handling requests with non-standard HTTP methods. In order to be affected, an instrumented software must use any of `promhttp.InstrumentHandler*` middleware except `RequestsInFlight`; not filter any specific methods (e.g GET) before middleware; pass metric with `method` label name to our middleware; and not have any firewall/LB/proxy that filters away requests with unknown `method`. client_golang version 1.11.1 contains a patch for this issue. Several workarounds are available, including removing the `method` label name from counter/gauge used in the InstrumentHandler; turning off affected promhttp handlers; adding custom middleware before promhttp handler that will sanitize the request method given by Go http.Request; and using a reverse proxy or web application firewall, configured to only allow a limited set of methods.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2022-21698.
+Cwe Links: (https://cwe.mitre.org/data/definitions/400.html)
+
+==================================================================================
+
+Language: Generic
+Severity: HIGH
+Line: 714
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/swaggo/http-swagger v1.0.0/go.mod h1:cKIcshBU9yEAnfWv6ZzVKSsEf8h5ozxB8/zHQWyOQ/8=
+	Installed Version: "1.0.0"
+	Update to Version: "v1.2.6" for fix this issue.
+RuleID: CVE-2022-24863
+Type: Vulnerability
+ReferenceHash: d639dbbf45802cf6ef09fdf987dc76193698ce531ee7024a0c083e45f0a8fab6
+Details: (1/1) * Possible vulnerability detected: http-swagger is an open source wrapper to automatically generate RESTful API documentation with Swagger 2.0. In versions of http-swagger prior to 1.2.6 an attacker may perform a denial of service attack consisting of memory exhaustion on the host system. The cause of the memory exhaustion is down to improper handling of http methods. Users are advised to upgrade. Users unable to upgrade may to restrict the path prefix to the "GET" method as a workaround.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2022-24863.
+Cwe Links: (https://cwe.mitre.org/data/definitions/755.html)
+
+==================================================================================
+
+Language: Generic
+Severity: HIGH
+Line: 750
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
+	Installed Version: "0.0.0-20191023171146-3cf2f69b5738"
+	Update to Version: "3.4.0" for fix this issue.
+RuleID: CVE-2018-1098
+Type: Vulnerability
+ReferenceHash: 9da71b514c729abf38fc73d8656f147e97b5f0d27af91d8390deef2cab3df474
+Details: (1/2) * Possible vulnerability detected: A cross-site request forgery flaw was found in etcd 3.3.1 and earlier. An attacker can set up a website that tries to send a POST request to the etcd server and modify a key. Adding a key is done with PUT so it is theoretically safe (can't PUT from an HTML form or such) but POST allows creating in-order keys that an attacker can send.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2018-1098.
+Cwe Links: (https://cwe.mitre.org/data/definitions/352.html)
+         
+(2/2) * Possible vulnerability detected: DNS rebinding vulnerability found in etcd 3.3.1 and earlier. An attacker can control his DNS records to direct to localhost, and trick the browser into sending requests to localhost (or any other address).
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2018-1099.
+Cwe Links: (https://cwe.mitre.org/data/definitions/20.html)
+
+==================================================================================
+
+Language: Generic
+Severity: HIGH
+Line: 750
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
+	Installed Version: "0.0.0-20191023171146-3cf2f69b5738"
+	Update to Version: "0.5.0-alpha.5.0.20190108173120-83c051b701d3" for fix this issue.
+RuleID: CVE-2018-16886
+Type: Vulnerability
+ReferenceHash: f3926ae71a8dd8031562bac8c8bf4aac86b73ee4c81ce94791ace68c6c13ef5e
+Details: (1/1) * Possible vulnerability detected: etcd versions 3.2.x before 3.2.26 and 3.3.x before 3.3.11 are vulnerable to an improper authentication issue when role-based access control (RBAC) is used and client-cert-auth is enabled. If an etcd client server TLS certificate contains a Common Name (CN) which matches a valid RBAC username, a remote attacker may authenticate as that user with any valid (trusted) client certificate in a REST API request to the gRPC-gateway.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2018-16886.
+Cwe Links: (https://cwe.mitre.org/data/definitions/287.html)
+
+==================================================================================
+
+Language: Generic
+Severity: HIGH
+Line: 795
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83 h1:/ZScEX8SfEmUGRHs0gxpqteO5nfNW6axyZbBdw9A12g=
+	Installed Version: "0.0.0-20210220033148-5ea612d1eb83"
+	Update to Version: "0.0.0-20220314234659-1baeb1ce4c0b" for fix this issue.
+RuleID: CVE-2022-27191
+Type: Vulnerability
+ReferenceHash: e32eab7289fef8307a61d9e7682dc28bc1ec30469bbc8dbfdf6a95fc393daf06
+Details: (1/1) * Possible vulnerability detected: The golang.org/x/crypto/ssh package before 0.0.0-20220314234659-1baeb1ce4c0b for Go allows an attacker to crash a server in certain circumstances involving AddHostKey.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2022-27191.
+Cwe Links: (https://cwe.mitre.org/data/definitions/327.html)
+
+==================================================================================
+
+Language: Generic
+Severity: HIGH
+Line: 879
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 h1:qWPm9rbaAMKs8Bq/9LRpbMqxWRVUAQwMI9fVrssnTfw=
+	Installed Version: "0.0.0-20210226172049-e18ecbb05110"
+	Update to Version: "0.0.0-20210520170846-37e1c6afe023" for fix this issue.
+RuleID: CVE-2021-33194
+Type: Vulnerability
+ReferenceHash: 9344322b876ec08a582ee98f69c81669d26fadfbbb4fdec027df32f2d453b295
+Details: (1/1) * Possible vulnerability detected: golang.org/x/net before v0.0.0-20210520170846-37e1c6afe023 allows attackers to cause a denial of service (infinite loop) via crafted ParseFragment input.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2021-33194.
+Cwe Links: (https://cwe.mitre.org/data/definitions/835.html)
+
+==================================================================================
+
+Language: Generic
+Severity: HIGH
+Line: 879
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 h1:qWPm9rbaAMKs8Bq/9LRpbMqxWRVUAQwMI9fVrssnTfw=
+	Installed Version: "0.0.0-20210226172049-e18ecbb05110"
+	Update to Version: "0.0.0-20211209124913-491a49abca63" for fix this issue.
+RuleID: CVE-2021-44716
+Type: Vulnerability
+ReferenceHash: 086d36c40254a25bfc847fb020cd0882a4f74b9f26d24418e071317e66e0470f
+Details: (1/1) * Possible vulnerability detected: net/http in Go before 1.16.12 and 1.17.x before 1.17.5 allows uncontrolled memory consumption in the header canonicalization cache via HTTP/2 requests.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2021-44716.
+Cwe Links: (https://cwe.mitre.org/data/definitions/400.html)
+
+==================================================================================
+
+Language: Generic
+Severity: HIGH
+Line: 966
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: golang.org/x/text v0.3.4 h1:0YWbFKbhXG/wIiuHDSKpS0Iy7FSA+u45VtBMfQcFTTc=
+	Installed Version: "0.3.4"
+	Update to Version: "0.3.7" for fix this issue.
+RuleID: CVE-2021-38561
+Type: Vulnerability
+ReferenceHash: da297fc45c1146c58006e9e098f12fc5268fd7eafbfff990dd7d1ed1be30f59d
+Details: (1/1) * Possible vulnerability detected: A flaw was found in golang. The language package for go language can panic due to an out-of-bounds read when an incorrectly formatted language tag is being parsed. This flaw allows an attacker to cause applications using this package to parse untrusted input data to crash, leading to a denial of service of the affected component.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2021-38561.
+
+==================================================================================
+
+Language: Go
+Severity: MEDIUM
+Line: 38
+Column: 7
+SecurityTool: GoSec
+Confidence: HIGH
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/api/util/util.go
+Code: 37: func GetMD5(s string) string {
+38: 	h := md5.New()
+39: 	io.WriteString(h, s) // #nohorus
+
+RuleID: G401
+Type: Vulnerability
+ReferenceHash: 53e26991220c99126dd29977f1f5e9ec4bde464301ff9f26880add0c537dd97d
+Details: (1/1) * Possible vulnerability detected: Use of weak cryptographic primitive
+
+==================================================================================
+
+Language: Go
+Severity: MEDIUM
+Line: 19
+Column: 2
+SecurityTool: GoSec
+Confidence: HIGH
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/api/util/util.go
+Code: 18: import (
+19: 	"crypto/md5"
+20: 	"fmt"
+
+RuleID: G501
+Type: Vulnerability
+ReferenceHash: a06b3404e246c8820533b847fd69ddf7cdadcc07749ffe0a2a840ba6b38daf3f
+Details: (1/1) * Possible vulnerability detected: Blocklisted import crypto/md5: weak cryptographic primitive
+
+==================================================================================
+
+Language: Go
+Severity: MEDIUM
+Line: 61
+Column: 
+SecurityTool: Nancy
+Confidence: HIGH
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.mod
+Code: 	github.com/jackc/pgproto3 v1.1.0 // indirect
+Type: Vulnerability
+ReferenceHash: 565eb2642f9ac5bd194a850ed6aa2fd95d893a8f8b672bb1fcfb5ff9f52149af
+Details: (1/1) * Possible vulnerability detected: 1 vulnerability found
+1 non-CVE vulnerability found. To see more details, please create a free account at https://ossindex.sonatype.org/ and request for this information using your registered account For more information, please checkout the following url (https://ossindex.sonatype.org/vulnerability/sonatype-2021-0853).
+
+==================================================================================
+
+Language: Go
+Severity: MEDIUM
+Line: 62
+Column: 
+SecurityTool: Nancy
+Confidence: HIGH
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.mod
+Code: 	github.com/jackc/pgproto3/v2 v2.0.6 // indirect
+Type: Vulnerability
+ReferenceHash: 854ebddb5f38166bfaa518e447f6e48c019d9e3793805427b94104df3e2b2cb7
+Details: (1/1) * Possible vulnerability detected: 1 vulnerability found
+1 non-CVE vulnerability found. To see more details, please create a free account at https://ossindex.sonatype.org/ and request for this information using your registered account For more information, please checkout the following url (https://ossindex.sonatype.org/vulnerability/sonatype-2021-0853).
+
+==================================================================================
+
+Language: Go
+Severity: MEDIUM
+Line: 571
+Column: 
+SecurityTool: Nancy
+Confidence: HIGH
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
+RuleID: CVE-2021-41190
+Type: Vulnerability
+ReferenceHash: 3d5678342c8b1c753a1d79243a834fdb9c7123ce4ec47f52079df5ee663fb7a0
+Details: (1/1) * Possible vulnerability detected: [CVE-2021-41190] CWE-843: Access of Resource Using Incompatible Type ('Type Confusion')
+The OCI Distribution Spec project defines an API protocol to facilitate and standardize the distribution of content. In the OCI Distribution Specification version 1.0.0 and prior, the Content-Type header alone was used to determine the type of document during push and pull operations. Documents that contain both “manifests” and “layers” fields could be interpreted as either a manifest or an index in the absence of an accompanying Content-Type header. If a Content-Type header changed between two pulls of the same digest, a client may interpret the resulting content differently. The OCI Distribution Specification has been updated to require that a mediaType value present in a manifest or index match the Content-Type header used during the push and pull operations. Clients pulling from a registry may distrust the Content-Type header and reject an ambiguous document that contains both “manifests” and “layers” fields or “manifests” and “config” fields if they are unable to update to version 1.0.1 of the spec. For more information, please checkout the following url (https://ossindex.sonatype.org/vulnerability/CVE-2021-41190?component-type=golang&component-name=github.com%2Fopencontainers%2Fimage-spec&utm_source=nancy-client&utm_medium=integration&utm_content=1.0.33).
+
+==================================================================================
+
+Language: Go
+Severity: MEDIUM
+Line: 732
+Column: 
+SecurityTool: Nancy
+Confidence: HIGH
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
+Type: Vulnerability
+ReferenceHash: 77f5d166d2f177dc07ba1e5998bcc307add10bb544de5aabacd96589d99848ea
+Details: (1/1) * Possible vulnerability detected: 1 vulnerability found
+1 non-CVE vulnerability found. To see more details, please create a free account at https://ossindex.sonatype.org/ and request for this information using your registered account For more information, please checkout the following url (https://ossindex.sonatype.org/vulnerability/sonatype-2021-1485).
+
+==================================================================================
+
+Language: Go
+Severity: MEDIUM
+Line: 113
+Column: 
+SecurityTool: Nancy
+Confidence: HIGH
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.mod
+Code: 	golang.org/x/text v0.3.4 // indirect
+RuleID: CVE-2021-38561
+Type: Vulnerability
+ReferenceHash: fc1b74afe2fadcded45d4a95388aa62c2629e735fe96c79ecbf220887f85a74a
+Details: (1/1) * Possible vulnerability detected: [CVE-2021-38561] CWE-125: Out-of-bounds Read
+golang-x-text - Out-of-bounds Read For more information, please checkout the following url (https://ossindex.sonatype.org/vulnerability/CVE-2021-38561?component-type=golang&component-name=golang.org%2Fx%2Ftext&utm_source=nancy-client&utm_medium=integration&utm_content=1.0.33).
+
+==================================================================================
+
+Language: Generic
+Severity: MEDIUM
+Line: 134
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/containerd/containerd v1.4.1/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
+	Installed Version: "1.4.1"
+	Update to Version: "1.2.0, 1.3.9, 1.4.3" for fix this issue.
+RuleID: CVE-2020-15257
+Type: Vulnerability
+ReferenceHash: bd130bd3e1e1642ec1b2cc08e9016ade9116b0a419062e7851942e7a1b44242b
+Details: (1/1) * Possible vulnerability detected: containerd is an industry-standard container runtime and is available as a daemon for Linux and Windows. In containerd before versions 1.3.9 and 1.4.3, the containerd-shim API is improperly exposed to host network containers. Access controls for the shim’s API socket verified that the connecting process had an effective UID of 0, but did not otherwise restrict access to the abstract Unix domain socket. This would allow malicious containers running in the same network namespace as the shim, with an effective UID of 0 but otherwise reduced privileges, to cause new processes to be run with elevated privileges. This vulnerability has been fixed in containerd 1.3.9 and 1.4.3. Users should update to these versions as soon as they are released. It should be noted that containers started with an old version of containerd-shim should be stopped and restarted, as running containers will continue to be vulnerable even after an upgrade. If you are not providing the ability for untrusted users to start containers in the same network namespace as the shim (typically the "host" network namespace, for example with docker run --net=host or hostNetwork: true in a Kubernetes pod) and run with an effective UID of 0, you are not vulnerable to this issue. If you are running containers with a vulnerable configuration, you can deny access to all abstract sockets with AppArmor by adding a line similar to deny unix addr=@**, to your policy. It is best practice to run containers with a reduced set of privileges, with a non-zero UID, and with isolated namespaces. The containerd maintainers strongly advise against sharing namespaces with the host. Reducing the set of isolation mechanisms used for a container necessarily increases that container's privilege, regardless of what container runtime is used for running that container.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2020-15257.
+Cwe Links: (https://cwe.mitre.org/data/definitions/669.html)
+
+==================================================================================
+
+Language: Generic
+Severity: MEDIUM
+Line: 134
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/containerd/containerd v1.4.1/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
+	Installed Version: "1.4.1"
+	Update to Version: "v1.3.10, v1.4.4" for fix this issue.
+RuleID: CVE-2021-21334
+Type: Vulnerability
+ReferenceHash: d29ad8e1d53afaf6146a3b225b6c12ce858244238aeb89904dc4d4fd52bf515f
+Details: (1/1) * Possible vulnerability detected: In containerd (an industry-standard container runtime) before versions 1.3.10 and 1.4.4, containers launched through containerd's CRI implementation (through Kubernetes, crictl, or any other pod/container client that uses the containerd CRI service) that share the same image may receive incorrect environment variables, including values that are defined for other containers. If the affected containers have different security contexts, this may allow sensitive information to be unintentionally shared. If you are not using containerd's CRI implementation (through one of the mechanisms described above), you are not vulnerable to this issue. If you are not launching multiple containers or Kubernetes pods from the same image which have different environment variables, you are not vulnerable to this issue. If you are not launching multiple containers or Kubernetes pods from the same image in rapid succession, you have reduced likelihood of being vulnerable to this issue This vulnerability has been fixed in containerd 1.3.10 and containerd 1.4.4. Users should update to these versions.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2021-21334.
+Cwe Links: (https://cwe.mitre.org/data/definitions/668.html)
+
+==================================================================================
+
+Language: Generic
+Severity: MEDIUM
+Line: 134
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/containerd/containerd v1.4.1/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
+	Installed Version: "1.4.1"
+	Update to Version: "v1.4.8, v1.5.4" for fix this issue.
+RuleID: CVE-2021-32760
+Type: Vulnerability
+ReferenceHash: 599bc20a0823db6b6cb6cb268eb4a31c6bca121b1ab6a59de66a521539eeac42
+Details: (1/1) * Possible vulnerability detected: containerd is a container runtime. A bug was found in containerd versions prior to 1.4.8 and 1.5.4 where pulling and extracting a specially-crafted container image can result in Unix file permission changes for existing files in the host’s filesystem. Changes to file permissions can deny access to the expected owner of the file, widen access to others, or set extended bits like setuid, setgid, and sticky. This bug does not directly allow files to be read, modified, or executed without an additional cooperating process. This bug has been fixed in containerd 1.5.4 and 1.4.8. As a workaround, ensure that users only pull images from trusted sources. Linux security modules (LSMs) like SELinux and AppArmor can limit the files potentially affected by this bug through policies and profiles that prevent containerd from interacting with specific files.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2021-32760.
+Cwe Links: (https://cwe.mitre.org/data/definitions/668.html)
+
+==================================================================================
+
+Language: Generic
+Severity: MEDIUM
+Line: 134
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/containerd/containerd v1.4.1/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
+	Installed Version: "1.4.1"
+	Update to Version: "v1.5.13, v1.6.6" for fix this issue.
+RuleID: CVE-2022-31030
+Type: Vulnerability
+ReferenceHash: c10c7ac6749677555bda2ed12edf715b3802718ce2759a0d8238e56a5427b545
+Details: (1/2) * Possible vulnerability detected: containerd is an open source container runtime. A bug was found in the containerd's CRI implementation where programs inside a container can cause the containerd daemon to consume memory without bound during invocation of the `ExecSync` API. This can cause containerd to consume all available memory on the computer, denying service to other legitimate workloads. Kubernetes and crictl can both be configured to use containerd's CRI implementation; `ExecSync` may be used when running probes or when executing processes via an "exec" facility. This bug has been fixed in containerd 1.6.6 and 1.5.13. Users should update to these versions to resolve the issue. Users unable to upgrade should ensure that only trusted images and commands are used.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2022-31030.
+Cwe Links: (https://cwe.mitre.org/data/definitions/400.html)
+         
+(2/2) * Possible vulnerability detected: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection') in github.com/containerd/containerd.
+PrimaryURL: https://github.com/advisories/GHSA-5ffw-gxpp-mxpf.
+
+==================================================================================
+
+Language: Generic
+Severity: MEDIUM
+Line: 525
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
+	Installed Version: "1.0.14"
+	Update to Version: "1.1.25-0.20191211073109-8ebf2e419df7" for fix this issue.
+RuleID: CVE-2019-19794
+Type: Vulnerability
+ReferenceHash: fba79d864c0ca5c4aab97dbdcd7f795c9bbde24dd2545aeb88d79b9d499968d1
+Details: (1/1) * Possible vulnerability detected: The miekg Go DNS package before 1.1.25, as used in CoreDNS before 1.6.6 and other products, improperly generates random numbers because math/rand is used. The TXID becomes predictable, leading to response forgeries.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2019-19794.
+Cwe Links: (https://cwe.mitre.org/data/definitions/338.html)
+
+==================================================================================
+
+Language: Generic
+Severity: MEDIUM
+Line: 750
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
+	Installed Version: "0.0.0-20191023171146-3cf2f69b5738"
+	Update to Version: "0.5.0-alpha.5.0.20200423152442-f4b650b51dc4" for fix this issue.
+RuleID: CVE-2020-15106
+Type: Vulnerability
+ReferenceHash: bfd32abe19fda7fc0b1acb34458d5c5a4ae9ed9515be79459e86a15b4361f6a6
+Details: (1/2) * Possible vulnerability detected: In etcd before versions 3.3.23 and 3.4.10, a large slice causes panic in decodeRecord method. The size of a record is stored in the length field of a WAL file and no additional validation is done on this data. Therefore, it is possible to forge an extremely large frame size that can unintentionally panic at the expense of any RAFT participant trying to decode the WAL.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2020-15106.
+         
+(2/2) * Possible vulnerability detected: In etcd before versions 3.3.23 and 3.4.10, it is possible to have an entry index greater then the number of entries in the ReadAll method in wal/wal.go. This could cause issues when WAL entries are being read during consensus as an arbitrary etcd consensus participant could go down from a runtime panic when reading the entry.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2020-15112.
+Cwe Links: (https://cwe.mitre.org/data/definitions/129.html)
+
+==================================================================================
+
+Language: Generic
+Severity: MEDIUM
+Line: 751
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: go.mongodb.org/mongo-driver v1.1.0/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
+	Installed Version: "1.1.0"
+	Update to Version: "1.5.1" for fix this issue.
+RuleID: CVE-2021-20329
+Type: Vulnerability
+ReferenceHash: 3bfc1be7cd2b4ee5888e6cb5c8c15dda3677914df44e7625c6519901bc839eb5
+Details: (1/1) * Possible vulnerability detected: Specific cstrings input may not be properly validated in the MongoDB Go Driver when marshalling Go objects into BSON. A malicious user could use a Go object with specific string to potentially inject additional fields into marshalled documents. This issue affects all MongoDB GO Drivers up to (and including) 1.5.0.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2021-20329.
+Cwe Links: (https://cwe.mitre.org/data/definitions/20.html)
+
+==================================================================================
+
+Language: Generic
+Severity: MEDIUM
+Line: 879
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 h1:qWPm9rbaAMKs8Bq/9LRpbMqxWRVUAQwMI9fVrssnTfw=
+	Installed Version: "0.0.0-20210226172049-e18ecbb05110"
+	Update to Version: "0.0.0-20210428140749-89ef3d95e781" for fix this issue.
+RuleID: CVE-2021-31525
+Type: Vulnerability
+ReferenceHash: ba0f25f61d6f419c8980d7fdcd2af4d93b476f13850e6f22c8d48b4e1705fcad
+Details: (1/1) * Possible vulnerability detected: net/http in Go before 1.15.12 and 1.16.x before 1.16.4 allows remote attackers to cause a denial of service (panic) via a large header to ReadRequest or ReadResponse. Server, Transport, and Client can each be affected in some configurations.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2021-31525.
+Cwe Links: (https://cwe.mitre.org/data/definitions/674.html)
+
+==================================================================================
+
+Language: Generic
+Severity: MEDIUM
+Line: 957
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: golang.org/x/sys v0.0.0-20201214210602-f9fddec55a1e h1:AyodaIpKjppX+cBfTASF2E1US3H2JFBj920Ot3rtDjs=
+	Installed Version: "0.0.0-20201214210602-f9fddec55a1e"
+	Update to Version: "0.0.0-20220412211240-33da011f77ad" for fix this issue.
+RuleID: CVE-2022-29526
+Type: Vulnerability
+ReferenceHash: e4eee3e55de59a865c85f2842c71e4e43f3b41768116313b279305397e98aceb
+Details: (1/1) * Possible vulnerability detected: Go before 1.17.10 and 1.18.x before 1.18.2 has Incorrect Privilege Assignment. When called with a non-zero flags parameter, the Faccessat function could incorrectly report that a file is accessible.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2022-29526.
+Cwe Links: (https://cwe.mitre.org/data/definitions/269.html)
+
+==================================================================================
+
+Language: Go
+Severity: LOW
+Line: 39
+Column: 2
+SecurityTool: GoSec
+Confidence: HIGH
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/api/util/util.go
+Code: : 	h := md5.New()
+39: 	io.WriteString(h, s) // #nohorus
+40: 	md5Result := fmt.Sprintf("%x", h.Sum(ni
+RuleID: G104
+Type: Vulnerability
+ReferenceHash: 4d6bec725b592e20ae221f09048dcc7eb30329ec56f0f1fa71b24a128bd3c9a3
+Details: (1/1) * Possible vulnerability detected: Errors unhandled.
+
+==================================================================================
+
+Language: Generic
+Severity: UNKNOWN
+Line: 98
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+	Installed Version: "1.27.0"
+	Update to Version: "1.34.0" for fix this issue.
+RuleID: GO-2022-0391
+Type: Vulnerability
+ReferenceHash: 094ed122d8e6f9c170c756e8359bb58eb8aab38bb121dddf4e6256118aa0aa22
+Details: (1/1) * Possible vulnerability detected: The AWS S3 Crypto SDK sends an unencrypted hash of the plaintext alongside
+the ciphertext as a metadata field. This hash can be used to brute force
+the plaintext, if the hash is readable to the attacker.AWS now blocks this metadata field, but older SDK versions still send it.
+
+==================================================================================
+
+Language: Generic
+Severity: UNKNOWN
+Line: 134
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/containerd/containerd v1.4.1/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
+	Installed Version: "1.4.1"
+	Update to Version: "1.4.12, 1.5.8" for fix this issue.
+RuleID: GHSA-5j5w-g665-5m35
+Type: Vulnerability
+ReferenceHash: 051b5f8b995c92f1d0b1e73e98bd07a97af84382b068f1230e0ce60e5db3e98e
+Details: (1/1) * Possible vulnerability detected: In the OCI Distribution Specification version 1.0.0 and prior and in the OCI Image Specification version 1.0.1 and prior, manifest and index documents are ambiguous without an accompanying Content-Type HTTP header.
+PrimaryURL: https://github.com/advisories/GHSA-5j5w-g665-5m35.
+
+==================================================================================
+
+Language: Generic
+Severity: UNKNOWN
+Line: 173
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+	Installed Version: "2.7.1+incompatible"
+	Update to Version: "v2.8.0" for fix this issue.
+RuleID: GHSA-qq97-vm5h-rrhg
+Type: Vulnerability
+ReferenceHash: 20fd869dbd72efa2fb071d26372d01ae9ca1c0cd3a4b25cd8e59fc68223de7f6
+Details: (1/1) * Possible vulnerability detected: ### ImpactSystems that rely on digest equivalence for image attestations may be vulnerable to type confusion.
+PrimaryURL: https://github.com/advisories/GHSA-qq97-vm5h-rrhg.
+
+==================================================================================
+
+Language: Generic
+Severity: UNKNOWN
+Line: 548
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/nats-io/jwt v0.3.2/go.mod h1:/euKqTS1ZD+zzjYrY7pseZrTtWQSjujC7xjPc8wL6eU=
+	Installed Version: "0.3.2"
+	Update to Version: "v2.0.1" for fix this issue.
+RuleID: GHSA-62mh-w5cv-p88c
+Type: Vulnerability
+ReferenceHash: 494b9727668898554f00b30b6f25b3d4766d15f3b04d1dd051713580c1120dbd
+Details: (1/1) * Possible vulnerability detected: The NATS server provides for Subjects which are namespaced by Account; all Subjects are supposed to be private to an account, with an `Export/Import` system used to grant cross-account access to some Subjects. Some Exports are public, such that anyone can import the relevant subjects, and some Exports are private, such that the Import requires a token JWT to prove permission. The JWT library's validation of the bindings in the `Import Token` incorrectly warned on mismatches, instead of outright rejecting the token. As a result, any account can take an Import token used by any other account and re-use it for themselves because the binding to the importing account is not rejected, and use it to import any Subject from the Exporting account, not just the Subject referenced in the Import Token. The NATS account-server system treats account JWTs as semi-public information, such that an attacker can easily enumerate all account JWTs and retrieve all Import Tokens from those account JWTs.
+PrimaryURL: https://github.com/advisories/GHSA-62mh-w5cv-p88c.
+
+==================================================================================
+
+Language: Generic
+Severity: UNKNOWN
+Line: 549
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/nats-io/nats-server/v2 v2.1.2/go.mod h1:Afk+wRZqkMQs/p45uXdrVLuab3gwv3Z8C4HTBu8GD/k=
+	Installed Version: "2.1.2"
+	Update to Version: "2.2.0" for fix this issue.
+RuleID: GHSA-gwj5-3vfq-q992
+Type: Vulnerability
+ReferenceHash: df21a68ed04bc3f0c1e944fad73247e80cfe2b595a4fdb401933f7e2e5d3ea61
+Details: (1/2) * Possible vulnerability detected: (This advisory is canonically <https://advisories.nats.io/CVE/CVE-2020-28466.txt>)## Problem DescriptionAn export/import cycle between accounts could crash the nats-server, after consuming CPU and memory.This issue was fixed publicly in <https://github.com/nats-io/nats-server/pull/1731> in November 2020.The need to call this out as a security issue was highlighted by `snyk.io` and we are grateful for their assistance in doing so.Organizations which run a NATS service providing access to accounts run by untrusted third parties are affected.
+See below for an important caveat if running such a service.
+## Affected versions#### NATS Server * Version 2 prior to 2.2.0
+   + 2.0.0 through and including 2.1.9 are vulnerable.
+ * fixed with nats-io/nats-server PR 1731, commit 2e3c226729
+## ImpactThe nats-server could be killed, after consuming resources.
+## WorkaroundThe import cycle requires at least two accounts to work; if you have open account sign-up, then restricting new account sign-up might hinder an attacker.
+## SolutionUpgrade the nats-server.
+## Caveat on NATS with untrusted usersRunning a NATS service which is exposed to untrusted users presents a heightened risk.Any remote execution flaw or equivalent seriousness, or denial-of-service by unauthenticated users, will lead to prompt releases by the NATS maintainers.Fixes for denial of service issues with no threat of remote execution, when limited to account holders, are likely to just be committed to the main development branch with no special attention.Those who are running such services are encouraged to build regularly from git.
+PrimaryURL: https://github.com/advisories/GHSA-gwj5-3vfq-q992.
+         
+(2/2) * Possible vulnerability detected: (This advisory is canonically <https://advisories.nats.io/CVE/CVE-2021-3127.txt>)## Problem DescriptionThe NATS server provides for Subjects which are namespaced by Account; all Subjects are supposed to be private to an account, with an Export/Import system used to grant cross-account access to some Subjects.  Some Exports are public, such that anyone can import the
+relevant subjects, and some Exports are private, such that the Import requires a token JWT to prove permission.The JWT library's validation of the bindings in the Import Token incorrectly warned on mismatches, instead of outright rejecting the token.As a result, any account can take an Import token used by any other account and re-use it for themselves because the binding to the
+importing account is not rejected, and use it to import *any* Subject from the Exporting account, not just the Subject referenced in the Import Token.The NATS account-server system treats account JWTs as semi-public information, such that an attacker can easily enumerate all account JWTs and retrieve all Import Tokens from those account JWTs.The CVE identifier should cover the JWT library repair and the nats-server containing the fixed JWT library, and any other application depending upon the fixed JWT library.
+## Affected versions#### JWT library * all versions prior to 2.0.1
+ * fixed after nats-io/jwt#149 landed (2021-03-14)#### NATS Server * Version 2 prior to 2.2.0
+   + 2.0.0 through and including 2.1.9 are vulnerable
+ * fixed with nats-io/nats-server@423b79440c (2021-03-14)
+## ImpactIn deployments with untrusted accounts able to update the Account Server with imports, a malicious account can access any Subject from an account which provides Exported Subjects.Abuse of this facility requires the malicious actor to upload their tampered Account JWT to the Account Server, providing the service operator with a data-store which can be scanned for signs of abuse.
+## WorkaroundDeny access to clients to update their account JWT in the account server.
+## SolutionUpgrade the JWT dependency in any application using it.Upgrade the NATS server if using NATS Accounts (with private Exports; Account owners can create those at any time though).Audit all accounts JWTs to scan for exploit attempts; a Python script to audit the accounts can be found at <https://gist.github.com/philpennock/09d49524ad98043ff11d8a40c2bb0d5a>.
+PrimaryURL: https://github.com/advisories/GHSA-j756-f273-xhp4.
+
+==================================================================================
+
+Language: Generic
+Severity: UNKNOWN
+Line: 571
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
+	Installed Version: "1.0.1"
+	Update to Version: "1.0.2" for fix this issue.
+RuleID: GHSA-77vh-xpmg-72qh
+Type: Vulnerability
+ReferenceHash: ebeecf1d4961049b2aca587ee83d5584a13243f31f7769a57a8435a793f6f03a
+Details: (1/1) * Possible vulnerability detected: ### Impact
+In the OCI Image Specification version 1.0.1 and prior, manifest and index documents are not self-describing and documents with a single digest could be interpreted as either a manifest or an index.### Patches
+The Image Specification will be updated to recommend that both manifest and index documents contain a `mediaType` field to identify the type of document.
+PrimaryURL: https://github.com/advisories/GHSA-77vh-xpmg-72qh.
+
+==================================================================================
+
+In this analysis, a total of 47 possible vulnerabilities were found and we classified them into:
+Total of Vulnerability CRITICAL is: 4
+Total of Vulnerability HIGH is: 20
+Total of Vulnerability MEDIUM is: 16
+Total of Vulnerability LOW is: 1
+Total of Vulnerability UNKNOWN is: 6
+
+==================================================================================
+
+
+time="2022-07-26T18:09:25-03:00" level=warning msg="{HORUSEC_CLI} No authorization token was found, your code it is not going to be sent to horusec. Please enter a token with the -a flag to configure and save your analysis"
+
+time="2022-07-26T18:09:25-03:00" level=warning msg="{HORUSEC_CLI} 47 VULNERABILITIES WERE FOUND IN YOUR CODE SENT TO HORUSEC, TO SEE MORE DETAILS USE THE LOG LEVEL AS DEBUG AND TRY AGAIN"
+
+time="2022-07-26T18:09:25-03:00" level=warning msg="{HORUSEC_CLI} Horusec not show info vulnerabilities in this analysis, to see info vulnerabilities add option \"--information-severity=true\". For more details use (horusec start --help) command."
+=== RUN   TestAnalyzerWithoutMock/Should_run_all_analysis_and_send_to_server_correctly
+
+time="2022-07-26T18:09:25-03:00" level=warning msg="Horusec will return a timeout after 600 seconds. This time can be customized in the cli settings."
+
+time="2022-07-26T18:09:25-03:00" level=warning msg="{HORUSEC_CLI} PLEASE DON'T REMOVE \".horusec\" FOLDER BEFORE THE ANALYSIS FINISH! Don’t worry, we’ll remove it after the analysis ends automatically! Project sent to folder in location: [/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/.horusec/e9d28b47-98b3-44dd-84f9-b941a4c83be8]"
+
+[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[K⣟ Scanning code ...[K⣯ Scanning code ...[K⣷ Scanning code ...[K⣾ Scanning code ...[K⣽ Scanning code ...[K⣻ Scanning code ...[K⢿ Scanning code ...[K⡿ Scanning code ...[Ktime="2022-07-26T18:10:03-03:00" level=error msg="[HORUSEC] something went wrong while sending analysis to horusec -> "
+
+
+==================================================================================
+
+HORUSEC ENDED THE ANALYSIS WITH STATUS OF "success" AND WITH THE FOLLOWING RESULTS:
+
+==================================================================================
+
+Analysis StartedAt: 2022-07-26 18:09:25
+Analysis FinishedAt: 2022-07-26 18:10:03
+
+==================================================================================
+
+Language: Leaks
+Severity: CRITICAL
+Line: 26
+Column: 1
+SecurityTool: HorusecEngine
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example2/main.go
+Code: password := "password"
+RuleID: HS-LEAKS-26
+Type: Vulnerability
+ReferenceHash: a9ce8cda7a343a56726511692ae611b79bac5e79473847759cf45ac505142a82
+Details: (1/1) * Possible vulnerability detected: Hard-coded password
+The software contains hard-coded credentials, such as a password or cryptographic key, which it uses for its own inbound authentication, outbound communication to external components, or encryption of internal data. For more information checkout the CWE-798 (https://cwe.mitre.org/data/definitions/798.html) advisory.
+
+==================================================================================
+
+Language: Leaks
+Severity: CRITICAL
+Line: 32
+Column: 20
+SecurityTool: HorusecEngine
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example2/main.go
+Code: URI := fmt.Sprint("postgresql://root:root@postgresql:5432/horusecDB?sslmode=disable")
+RuleID: HS-LEAKS-27
+Type: Vulnerability
+ReferenceHash: acb9003db490b067688e19b7b2fac02aa0d98c459e7f32fc35f10700e443648c
+Details: (1/1) * Possible vulnerability detected: Password found in a hardcoded URL
+A password was found in a hardcoded URL, this can lead to not only the leak of this password but also a failure point to some more sophisticated CSRF and SSRF attacks. Check CWE-352 (https://cwe.mitre.org/data/definitions/352.html) and CWE-918 (https://cwe.mitre.org/data/definitions/918.html) for more details.
+
+==================================================================================
+
+Language: Generic
+Severity: CRITICAL
+Line: 548
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/nats-io/jwt v0.3.2/go.mod h1:/euKqTS1ZD+zzjYrY7pseZrTtWQSjujC7xjPc8wL6eU=
+	Installed Version: "0.3.2"
+	Update to Version: "1.1.0" for fix this issue.
+RuleID: CVE-2020-26892
+Type: Vulnerability
+ReferenceHash: f99194de8dd5153529c53eab4aee8e0c6620669512feb932779432d947d07314
+Details: (1/2) * Possible vulnerability detected: The JWT library in NATS nats-server before 2.1.9 has Incorrect Access Control because of how expired credentials are handled.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2020-26892.
+Cwe Links: (https://cwe.mitre.org/data/definitions/798.html)
+         
+(2/2) * Possible vulnerability detected: The JWT library in NATS nats-server before 2.1.9 allows a denial of service (a nil dereference in Go code).
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2020-26521.
+Cwe Links: (https://cwe.mitre.org/data/definitions/476.html)
+
+==================================================================================
+
+Language: Generic
+Severity: CRITICAL
+Line: 549
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/nats-io/nats-server/v2 v2.1.2/go.mod h1:Afk+wRZqkMQs/p45uXdrVLuab3gwv3Z8C4HTBu8GD/k=
+	Installed Version: "2.1.2"
+	Update to Version: "2.1.9" for fix this issue.
+RuleID: CVE-2020-26892
+Type: Vulnerability
+ReferenceHash: 4fda2c6d714f3313ebafe40494d555c1b86f59469d21ffe6d47cbe11442dc783
+Details: (1/4) * Possible vulnerability detected: The JWT library in NATS nats-server before 2.1.9 has Incorrect Access Control because of how expired credentials are handled.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2020-26892.
+Cwe Links: (https://cwe.mitre.org/data/definitions/798.html)
+         
+(2/4) * Possible vulnerability detected: The JWT library in NATS nats-server before 2.1.9 allows a denial of service (a nil dereference in Go code).
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2020-26521.
+Cwe Links: (https://cwe.mitre.org/data/definitions/476.html)
+         
+(3/4) * Possible vulnerability detected: (This advisory is canonically https://advisories.nats.io/CVE/CVE-2020-26892.txt )## Problem DescriptionNATS nats-server through 2020-10-07 has Incorrect Access Control because of how expired credentials are handled.The NATS accounts system has expiration timestamps on credentials; the <https://github.com/nats-io/jwt> library had an API which encouraged misuse and an `IsRevoked()` method which misused its own API.A new `IsClaimRevoked()` method has correct handling and the nats-server has been updated to use this.  The old `IsRevoked()` method now always returns true and other client code will have to be updated to avoid calling it.The CVE identifier should cover any application using the old JWT API, where the nats-server is one of those applications.
+## Affected versions#### JWT library * all versions prior to 1.1.0
+ * fixed after nats-io/jwt PR 103 landed (2020-10-06)#### NATS Server * Version 2 prior to 2.1.9
+   + 2.0.0 through and including 2.1.8 are vulnerable.
+ * fixed with nats-io/nats-server PRs 1632, 1635, 1645
+## ImpactTime-based credential expiry did not work.
+## WorkaroundHave credentials which only expire after fixes can be deployed.
+## SolutionUpgrade the JWT dependency in any application using it.Upgrade the NATS server if using NATS Accounts.
+PrimaryURL: https://github.com/advisories/GHSA-2c64-vj8g-vwrq.
+         
+(4/4) * Possible vulnerability detected: (This advisory is canonically <https://advisories.nats.io/CVE/CVE-2020-26521.txt>)## Problem DescriptionThe NATS account system has an Operator trusted by the servers, which signs Accounts, and each Account can then create and sign Users within their account.  The Operator should be able to safely issue Accounts to other entities which it does not fully trust.A malicious Account could create and sign a User JWT with a state not created by the normal tooling, such that decoding by the NATS JWT library (written in Go) would attempt a nil dereference, aborting execution.The NATS Server is known to be impacted by this.
+## Affected versions#### JWT library * all versions prior to 1.1.0#### NATS Server * Version 2 prior to 2.1.9
+## Impact#### JWT library * Programs would nil dereference and panic, aborting execution by default.#### NATS server * Denial of Service caused by process termination
+## WorkaroundIf your NATS servers do not trust any accounts which are managed by untrusted entities, then malformed User credentials are unlikely to be encountered.
+## SolutionUpgrade the JWT dependency in any application using it.Upgrade the NATS server if using NATS Accounts.
+PrimaryURL: https://github.com/advisories/GHSA-hmm9-r2m2-qg9w.
+
+==================================================================================
+
+Language: Go
+Severity: HIGH
+Line: 21
+Column: 
+SecurityTool: Nancy
+Confidence: HIGH
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.mod
+Code: 	github.com/containerd/containerd v1.4.1 // indirect
+RuleID: CVE-2021-41103
+Type: Vulnerability
+ReferenceHash: 33f54c0870abd03eb16a5281f27bbf1e66f6598784dcb03aca86eb8e02ed0fb6
+Details: (1/1) * Possible vulnerability detected: [CVE-2021-41103] CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
+containerd is an open source container runtime with an emphasis on simplicity, robustness and portability. A bug was found in containerd where container root directories and some plugins had insufficiently restricted permissions, allowing otherwise unprivileged Linux users to traverse directory contents and execute programs. When containers included executable programs with extended permission bits (such as setuid), unprivileged Linux users could discover and execute those programs. When the UID of an unprivileged Linux user on the host collided with the file owner or group inside a container, the unprivileged Linux user on the host could discover, read, and modify those files. This vulnerability has been fixed in containerd 1.4.11 and containerd 1.5.7. Users should update to these version when they are released and may restart containers or update directory permissions to mitigate the vulnerability. Users unable to update should limit access to the host to trusted users. Update directory permission on container bundles directories. For more information, please checkout the following url (https://ossindex.sonatype.org/vulnerability/CVE-2021-41103?component-type=golang&component-name=github.com%2Fcontainerd%2Fcontainerd&utm_source=nancy-client&utm_medium=integration&utm_content=1.0.33).
+
+==================================================================================
+
+Language: Go
+Severity: HIGH
+Line: 32
+Column: 
+SecurityTool: Nancy
+Confidence: HIGH
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.mod
+Code: 	github.com/gin-gonic/gin v1.6.3 // indirect
+RuleID: CVE-2020-28483
+Type: Vulnerability
+ReferenceHash: c42a2b2e19d7ca74fb544a80f6e6a703ef8d415049b4ef68f57c99ea86885d78
+Details: (1/1) * Possible vulnerability detected: [CVE-2020-28483] CWE-444: Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
+This affects all versions of package github.com/gin-gonic/gin. When gin is exposed directly to the internet, a client's IP can be spoofed by setting the X-Forwarded-For header. For more information, please checkout the following url (https://ossindex.sonatype.org/vulnerability/CVE-2020-28483?component-type=golang&component-name=github.com%2Fgin-gonic%2Fgin&utm_source=nancy-client&utm_medium=integration&utm_content=1.0.33).
+
+==================================================================================
+
+Language: Go
+Severity: HIGH
+Line: 46
+Column: 
+SecurityTool: Nancy
+Confidence: HIGH
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.mod
+Code: 	github.com/gogo/protobuf v1.3.1 // indirect
+RuleID: CVE-2021-3121
+Type: Vulnerability
+ReferenceHash: 318d8e7ad6e3d2ab5df166c6521aabfac2ac5c654011c2f735aa251d4c96b414
+Details: (1/1) * Possible vulnerability detected: [CVE-2021-3121] CWE-129: Improper Validation of Array Index
+An issue was discovered in GoGo Protobuf before 1.3.2. plugin/unmarshal/unmarshal.go lacks certain index validation, aka the "skippy peanut butter" issue. For more information, please checkout the following url (https://ossindex.sonatype.org/vulnerability/CVE-2021-3121?component-type=golang&component-name=github.com%2Fgogo%2Fprotobuf&utm_source=nancy-client&utm_medium=integration&utm_content=1.0.33).
+
+==================================================================================
+
+Language: Go
+Severity: HIGH
+Line: 89
+Column: 
+SecurityTool: Nancy
+Confidence: HIGH
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.mod
+Code: 	github.com/prometheus/client_golang v1.7.1 // indirect
+RuleID: CVE-2022-21698
+Type: Vulnerability
+ReferenceHash: 6aac753014b7fa5b0f49acc766a7495523935522e6e2b11a1f0604761414621e
+Details: (1/1) * Possible vulnerability detected: [CVE-2022-21698] CWE-400: Uncontrolled Resource Consumption ('Resource Exhaustion')
+client_golang is the instrumentation library for Go applications in Prometheus, and the promhttp package in client_golang provides tooling around HTTP servers and clients. In client_golang prior to version 1.11.1, HTTP server is susceptible to a Denial of Service through unbounded cardinality, and potential memory exhaustion, when handling requests with non-standard HTTP methods. In order to be affected, an instrumented software must use any of `promhttp.InstrumentHandler*` middleware except `RequestsInFlight`; not filter any specific methods (e.g GET) before middleware; pass metric with `method` label name to our middleware; and not have any firewall/LB/proxy that filters away requests with unknown `method`. client_golang version 1.11.1 contains a patch for this issue. Several workarounds are available, including removing the `method` label name from counter/gauge used in the InstrumentHandler; turning off affected promhttp handlers; adding custom middleware before promhttp handler that will sanitize the request method given by Go http.Request; and using a reverse proxy or web application firewall, configured to only allow a limited set of methods. For more information, please checkout the following url (https://ossindex.sonatype.org/vulnerability/CVE-2022-21698?component-type=golang&component-name=github.com%2Fprometheus%2Fclient_golang&utm_source=nancy-client&utm_medium=integration&utm_content=1.0.33).
+
+==================================================================================
+
+Language: Generic
+Severity: HIGH
+Line: 85
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
+	Installed Version: "0.13.0"
+	Update to Version: "v0.14.0" for fix this issue.
+RuleID: CVE-2020-13949
+Type: Vulnerability
+ReferenceHash: c193281bcff80abb3b500643b080edb2f159793a8e218fde3e31c20960ed4e16
+Details: (1/1) * Possible vulnerability detected: In Apache Thrift 0.9.3 to 0.13.0, malicious RPC clients could send short messages which would result in a large memory allocation, potentially leading to denial of service.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2020-13949.
+Cwe Links: (https://cwe.mitre.org/data/definitions/400.html)
+
+==================================================================================
+
+Language: Generic
+Severity: HIGH
+Line: 134
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/containerd/containerd v1.4.1/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
+	Installed Version: "1.4.1"
+	Update to Version: "v1.4.11, v1.5.7" for fix this issue.
+RuleID: CVE-2021-41103
+Type: Vulnerability
+ReferenceHash: 050c6510d5cb499119ea4b969353260b957d50fa081f252caa4c9cfc5a760bfc
+Details: (1/1) * Possible vulnerability detected: containerd is an open source container runtime with an emphasis on simplicity, robustness and portability. A bug was found in containerd where container root directories and some plugins had insufficiently restricted permissions, allowing otherwise unprivileged Linux users to traverse directory contents and execute programs. When containers included executable programs with extended permission bits (such as setuid), unprivileged Linux users could discover and execute those programs. When the UID of an unprivileged Linux user on the host collided with the file owner or group inside a container, the unprivileged Linux user on the host could discover, read, and modify those files. This vulnerability has been fixed in containerd 1.4.11 and containerd 1.5.7. Users should update to these version when they are released and may restart containers or update directory permissions to mitigate the vulnerability. Users unable to update should limit access to the host to trusted users. Update directory permission on container bundles directories.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2021-41103.
+Cwe Links: (https://cwe.mitre.org/data/definitions/22.html)
+
+==================================================================================
+
+Language: Generic
+Severity: HIGH
+Line: 134
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/containerd/containerd v1.4.1/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
+	Installed Version: "1.4.1"
+	Update to Version: "1.4.13, 1.5.10, 1.6.1" for fix this issue.
+RuleID: CVE-2022-23648
+Type: Vulnerability
+ReferenceHash: bb11b724ee47a44545247ba9898bb163e6df1fbecc462dc3fc16f12433294ebe
+Details: (1/1) * Possible vulnerability detected: containerd is a container runtime available as a daemon for Linux and Windows. A bug was found in containerd prior to versions 1.6.1, 1.5.10, and 1.14.12 where containers launched through containerd’s CRI implementation on Linux with a specially-crafted image configuration could gain access to read-only copies of arbitrary files and directories on the host. This may bypass any policy-based enforcement on container setup (including a Kubernetes Pod Security Policy) and expose potentially sensitive information. Kubernetes and crictl can both be configured to use containerd’s CRI implementation. This bug has been fixed in containerd 1.6.1, 1.5.10, and 1.4.12. Users should update to these versions to resolve the issue.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2022-23648.
+Cwe Links: (https://cwe.mitre.org/data/definitions/200.html)
+
+==================================================================================
+
+Language: Generic
+Severity: HIGH
+Line: 165
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
+
+RuleID: CVE-2020-26160
+Type: Vulnerability
+ReferenceHash: 8b62f92e6d47b24dbc066a32d14ec52c74ef97f9bc1d9463efa23a0edb99bc63
+Details: (1/1) * Possible vulnerability detected: jwt-go before 4.0.0-preview1 allows attackers to bypass intended access restrictions in situations with []string{} for m["aud"] (which is allowed by the specification). Because the type assertion fails, "" is the value of aud. This is a security problem if the JWT token is presented to a service that lacks its own audience check.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2020-26160.
+Cwe Links: (https://cwe.mitre.org/data/definitions/862.html)
+
+==================================================================================
+
+Language: Generic
+Severity: HIGH
+Line: 272
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
+	Installed Version: "1.3.1"
+	Update to Version: "1.3.2" for fix this issue.
+RuleID: CVE-2021-3121
+Type: Vulnerability
+ReferenceHash: 70d87bc61cd2d5681ba3fd2a0d52a5637f4ff95251d798a6339604850bb747cc
+Details: (1/1) * Possible vulnerability detected: An issue was discovered in GoGo Protobuf before 1.3.2. plugin/unmarshal/unmarshal.go lacks certain index validation, aka the "skippy peanut butter" issue.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2021-3121.
+Cwe Links: (https://cwe.mitre.org/data/definitions/129.html)
+
+==================================================================================
+
+Language: Generic
+Severity: HIGH
+Line: 548
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/nats-io/jwt v0.3.2/go.mod h1:/euKqTS1ZD+zzjYrY7pseZrTtWQSjujC7xjPc8wL6eU=
+	Installed Version: "0.3.2"
+	Update to Version: "1.2.3-0.20210314221642-a826c77dc9d2" for fix this issue.
+RuleID: CVE-2021-3127
+Type: Vulnerability
+ReferenceHash: ab1a5556a3539136ee70e98f0749e7a51ec2f7108ed987e51a979fb206694d7a
+Details: (1/1) * Possible vulnerability detected: NATS Server 2.x before 2.2.0 and JWT library before 2.0.1 have Incorrect Access Control because Import Token bindings are mishandled.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2021-3127.
+Cwe Links: (https://cwe.mitre.org/data/definitions/755.html)
+
+==================================================================================
+
+Language: Generic
+Severity: HIGH
+Line: 549
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/nats-io/nats-server/v2 v2.1.2/go.mod h1:Afk+wRZqkMQs/p45uXdrVLuab3gwv3Z8C4HTBu8GD/k=
+	Installed Version: "2.1.2"
+	Update to Version: "v2.2.0" for fix this issue.
+RuleID: CVE-2020-28466
+Type: Vulnerability
+ReferenceHash: 136363832d5215ba67c03f266fdadc63b5305a8b170dd4b174156d4e34d00e90
+Details: (1/2) * Possible vulnerability detected: This affects all versions of package github.com/nats-io/nats-server/server. Untrusted accounts are able to crash the server using configs that represent a service export/import cycles. Disclaimer from the maintainers: Running a NATS service which is exposed to untrusted users presents a heightened risk. Any remote execution flaw or equivalent seriousness, or denial-of-service by unauthenticated users, will lead to prompt releases by the NATS maintainers. Fixes for denial of service issues with no threat of remote execution, when limited to account holders, are likely to just be committed to the main development branch with no special attention. Those who are running such services are encouraged to build regularly from git.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2020-28466.
+         
+(2/2) * Possible vulnerability detected: NATS Server 2.x before 2.2.0 and JWT library before 2.0.1 have Incorrect Access Control because Import Token bindings are mishandled.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2021-3127.
+Cwe Links: (https://cwe.mitre.org/data/definitions/755.html)
+
+==================================================================================
+
+Language: Generic
+Severity: HIGH
+Line: 549
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/nats-io/nats-server/v2 v2.1.2/go.mod h1:Afk+wRZqkMQs/p45uXdrVLuab3gwv3Z8C4HTBu8GD/k=
+	Installed Version: "2.1.2"
+	Update to Version: "2.7.2" for fix this issue.
+RuleID: CVE-2022-24450
+Type: Vulnerability
+ReferenceHash: 839b2b338993b92ea5fde6467e56206ccd7532f549b68fe3dd2cbf2bcc88ff12
+Details: (1/1) * Possible vulnerability detected: NATS nats-server before 2.7.2 has Incorrect Access Control. Any authenticated user can obtain the privileges of the System account by misusing the "dynamically provisioned sandbox accounts" feature.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2022-24450.
+Cwe Links: (https://cwe.mitre.org/data/definitions/863.html)
+
+==================================================================================
+
+Language: Generic
+Severity: HIGH
+Line: 615
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/prometheus/client_golang v1.9.0/go.mod h1:FqZLKOZnGdFAhOK4nqGHa7D66IdsO+O441Eve7ptJDU=
+	Installed Version: "1.9.0"
+	Update to Version: "1.11.1" for fix this issue.
+RuleID: CVE-2022-21698
+Type: Vulnerability
+ReferenceHash: 67822e085d54b12024a35aec055ccd91edf4fe0f80a51113e97e892fe1bc5cbd
+Details: (1/1) * Possible vulnerability detected: client_golang is the instrumentation library for Go applications in Prometheus, and the promhttp package in client_golang provides tooling around HTTP servers and clients. In client_golang prior to version 1.11.1, HTTP server is susceptible to a Denial of Service through unbounded cardinality, and potential memory exhaustion, when handling requests with non-standard HTTP methods. In order to be affected, an instrumented software must use any of `promhttp.InstrumentHandler*` middleware except `RequestsInFlight`; not filter any specific methods (e.g GET) before middleware; pass metric with `method` label name to our middleware; and not have any firewall/LB/proxy that filters away requests with unknown `method`. client_golang version 1.11.1 contains a patch for this issue. Several workarounds are available, including removing the `method` label name from counter/gauge used in the InstrumentHandler; turning off affected promhttp handlers; adding custom middleware before promhttp handler that will sanitize the request method given by Go http.Request; and using a reverse proxy or web application firewall, configured to only allow a limited set of methods.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2022-21698.
+Cwe Links: (https://cwe.mitre.org/data/definitions/400.html)
+
+==================================================================================
+
+Language: Generic
+Severity: HIGH
+Line: 714
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/swaggo/http-swagger v1.0.0/go.mod h1:cKIcshBU9yEAnfWv6ZzVKSsEf8h5ozxB8/zHQWyOQ/8=
+	Installed Version: "1.0.0"
+	Update to Version: "v1.2.6" for fix this issue.
+RuleID: CVE-2022-24863
+Type: Vulnerability
+ReferenceHash: d639dbbf45802cf6ef09fdf987dc76193698ce531ee7024a0c083e45f0a8fab6
+Details: (1/1) * Possible vulnerability detected: http-swagger is an open source wrapper to automatically generate RESTful API documentation with Swagger 2.0. In versions of http-swagger prior to 1.2.6 an attacker may perform a denial of service attack consisting of memory exhaustion on the host system. The cause of the memory exhaustion is down to improper handling of http methods. Users are advised to upgrade. Users unable to upgrade may to restrict the path prefix to the "GET" method as a workaround.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2022-24863.
+Cwe Links: (https://cwe.mitre.org/data/definitions/755.html)
+
+==================================================================================
+
+Language: Generic
+Severity: HIGH
+Line: 750
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
+	Installed Version: "0.0.0-20191023171146-3cf2f69b5738"
+	Update to Version: "3.4.0" for fix this issue.
+RuleID: CVE-2018-1098
+Type: Vulnerability
+ReferenceHash: 9da71b514c729abf38fc73d8656f147e97b5f0d27af91d8390deef2cab3df474
+Details: (1/2) * Possible vulnerability detected: A cross-site request forgery flaw was found in etcd 3.3.1 and earlier. An attacker can set up a website that tries to send a POST request to the etcd server and modify a key. Adding a key is done with PUT so it is theoretically safe (can't PUT from an HTML form or such) but POST allows creating in-order keys that an attacker can send.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2018-1098.
+Cwe Links: (https://cwe.mitre.org/data/definitions/352.html)
+         
+(2/2) * Possible vulnerability detected: DNS rebinding vulnerability found in etcd 3.3.1 and earlier. An attacker can control his DNS records to direct to localhost, and trick the browser into sending requests to localhost (or any other address).
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2018-1099.
+Cwe Links: (https://cwe.mitre.org/data/definitions/20.html)
+
+==================================================================================
+
+Language: Generic
+Severity: HIGH
+Line: 750
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
+	Installed Version: "0.0.0-20191023171146-3cf2f69b5738"
+	Update to Version: "0.5.0-alpha.5.0.20190108173120-83c051b701d3" for fix this issue.
+RuleID: CVE-2018-16886
+Type: Vulnerability
+ReferenceHash: f3926ae71a8dd8031562bac8c8bf4aac86b73ee4c81ce94791ace68c6c13ef5e
+Details: (1/1) * Possible vulnerability detected: etcd versions 3.2.x before 3.2.26 and 3.3.x before 3.3.11 are vulnerable to an improper authentication issue when role-based access control (RBAC) is used and client-cert-auth is enabled. If an etcd client server TLS certificate contains a Common Name (CN) which matches a valid RBAC username, a remote attacker may authenticate as that user with any valid (trusted) client certificate in a REST API request to the gRPC-gateway.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2018-16886.
+Cwe Links: (https://cwe.mitre.org/data/definitions/287.html)
+
+==================================================================================
+
+Language: Generic
+Severity: HIGH
+Line: 795
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83 h1:/ZScEX8SfEmUGRHs0gxpqteO5nfNW6axyZbBdw9A12g=
+	Installed Version: "0.0.0-20210220033148-5ea612d1eb83"
+	Update to Version: "0.0.0-20220314234659-1baeb1ce4c0b" for fix this issue.
+RuleID: CVE-2022-27191
+Type: Vulnerability
+ReferenceHash: e32eab7289fef8307a61d9e7682dc28bc1ec30469bbc8dbfdf6a95fc393daf06
+Details: (1/1) * Possible vulnerability detected: The golang.org/x/crypto/ssh package before 0.0.0-20220314234659-1baeb1ce4c0b for Go allows an attacker to crash a server in certain circumstances involving AddHostKey.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2022-27191.
+Cwe Links: (https://cwe.mitre.org/data/definitions/327.html)
+
+==================================================================================
+
+Language: Generic
+Severity: HIGH
+Line: 879
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 h1:qWPm9rbaAMKs8Bq/9LRpbMqxWRVUAQwMI9fVrssnTfw=
+	Installed Version: "0.0.0-20210226172049-e18ecbb05110"
+	Update to Version: "0.0.0-20210520170846-37e1c6afe023" for fix this issue.
+RuleID: CVE-2021-33194
+Type: Vulnerability
+ReferenceHash: 9344322b876ec08a582ee98f69c81669d26fadfbbb4fdec027df32f2d453b295
+Details: (1/1) * Possible vulnerability detected: golang.org/x/net before v0.0.0-20210520170846-37e1c6afe023 allows attackers to cause a denial of service (infinite loop) via crafted ParseFragment input.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2021-33194.
+Cwe Links: (https://cwe.mitre.org/data/definitions/835.html)
+
+==================================================================================
+
+Language: Generic
+Severity: HIGH
+Line: 879
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 h1:qWPm9rbaAMKs8Bq/9LRpbMqxWRVUAQwMI9fVrssnTfw=
+	Installed Version: "0.0.0-20210226172049-e18ecbb05110"
+	Update to Version: "0.0.0-20211209124913-491a49abca63" for fix this issue.
+RuleID: CVE-2021-44716
+Type: Vulnerability
+ReferenceHash: 086d36c40254a25bfc847fb020cd0882a4f74b9f26d24418e071317e66e0470f
+Details: (1/1) * Possible vulnerability detected: net/http in Go before 1.16.12 and 1.17.x before 1.17.5 allows uncontrolled memory consumption in the header canonicalization cache via HTTP/2 requests.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2021-44716.
+Cwe Links: (https://cwe.mitre.org/data/definitions/400.html)
+
+==================================================================================
+
+Language: Generic
+Severity: HIGH
+Line: 966
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: golang.org/x/text v0.3.4 h1:0YWbFKbhXG/wIiuHDSKpS0Iy7FSA+u45VtBMfQcFTTc=
+	Installed Version: "0.3.4"
+	Update to Version: "0.3.7" for fix this issue.
+RuleID: CVE-2021-38561
+Type: Vulnerability
+ReferenceHash: da297fc45c1146c58006e9e098f12fc5268fd7eafbfff990dd7d1ed1be30f59d
+Details: (1/1) * Possible vulnerability detected: A flaw was found in golang. The language package for go language can panic due to an out-of-bounds read when an incorrectly formatted language tag is being parsed. This flaw allows an attacker to cause applications using this package to parse untrusted input data to crash, leading to a denial of service of the affected component.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2021-38561.
+
+==================================================================================
+
+Language: Go
+Severity: MEDIUM
+Line: 38
+Column: 7
+SecurityTool: GoSec
+Confidence: HIGH
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/api/util/util.go
+Code: 37: func GetMD5(s string) string {
+38: 	h := md5.New()
+39: 	io.WriteString(h, s) // #nohorus
+
+RuleID: G401
+Type: Vulnerability
+ReferenceHash: 53e26991220c99126dd29977f1f5e9ec4bde464301ff9f26880add0c537dd97d
+Details: (1/1) * Possible vulnerability detected: Use of weak cryptographic primitive
+
+==================================================================================
+
+Language: Go
+Severity: MEDIUM
+Line: 19
+Column: 2
+SecurityTool: GoSec
+Confidence: HIGH
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/api/util/util.go
+Code: 18: import (
+19: 	"crypto/md5"
+20: 	"fmt"
+
+RuleID: G501
+Type: Vulnerability
+ReferenceHash: a06b3404e246c8820533b847fd69ddf7cdadcc07749ffe0a2a840ba6b38daf3f
+Details: (1/1) * Possible vulnerability detected: Blocklisted import crypto/md5: weak cryptographic primitive
+
+==================================================================================
+
+Language: Go
+Severity: MEDIUM
+Line: 61
+Column: 
+SecurityTool: Nancy
+Confidence: HIGH
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.mod
+Code: 	github.com/jackc/pgproto3 v1.1.0 // indirect
+Type: Vulnerability
+ReferenceHash: 565eb2642f9ac5bd194a850ed6aa2fd95d893a8f8b672bb1fcfb5ff9f52149af
+Details: (1/1) * Possible vulnerability detected: 1 vulnerability found
+1 non-CVE vulnerability found. To see more details, please create a free account at https://ossindex.sonatype.org/ and request for this information using your registered account For more information, please checkout the following url (https://ossindex.sonatype.org/vulnerability/sonatype-2021-0853).
+
+==================================================================================
+
+Language: Go
+Severity: MEDIUM
+Line: 62
+Column: 
+SecurityTool: Nancy
+Confidence: HIGH
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.mod
+Code: 	github.com/jackc/pgproto3/v2 v2.0.6 // indirect
+Type: Vulnerability
+ReferenceHash: 854ebddb5f38166bfaa518e447f6e48c019d9e3793805427b94104df3e2b2cb7
+Details: (1/1) * Possible vulnerability detected: 1 vulnerability found
+1 non-CVE vulnerability found. To see more details, please create a free account at https://ossindex.sonatype.org/ and request for this information using your registered account For more information, please checkout the following url (https://ossindex.sonatype.org/vulnerability/sonatype-2021-0853).
+
+==================================================================================
+
+Language: Go
+Severity: MEDIUM
+Line: 571
+Column: 
+SecurityTool: Nancy
+Confidence: HIGH
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
+RuleID: CVE-2021-41190
+Type: Vulnerability
+ReferenceHash: 3d5678342c8b1c753a1d79243a834fdb9c7123ce4ec47f52079df5ee663fb7a0
+Details: (1/1) * Possible vulnerability detected: [CVE-2021-41190] CWE-843: Access of Resource Using Incompatible Type ('Type Confusion')
+The OCI Distribution Spec project defines an API protocol to facilitate and standardize the distribution of content. In the OCI Distribution Specification version 1.0.0 and prior, the Content-Type header alone was used to determine the type of document during push and pull operations. Documents that contain both “manifests” and “layers” fields could be interpreted as either a manifest or an index in the absence of an accompanying Content-Type header. If a Content-Type header changed between two pulls of the same digest, a client may interpret the resulting content differently. The OCI Distribution Specification has been updated to require that a mediaType value present in a manifest or index match the Content-Type header used during the push and pull operations. Clients pulling from a registry may distrust the Content-Type header and reject an ambiguous document that contains both “manifests” and “layers” fields or “manifests” and “config” fields if they are unable to update to version 1.0.1 of the spec. For more information, please checkout the following url (https://ossindex.sonatype.org/vulnerability/CVE-2021-41190?component-type=golang&component-name=github.com%2Fopencontainers%2Fimage-spec&utm_source=nancy-client&utm_medium=integration&utm_content=1.0.33).
+
+==================================================================================
+
+Language: Go
+Severity: MEDIUM
+Line: 732
+Column: 
+SecurityTool: Nancy
+Confidence: HIGH
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
+Type: Vulnerability
+ReferenceHash: 77f5d166d2f177dc07ba1e5998bcc307add10bb544de5aabacd96589d99848ea
+Details: (1/1) * Possible vulnerability detected: 1 vulnerability found
+1 non-CVE vulnerability found. To see more details, please create a free account at https://ossindex.sonatype.org/ and request for this information using your registered account For more information, please checkout the following url (https://ossindex.sonatype.org/vulnerability/sonatype-2021-1485).
+
+==================================================================================
+
+Language: Go
+Severity: MEDIUM
+Line: 113
+Column: 
+SecurityTool: Nancy
+Confidence: HIGH
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.mod
+Code: 	golang.org/x/text v0.3.4 // indirect
+RuleID: CVE-2021-38561
+Type: Vulnerability
+ReferenceHash: fc1b74afe2fadcded45d4a95388aa62c2629e735fe96c79ecbf220887f85a74a
+Details: (1/1) * Possible vulnerability detected: [CVE-2021-38561] CWE-125: Out-of-bounds Read
+golang-x-text - Out-of-bounds Read For more information, please checkout the following url (https://ossindex.sonatype.org/vulnerability/CVE-2021-38561?component-type=golang&component-name=golang.org%2Fx%2Ftext&utm_source=nancy-client&utm_medium=integration&utm_content=1.0.33).
+
+==================================================================================
+
+Language: Generic
+Severity: MEDIUM
+Line: 134
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/containerd/containerd v1.4.1/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
+	Installed Version: "1.4.1"
+	Update to Version: "1.2.0, 1.3.9, 1.4.3" for fix this issue.
+RuleID: CVE-2020-15257
+Type: Vulnerability
+ReferenceHash: bd130bd3e1e1642ec1b2cc08e9016ade9116b0a419062e7851942e7a1b44242b
+Details: (1/1) * Possible vulnerability detected: containerd is an industry-standard container runtime and is available as a daemon for Linux and Windows. In containerd before versions 1.3.9 and 1.4.3, the containerd-shim API is improperly exposed to host network containers. Access controls for the shim’s API socket verified that the connecting process had an effective UID of 0, but did not otherwise restrict access to the abstract Unix domain socket. This would allow malicious containers running in the same network namespace as the shim, with an effective UID of 0 but otherwise reduced privileges, to cause new processes to be run with elevated privileges. This vulnerability has been fixed in containerd 1.3.9 and 1.4.3. Users should update to these versions as soon as they are released. It should be noted that containers started with an old version of containerd-shim should be stopped and restarted, as running containers will continue to be vulnerable even after an upgrade. If you are not providing the ability for untrusted users to start containers in the same network namespace as the shim (typically the "host" network namespace, for example with docker run --net=host or hostNetwork: true in a Kubernetes pod) and run with an effective UID of 0, you are not vulnerable to this issue. If you are running containers with a vulnerable configuration, you can deny access to all abstract sockets with AppArmor by adding a line similar to deny unix addr=@**, to your policy. It is best practice to run containers with a reduced set of privileges, with a non-zero UID, and with isolated namespaces. The containerd maintainers strongly advise against sharing namespaces with the host. Reducing the set of isolation mechanisms used for a container necessarily increases that container's privilege, regardless of what container runtime is used for running that container.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2020-15257.
+Cwe Links: (https://cwe.mitre.org/data/definitions/669.html)
+
+==================================================================================
+
+Language: Generic
+Severity: MEDIUM
+Line: 134
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/containerd/containerd v1.4.1/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
+	Installed Version: "1.4.1"
+	Update to Version: "v1.3.10, v1.4.4" for fix this issue.
+RuleID: CVE-2021-21334
+Type: Vulnerability
+ReferenceHash: d29ad8e1d53afaf6146a3b225b6c12ce858244238aeb89904dc4d4fd52bf515f
+Details: (1/1) * Possible vulnerability detected: In containerd (an industry-standard container runtime) before versions 1.3.10 and 1.4.4, containers launched through containerd's CRI implementation (through Kubernetes, crictl, or any other pod/container client that uses the containerd CRI service) that share the same image may receive incorrect environment variables, including values that are defined for other containers. If the affected containers have different security contexts, this may allow sensitive information to be unintentionally shared. If you are not using containerd's CRI implementation (through one of the mechanisms described above), you are not vulnerable to this issue. If you are not launching multiple containers or Kubernetes pods from the same image which have different environment variables, you are not vulnerable to this issue. If you are not launching multiple containers or Kubernetes pods from the same image in rapid succession, you have reduced likelihood of being vulnerable to this issue This vulnerability has been fixed in containerd 1.3.10 and containerd 1.4.4. Users should update to these versions.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2021-21334.
+Cwe Links: (https://cwe.mitre.org/data/definitions/668.html)
+
+==================================================================================
+
+Language: Generic
+Severity: MEDIUM
+Line: 134
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/containerd/containerd v1.4.1/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
+	Installed Version: "1.4.1"
+	Update to Version: "v1.4.8, v1.5.4" for fix this issue.
+RuleID: CVE-2021-32760
+Type: Vulnerability
+ReferenceHash: 599bc20a0823db6b6cb6cb268eb4a31c6bca121b1ab6a59de66a521539eeac42
+Details: (1/1) * Possible vulnerability detected: containerd is a container runtime. A bug was found in containerd versions prior to 1.4.8 and 1.5.4 where pulling and extracting a specially-crafted container image can result in Unix file permission changes for existing files in the host’s filesystem. Changes to file permissions can deny access to the expected owner of the file, widen access to others, or set extended bits like setuid, setgid, and sticky. This bug does not directly allow files to be read, modified, or executed without an additional cooperating process. This bug has been fixed in containerd 1.5.4 and 1.4.8. As a workaround, ensure that users only pull images from trusted sources. Linux security modules (LSMs) like SELinux and AppArmor can limit the files potentially affected by this bug through policies and profiles that prevent containerd from interacting with specific files.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2021-32760.
+Cwe Links: (https://cwe.mitre.org/data/definitions/668.html)
+
+==================================================================================
+
+Language: Generic
+Severity: MEDIUM
+Line: 134
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/containerd/containerd v1.4.1/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
+	Installed Version: "1.4.1"
+	Update to Version: "v1.5.13, v1.6.6" for fix this issue.
+RuleID: CVE-2022-31030
+Type: Vulnerability
+ReferenceHash: c10c7ac6749677555bda2ed12edf715b3802718ce2759a0d8238e56a5427b545
+Details: (1/2) * Possible vulnerability detected: containerd is an open source container runtime. A bug was found in the containerd's CRI implementation where programs inside a container can cause the containerd daemon to consume memory without bound during invocation of the `ExecSync` API. This can cause containerd to consume all available memory on the computer, denying service to other legitimate workloads. Kubernetes and crictl can both be configured to use containerd's CRI implementation; `ExecSync` may be used when running probes or when executing processes via an "exec" facility. This bug has been fixed in containerd 1.6.6 and 1.5.13. Users should update to these versions to resolve the issue. Users unable to upgrade should ensure that only trusted images and commands are used.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2022-31030.
+Cwe Links: (https://cwe.mitre.org/data/definitions/400.html)
+         
+(2/2) * Possible vulnerability detected: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection') in github.com/containerd/containerd.
+PrimaryURL: https://github.com/advisories/GHSA-5ffw-gxpp-mxpf.
+
+==================================================================================
+
+Language: Generic
+Severity: MEDIUM
+Line: 525
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
+	Installed Version: "1.0.14"
+	Update to Version: "1.1.25-0.20191211073109-8ebf2e419df7" for fix this issue.
+RuleID: CVE-2019-19794
+Type: Vulnerability
+ReferenceHash: fba79d864c0ca5c4aab97dbdcd7f795c9bbde24dd2545aeb88d79b9d499968d1
+Details: (1/1) * Possible vulnerability detected: The miekg Go DNS package before 1.1.25, as used in CoreDNS before 1.6.6 and other products, improperly generates random numbers because math/rand is used. The TXID becomes predictable, leading to response forgeries.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2019-19794.
+Cwe Links: (https://cwe.mitre.org/data/definitions/338.html)
+
+==================================================================================
+
+Language: Generic
+Severity: MEDIUM
+Line: 750
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
+	Installed Version: "0.0.0-20191023171146-3cf2f69b5738"
+	Update to Version: "0.5.0-alpha.5.0.20200423152442-f4b650b51dc4" for fix this issue.
+RuleID: CVE-2020-15106
+Type: Vulnerability
+ReferenceHash: bfd32abe19fda7fc0b1acb34458d5c5a4ae9ed9515be79459e86a15b4361f6a6
+Details: (1/2) * Possible vulnerability detected: In etcd before versions 3.3.23 and 3.4.10, a large slice causes panic in decodeRecord method. The size of a record is stored in the length field of a WAL file and no additional validation is done on this data. Therefore, it is possible to forge an extremely large frame size that can unintentionally panic at the expense of any RAFT participant trying to decode the WAL.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2020-15106.
+         
+(2/2) * Possible vulnerability detected: In etcd before versions 3.3.23 and 3.4.10, it is possible to have an entry index greater then the number of entries in the ReadAll method in wal/wal.go. This could cause issues when WAL entries are being read during consensus as an arbitrary etcd consensus participant could go down from a runtime panic when reading the entry.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2020-15112.
+Cwe Links: (https://cwe.mitre.org/data/definitions/129.html)
+
+==================================================================================
+
+Language: Generic
+Severity: MEDIUM
+Line: 751
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: go.mongodb.org/mongo-driver v1.1.0/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
+	Installed Version: "1.1.0"
+	Update to Version: "1.5.1" for fix this issue.
+RuleID: CVE-2021-20329
+Type: Vulnerability
+ReferenceHash: 3bfc1be7cd2b4ee5888e6cb5c8c15dda3677914df44e7625c6519901bc839eb5
+Details: (1/1) * Possible vulnerability detected: Specific cstrings input may not be properly validated in the MongoDB Go Driver when marshalling Go objects into BSON. A malicious user could use a Go object with specific string to potentially inject additional fields into marshalled documents. This issue affects all MongoDB GO Drivers up to (and including) 1.5.0.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2021-20329.
+Cwe Links: (https://cwe.mitre.org/data/definitions/20.html)
+
+==================================================================================
+
+Language: Generic
+Severity: MEDIUM
+Line: 879
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 h1:qWPm9rbaAMKs8Bq/9LRpbMqxWRVUAQwMI9fVrssnTfw=
+	Installed Version: "0.0.0-20210226172049-e18ecbb05110"
+	Update to Version: "0.0.0-20210428140749-89ef3d95e781" for fix this issue.
+RuleID: CVE-2021-31525
+Type: Vulnerability
+ReferenceHash: ba0f25f61d6f419c8980d7fdcd2af4d93b476f13850e6f22c8d48b4e1705fcad
+Details: (1/1) * Possible vulnerability detected: net/http in Go before 1.15.12 and 1.16.x before 1.16.4 allows remote attackers to cause a denial of service (panic) via a large header to ReadRequest or ReadResponse. Server, Transport, and Client can each be affected in some configurations.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2021-31525.
+Cwe Links: (https://cwe.mitre.org/data/definitions/674.html)
+
+==================================================================================
+
+Language: Generic
+Severity: MEDIUM
+Line: 957
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: golang.org/x/sys v0.0.0-20201214210602-f9fddec55a1e h1:AyodaIpKjppX+cBfTASF2E1US3H2JFBj920Ot3rtDjs=
+	Installed Version: "0.0.0-20201214210602-f9fddec55a1e"
+	Update to Version: "0.0.0-20220412211240-33da011f77ad" for fix this issue.
+RuleID: CVE-2022-29526
+Type: Vulnerability
+ReferenceHash: e4eee3e55de59a865c85f2842c71e4e43f3b41768116313b279305397e98aceb
+Details: (1/1) * Possible vulnerability detected: Go before 1.17.10 and 1.18.x before 1.18.2 has Incorrect Privilege Assignment. When called with a non-zero flags parameter, the Faccessat function could incorrectly report that a file is accessible.
+PrimaryURL: https://avd.aquasec.com/nvd/cve-2022-29526.
+Cwe Links: (https://cwe.mitre.org/data/definitions/269.html)
+
+==================================================================================
+
+Language: Go
+Severity: LOW
+Line: 39
+Column: 2
+SecurityTool: GoSec
+Confidence: HIGH
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/api/util/util.go
+Code: : 	h := md5.New()
+39: 	io.WriteString(h, s) // #nohorus
+40: 	md5Result := fmt.Sprintf("%x", h.Sum(ni
+RuleID: G104
+Type: Vulnerability
+ReferenceHash: 4d6bec725b592e20ae221f09048dcc7eb30329ec56f0f1fa71b24a128bd3c9a3
+Details: (1/1) * Possible vulnerability detected: Errors unhandled.
+
+==================================================================================
+
+Language: Generic
+Severity: UNKNOWN
+Line: 98
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+	Installed Version: "1.27.0"
+	Update to Version: "1.34.0" for fix this issue.
+RuleID: GO-2022-0391
+Type: Vulnerability
+ReferenceHash: 094ed122d8e6f9c170c756e8359bb58eb8aab38bb121dddf4e6256118aa0aa22
+Details: (1/1) * Possible vulnerability detected: The AWS S3 Crypto SDK sends an unencrypted hash of the plaintext alongside
+the ciphertext as a metadata field. This hash can be used to brute force
+the plaintext, if the hash is readable to the attacker.AWS now blocks this metadata field, but older SDK versions still send it.
+
+==================================================================================
+
+Language: Generic
+Severity: UNKNOWN
+Line: 134
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/containerd/containerd v1.4.1/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
+	Installed Version: "1.4.1"
+	Update to Version: "1.4.12, 1.5.8" for fix this issue.
+RuleID: GHSA-5j5w-g665-5m35
+Type: Vulnerability
+ReferenceHash: 051b5f8b995c92f1d0b1e73e98bd07a97af84382b068f1230e0ce60e5db3e98e
+Details: (1/1) * Possible vulnerability detected: In the OCI Distribution Specification version 1.0.0 and prior and in the OCI Image Specification version 1.0.1 and prior, manifest and index documents are ambiguous without an accompanying Content-Type HTTP header.
+PrimaryURL: https://github.com/advisories/GHSA-5j5w-g665-5m35.
+
+==================================================================================
+
+Language: Generic
+Severity: UNKNOWN
+Line: 173
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+	Installed Version: "2.7.1+incompatible"
+	Update to Version: "v2.8.0" for fix this issue.
+RuleID: GHSA-qq97-vm5h-rrhg
+Type: Vulnerability
+ReferenceHash: 20fd869dbd72efa2fb071d26372d01ae9ca1c0cd3a4b25cd8e59fc68223de7f6
+Details: (1/1) * Possible vulnerability detected: ### ImpactSystems that rely on digest equivalence for image attestations may be vulnerable to type confusion.
+PrimaryURL: https://github.com/advisories/GHSA-qq97-vm5h-rrhg.
+
+==================================================================================
+
+Language: Generic
+Severity: UNKNOWN
+Line: 548
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/nats-io/jwt v0.3.2/go.mod h1:/euKqTS1ZD+zzjYrY7pseZrTtWQSjujC7xjPc8wL6eU=
+	Installed Version: "0.3.2"
+	Update to Version: "v2.0.1" for fix this issue.
+RuleID: GHSA-62mh-w5cv-p88c
+Type: Vulnerability
+ReferenceHash: 494b9727668898554f00b30b6f25b3d4766d15f3b04d1dd051713580c1120dbd
+Details: (1/1) * Possible vulnerability detected: The NATS server provides for Subjects which are namespaced by Account; all Subjects are supposed to be private to an account, with an `Export/Import` system used to grant cross-account access to some Subjects. Some Exports are public, such that anyone can import the relevant subjects, and some Exports are private, such that the Import requires a token JWT to prove permission. The JWT library's validation of the bindings in the `Import Token` incorrectly warned on mismatches, instead of outright rejecting the token. As a result, any account can take an Import token used by any other account and re-use it for themselves because the binding to the importing account is not rejected, and use it to import any Subject from the Exporting account, not just the Subject referenced in the Import Token. The NATS account-server system treats account JWTs as semi-public information, such that an attacker can easily enumerate all account JWTs and retrieve all Import Tokens from those account JWTs.
+PrimaryURL: https://github.com/advisories/GHSA-62mh-w5cv-p88c.
+
+==================================================================================
+
+Language: Generic
+Severity: UNKNOWN
+Line: 549
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/nats-io/nats-server/v2 v2.1.2/go.mod h1:Afk+wRZqkMQs/p45uXdrVLuab3gwv3Z8C4HTBu8GD/k=
+	Installed Version: "2.1.2"
+	Update to Version: "2.2.0" for fix this issue.
+RuleID: GHSA-gwj5-3vfq-q992
+Type: Vulnerability
+ReferenceHash: df21a68ed04bc3f0c1e944fad73247e80cfe2b595a4fdb401933f7e2e5d3ea61
+Details: (1/2) * Possible vulnerability detected: (This advisory is canonically <https://advisories.nats.io/CVE/CVE-2020-28466.txt>)## Problem DescriptionAn export/import cycle between accounts could crash the nats-server, after consuming CPU and memory.This issue was fixed publicly in <https://github.com/nats-io/nats-server/pull/1731> in November 2020.The need to call this out as a security issue was highlighted by `snyk.io` and we are grateful for their assistance in doing so.Organizations which run a NATS service providing access to accounts run by untrusted third parties are affected.
+See below for an important caveat if running such a service.
+## Affected versions#### NATS Server * Version 2 prior to 2.2.0
+   + 2.0.0 through and including 2.1.9 are vulnerable.
+ * fixed with nats-io/nats-server PR 1731, commit 2e3c226729
+## ImpactThe nats-server could be killed, after consuming resources.
+## WorkaroundThe import cycle requires at least two accounts to work; if you have open account sign-up, then restricting new account sign-up might hinder an attacker.
+## SolutionUpgrade the nats-server.
+## Caveat on NATS with untrusted usersRunning a NATS service which is exposed to untrusted users presents a heightened risk.Any remote execution flaw or equivalent seriousness, or denial-of-service by unauthenticated users, will lead to prompt releases by the NATS maintainers.Fixes for denial of service issues with no threat of remote execution, when limited to account holders, are likely to just be committed to the main development branch with no special attention.Those who are running such services are encouraged to build regularly from git.
+PrimaryURL: https://github.com/advisories/GHSA-gwj5-3vfq-q992.
+         
+(2/2) * Possible vulnerability detected: (This advisory is canonically <https://advisories.nats.io/CVE/CVE-2021-3127.txt>)## Problem DescriptionThe NATS server provides for Subjects which are namespaced by Account; all Subjects are supposed to be private to an account, with an Export/Import system used to grant cross-account access to some Subjects.  Some Exports are public, such that anyone can import the
+relevant subjects, and some Exports are private, such that the Import requires a token JWT to prove permission.The JWT library's validation of the bindings in the Import Token incorrectly warned on mismatches, instead of outright rejecting the token.As a result, any account can take an Import token used by any other account and re-use it for themselves because the binding to the
+importing account is not rejected, and use it to import *any* Subject from the Exporting account, not just the Subject referenced in the Import Token.The NATS account-server system treats account JWTs as semi-public information, such that an attacker can easily enumerate all account JWTs and retrieve all Import Tokens from those account JWTs.The CVE identifier should cover the JWT library repair and the nats-server containing the fixed JWT library, and any other application depending upon the fixed JWT library.
+## Affected versions#### JWT library * all versions prior to 2.0.1
+ * fixed after nats-io/jwt#149 landed (2021-03-14)#### NATS Server * Version 2 prior to 2.2.0
+   + 2.0.0 through and including 2.1.9 are vulnerable
+ * fixed with nats-io/nats-server@423b79440c (2021-03-14)
+## ImpactIn deployments with untrusted accounts able to update the Account Server with imports, a malicious account can access any Subject from an account which provides Exported Subjects.Abuse of this facility requires the malicious actor to upload their tampered Account JWT to the Account Server, providing the service operator with a data-store which can be scanned for signs of abuse.
+## WorkaroundDeny access to clients to update their account JWT in the account server.
+## SolutionUpgrade the JWT dependency in any application using it.Upgrade the NATS server if using NATS Accounts (with private Exports; Account owners can create those at any time though).Audit all accounts JWTs to scan for exploit attempts; a Python script to audit the accounts can be found at <https://gist.github.com/philpennock/09d49524ad98043ff11d8a40c2bb0d5a>.
+PrimaryURL: https://github.com/advisories/GHSA-j756-f273-xhp4.
+
+==================================================================================
+
+Language: Generic
+Severity: UNKNOWN
+Line: 571
+Column: 0
+SecurityTool: Trivy
+Confidence: MEDIUM
+File: /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/go/example1/go.sum
+Code: github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
+	Installed Version: "1.0.1"
+	Update to Version: "1.0.2" for fix this issue.
+RuleID: GHSA-77vh-xpmg-72qh
+Type: Vulnerability
+ReferenceHash: ebeecf1d4961049b2aca587ee83d5584a13243f31f7769a57a8435a793f6f03a
+Details: (1/1) * Possible vulnerability detected: ### Impact
+In the OCI Image Specification version 1.0.1 and prior, manifest and index documents are not self-describing and documents with a single digest could be interpreted as either a manifest or an index.### Patches
+The Image Specification will be updated to recommend that both manifest and index documents contain a `mediaType` field to identify the type of document.
+PrimaryURL: https://github.com/advisories/GHSA-77vh-xpmg-72qh.
+
+==================================================================================
+
+In this analysis, a total of 47 possible vulnerabilities were found and we classified them into:
+Total of Vulnerability CRITICAL is: 4
+Total of Vulnerability HIGH is: 20
+Total of Vulnerability MEDIUM is: 16
+Total of Vulnerability LOW is: 1
+Total of Vulnerability UNKNOWN is: 6
+
+==================================================================================
+
+time="2022-07-26T18:10:03-03:00" level=warning msg="{HORUSEC_CLI} 47 VULNERABILITIES WERE FOUND IN YOUR CODE SENT TO HORUSEC, TO SEE MORE DETAILS USE THE LOG LEVEL AS DEBUG AND TRY AGAIN"
+
+time="2022-07-26T18:10:03-03:00" level=warning msg="{HORUSEC_CLI} Horusec not show info vulnerabilities in this analysis, to see info vulnerabilities add option \"--information-severity=true\". For more details use (horusec start --help) command."
+--- PASS: TestAnalyzerWithoutMock (84.15s)
+    --- PASS: TestAnalyzerWithoutMock/Should_run_all_analysis_with_no_timeout_and_error (46.40s)
+    --- PASS: TestAnalyzerWithoutMock/Should_run_all_analysis_and_send_to_server_correctly (37.75s)
+=== RUN   TestAnalyze
+=== RUN   TestAnalyze/Should_run_all_analysis_with_no_timeout_and_error
+time="2022-07-26T18:10:03-03:00" level=warning msg="{HORUSEC_CLI} Starting the analysis with git history enabled. ATTENTION the waiting time can be longer when this option is enabled!"
+
+[K⣾ Scanning code ...time="2022-07-26T18:10:03-03:00" level=error msg="Error to walk on path" error="lstat /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000/test: no such file or directory" ext=.mod path=/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000/test projectPath=/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000 subPath=test
+time="2022-07-26T18:10:03-03:00" level=error msg="Error to walk on path" error="lstat /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000: no such file or directory" ext=requirements.txt path=/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000 projectPath=/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000 subPath=
+time="2022-07-26T18:10:03-03:00" level=error msg="Error to walk on path" error="lstat /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000: no such file or directory" ext=Gemfile.lock path=/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000 projectPath=/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000 subPath=
+time="2022-07-26T18:10:03-03:00" level=error msg="Error to find filepath" basePath=/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000 error="lstat /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000: no such file or directory" filename=Gemfile
+time="2022-07-26T18:10:03-03:00" level=error msg="Error to walk on path" error="lstat /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000: no such file or directory" ext=package-lock.json path=/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000 projectPath=/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000 subPath=
+time="2022-07-26T18:10:03-03:00" level=error msg="Error to walk on path" error="lstat /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000: no such file or directory" ext=yarn.lock path=/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000 projectPath=/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000 subPath=
+time="2022-07-26T18:10:03-03:00" level=error msg="Error to walk on path" error="lstat /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000: no such file or directory" ext="*.sln" path=/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000 projectPath=/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000 subPath=
+time="2022-07-26T18:10:03-03:00" level=error msg="Error to walk on path" error="lstat /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000: no such file or directory" ext=.sln path=/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000 projectPath=/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000 subPath=
+time="2022-07-26T18:10:03-03:00" level=error msg="Error to walk on path" error="lstat /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000: no such file or directory" ext=.sln path=/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000 projectPath=/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000 subPath=
+time="2022-07-26T18:10:03-03:00" level=error msg="Could not get filename by extension: " error="lstat /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000: no such file or directory"
+[Ktime="2022-07-26T18:10:03-03:00" level=warning msg="{HORUSEC_CLI} Hash not found in the list of vulnerabilities pointed out by Horusec: "
+time="2022-07-26T18:10:03-03:00" level=warning msg="{HORUSEC_CLI} Hash not found in the list of vulnerabilities pointed out by Horusec: test"
+=== RUN   TestAnalyze/Should_run_all_analysis_with_and_send_to_server_correctly
+[K⣾ Scanning code ...time="2022-07-26T18:10:03-03:00" level=error msg="Error to walk on path" error="lstat /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000/test: no such file or directory" ext=.mod path=/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000/test projectPath=/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000 subPath=test
+time="2022-07-26T18:10:03-03:00" level=error msg="Error to walk on path" error="lstat /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000: no such file or directory" ext=Gemfile.lock path=/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000 projectPath=/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000 subPath=
+time="2022-07-26T18:10:03-03:00" level=error msg="Error to walk on path" error="lstat /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000: no such file or directory" ext=requirements.txt path=/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000 projectPath=/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000 subPath=
+time="2022-07-26T18:10:03-03:00" level=error msg="Error to find filepath" basePath=/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000 error="lstat /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000: no such file or directory" filename=Gemfile
+time="2022-07-26T18:10:03-03:00" level=error msg="Error to walk on path" error="lstat /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000: no such file or directory" ext=yarn.lock path=/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000 projectPath=/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000 subPath=
+time="2022-07-26T18:10:03-03:00" level=error msg="Error to walk on path" error="lstat /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000: no such file or directory" ext=package-lock.json path=/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000 projectPath=/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000 subPath=
+time="2022-07-26T18:10:03-03:00" level=error msg="Error to walk on path" error="lstat /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000: no such file or directory" ext="*.sln" path=/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000 projectPath=/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000 subPath=
+time="2022-07-26T18:10:03-03:00" level=error msg="Error to walk on path" error="lstat /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000: no such file or directory" ext=.sln path=/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000 projectPath=/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000 subPath=
+time="2022-07-26T18:10:03-03:00" level=error msg="Error to walk on path" error="lstat /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000: no such file or directory" ext=.sln path=/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000 projectPath=/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000 subPath=
+time="2022-07-26T18:10:03-03:00" level=error msg="Could not get filename by extension: " error="lstat /home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/internal/controllers/analyzer/.horusec/00000000-0000-0000-0000-000000000000: no such file or directory"
+[Ktime="2022-07-26T18:10:03-03:00" level=warning msg="{HORUSEC_CLI} Hash not found in the list of vulnerabilities pointed out by Horusec: test"
+=== RUN   TestAnalyze/Should_run_error_in_language_detect
+=== RUN   TestAnalyze/should_not_remove_info_vulnerabilities_when_enable_information_severity_enabled
+[K⣾ Scanning code ...[K--- PASS: TestAnalyze (0.06s)
+    --- PASS: TestAnalyze/Should_run_all_analysis_with_no_timeout_and_error (0.03s)
+    --- PASS: TestAnalyze/Should_run_all_analysis_with_and_send_to_server_correctly (0.03s)
+    --- PASS: TestAnalyze/Should_run_error_in_language_detect (0.00s)
+    --- PASS: TestAnalyze/should_not_remove_info_vulnerabilities_when_enable_information_severity_enabled (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/controllers/analyzer	84.448s
+=== RUN   TestLanguageDetectIgnoreFilesUsingWindowsPaths
+    language_detect_test.go:52: Only check if files is ignored correctly using Windows paths
+--- SKIP: TestLanguageDetectIgnoreFilesUsingWindowsPaths (0.00s)
+=== RUN   TestLanguageDetectIgnoreFiles
+
+
+
+--- PASS: TestLanguageDetectIgnoreFiles (0.01s)
+=== RUN   TestLanguageDetectIgnoreFilesGithubFolder
+
+
+
+--- PASS: TestLanguageDetectIgnoreFilesGithubFolder (4.96s)
+=== RUN   TestLanguageDetect
+=== RUN   TestLanguageDetect/Should_return_error_when_the_folder_not_exists
+=== RUN   TestLanguageDetect/Should_ignore_files_of_the_type_images
+
+
+
+=== RUN   TestLanguageDetect/Should_ignore_additional_folder_setup_in_configs
+
+
+
+=== RUN   TestLanguageDetect/Should_ignore_additional_specific_file_name_setup_in_configs
+
+
+
+=== RUN   TestLanguageDetect/Should_run_language_detect_and_return_GO_and_GITLEAKS
+
+
+
+=== RUN   TestLanguageDetect/Should_run_language_detect_and_return_GITLEAKS
+
+
+
+=== RUN   TestLanguageDetect/Should_run_language_detect_and_return_JAVA_and_GITLEAKS
+
+
+
+=== RUN   TestLanguageDetect/Should_run_language_detect_and_return_JAVASCRIPT_and_GITLEAKS
+
+
+
+=== RUN   TestLanguageDetect/Should_run_language_detect_and_return_JAVASCRIPT_and_GITLEAKS#01
+
+
+
+=== RUN   TestLanguageDetect/Should_run_language_detect_and_return_PHP,_LEAKS,_GENERIC_in_example2
+
+
+
+=== RUN   TestLanguageDetect/Should_run_language_detect_and_return_PHP,_LEAKS,_GENERIC_in_example1
+
+
+
+=== RUN   TestLanguageDetect/Should_run_language_detect_and_return_KOTLIN_and_GITLEAKS
+
+
+
+=== RUN   TestLanguageDetect/Should_run_language_detect_and_return_CSHARP_and_GITLEAKS
+
+
+
+=== RUN   TestLanguageDetect/Should_run_language_detect_and_return_PYTHON_and_GITLEAKS
+
+
+
+=== RUN   TestLanguageDetect/Should_run_language_detect_and_return_PYTHON_safety_and_GITLEAKS
+
+
+
+=== RUN   TestLanguageDetect/Should_run_language_detect_and_return_RUBY_and_GITLEAKS
+
+
+
+=== RUN   TestLanguageDetect/Should_run_language_detect_on_examples_folder_and_return_RUBY_and_GITLEAKS
+
+
+
+=== RUN   TestLanguageDetect/Should_run_language_detect_on_examples_folder_and_return_all_languages
+
+
+
+=== RUN   TestLanguageDetect/Should_ignore_folders_present_in_toignore.GetDefaultFoldersToIgnore()
+
+
+
+=== RUN   TestLanguageDetect/Should_read_git_submodule_path_and_copy_to_.horusec_folder_git_submodule_correctly
+time="2022-07-26T18:08:48-03:00" level=warning msg="{HORUSEC_CLI} When starting the analysis WE SKIP A TOTAL OF 1117 FILES that are not considered to be analyzed. To see more details use flag --log-level=debug"
+
+time="2022-07-26T18:08:50-03:00" level=warning msg="Horusec will return a timeout after 600 seconds. This time can be customized in the cli settings."
+
+time="2022-07-26T18:08:50-03:00" level=warning msg="{HORUSEC_CLI} PLEASE DON'T REMOVE \".horusec\" FOLDER BEFORE THE ANALYSIS FINISH! Don’t worry, we’ll remove it after the analysis ends automatically! Project sent to folder in location: [/home/guilherme_paulo/Documents/Development/Zup/appsec/github/zupit/horusec/examples/.horusec/ddb84fb1-c8a6-4e44-871d-2f59240a1049]"
+
+--- PASS: TestLanguageDetect (6.18s)
+    --- PASS: TestLanguageDetect/Should_return_error_when_the_folder_not_exists (0.00s)
+    --- PASS: TestLanguageDetect/Should_ignore_files_of_the_type_images (0.08s)
+    --- PASS: TestLanguageDetect/Should_ignore_additional_folder_setup_in_configs (0.06s)
+    --- PASS: TestLanguageDetect/Should_ignore_additional_specific_file_name_setup_in_configs (0.05s)
+    --- PASS: TestLanguageDetect/Should_run_language_detect_and_return_GO_and_GITLEAKS (0.06s)
+    --- PASS: TestLanguageDetect/Should_run_language_detect_and_return_GITLEAKS (0.40s)
+    --- PASS: TestLanguageDetect/Should_run_language_detect_and_return_JAVA_and_GITLEAKS (0.30s)
+    --- PASS: TestLanguageDetect/Should_run_language_detect_and_return_JAVASCRIPT_and_GITLEAKS (0.09s)
+    --- PASS: TestLanguageDetect/Should_run_language_detect_and_return_JAVASCRIPT_and_GITLEAKS#01 (0.05s)
+    --- PASS: TestLanguageDetect/Should_run_language_detect_and_return_PHP,_LEAKS,_GENERIC_in_example2 (0.12s)
+    --- PASS: TestLanguageDetect/Should_run_language_detect_and_return_PHP,_LEAKS,_GENERIC_in_example1 (0.01s)
+    --- PASS: TestLanguageDetect/Should_run_language_detect_and_return_KOTLIN_and_GITLEAKS (0.05s)
+    --- PASS: TestLanguageDetect/Should_run_language_detect_and_return_CSHARP_and_GITLEAKS (0.05s)
+    --- PASS: TestLanguageDetect/Should_run_language_detect_and_return_PYTHON_and_GITLEAKS (0.02s)
+    --- PASS: TestLanguageDetect/Should_run_language_detect_and_return_PYTHON_safety_and_GITLEAKS (0.03s)
+    --- PASS: TestLanguageDetect/Should_run_language_detect_and_return_RUBY_and_GITLEAKS (0.63s)
+    --- PASS: TestLanguageDetect/Should_run_language_detect_on_examples_folder_and_return_RUBY_and_GITLEAKS (0.88s)
+    --- PASS: TestLanguageDetect/Should_run_language_detect_on_examples_folder_and_return_all_languages (1.62s)
+    --- PASS: TestLanguageDetect/Should_ignore_folders_present_in_toignore.GetDefaultFoldersToIgnore() (0.02s)
+    --- PASS: TestLanguageDetect/Should_read_git_submodule_path_and_copy_to_.horusec_folder_git_submodule_correctly (1.49s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/controllers/language_detect	11.481s
+=== RUN   TestStartPrintResultsMock
+=== RUN   TestStartPrintResultsMock/Should_return_correctly_mock
+--- PASS: TestStartPrintResultsMock (0.00s)
+    --- PASS: TestStartPrintResultsMock/Should_return_correctly_mock (0.00s)
+=== RUN   TestPrintResultsStartPrintResults
+=== RUN   TestPrintResultsStartPrintResults/Should_not_return_error_using_default_output_type_text
+=== RUN   TestPrintResultsStartPrintResults/Should_not_return_error_using_output_type_json
+=== RUN   TestPrintResultsStartPrintResults/Should_not_return_error_using_output_type_sonarqube
+=== RUN   TestPrintResultsStartPrintResults/Should_return_not_errors_because_exists_error_in_analysis
+=== RUN   TestPrintResultsStartPrintResults/Should_return_error_when_using_json_output_type_without_output_file_path
+=== RUN   TestPrintResultsStartPrintResults/Should_return_11_vulnerabilities_with_timeout_occurs
+=== RUN   TestPrintResultsStartPrintResults/Should_print_11_vulnerabilities
+=== RUN   TestPrintResultsStartPrintResults/Should_print_11_vulnerabilities_with_commit_authors
+=== RUN   TestPrintResultsStartPrintResults/Should_not_return_errors_when_configured_to_ignore_vulnerabilities_with_severity_LOW_and_MEDIUM
+=== RUN   TestPrintResultsStartPrintResults/Should_save_output_to_file_when_using_json_output_file_path_and_text_format
+=== RUN   TestPrintResultsStartPrintResults/Should_print_correct_path_when_using_ContainerBindProjectPath
+--- PASS: TestPrintResultsStartPrintResults (0.09s)
+    --- PASS: TestPrintResultsStartPrintResults/Should_not_return_error_using_default_output_type_text (0.01s)
+    --- PASS: TestPrintResultsStartPrintResults/Should_not_return_error_using_output_type_json (0.00s)
+    --- PASS: TestPrintResultsStartPrintResults/Should_not_return_error_using_output_type_sonarqube (0.01s)
+    --- PASS: TestPrintResultsStartPrintResults/Should_return_not_errors_because_exists_error_in_analysis (0.00s)
+    --- PASS: TestPrintResultsStartPrintResults/Should_return_error_when_using_json_output_type_without_output_file_path (0.01s)
+    --- PASS: TestPrintResultsStartPrintResults/Should_return_11_vulnerabilities_with_timeout_occurs (0.00s)
+    --- PASS: TestPrintResultsStartPrintResults/Should_print_11_vulnerabilities (0.00s)
+    --- PASS: TestPrintResultsStartPrintResults/Should_print_11_vulnerabilities_with_commit_authors (0.00s)
+    --- PASS: TestPrintResultsStartPrintResults/Should_not_return_errors_when_configured_to_ignore_vulnerabilities_with_severity_LOW_and_MEDIUM (0.00s)
+    --- PASS: TestPrintResultsStartPrintResults/Should_save_output_to_file_when_using_json_output_file_path_and_text_format (0.01s)
+    --- PASS: TestPrintResultsStartPrintResults/Should_print_correct_path_when_using_ContainerBindProjectPath (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/controllers/printresults	0.150s
+=== RUN   TestValidateAllRequirements
+=== RUN   TestValidateAllRequirements/should_return_no_error_when_everything_it_is_ok
+--- PASS: TestValidateAllRequirements (0.03s)
+    --- PASS: TestValidateAllRequirements/should_return_no_error_when_everything_it_is_ok (0.03s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/controllers/requirements	0.084s
+?   	github.com/ZupIT/horusec/internal/controllers/requirements/docker	[no test files]
+?   	github.com/ZupIT/horusec/internal/controllers/requirements/git	[no test files]
+=== RUN   TestNewCustomImages
+=== RUN   TestNewCustomImages/Should_return_12_custom_images
+=== RUN   TestNewCustomImages/Should_return_empty_image_for_all_languages_as_default
+--- PASS: TestNewCustomImages (0.00s)
+    --- PASS: TestNewCustomImages/Should_return_12_custom_images (0.00s)
+    --- PASS: TestNewCustomImages/Should_return_empty_image_for_all_languages_as_default (0.00s)
+=== RUN   TestMustParseCustomImages
+=== RUN   TestMustParseCustomImages/Should_parse_valid_custom_images
+=== RUN   TestMustParseCustomImages/Should_return_default_values_using_invalid_schema
+=== RUN   TestMustParseCustomImages/Should_return_default_values_using_invalid_language
+--- PASS: TestMustParseCustomImages (0.00s)
+    --- PASS: TestMustParseCustomImages/Should_parse_valid_custom_images (0.00s)
+    --- PASS: TestMustParseCustomImages/Should_return_default_values_using_invalid_schema (0.00s)
+    --- PASS: TestMustParseCustomImages/Should_return_default_values_using_invalid_language (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/entities/custom_images	0.091s
+=== RUN   TestIsInvalid
+=== RUN   TestIsInvalid/should_return_false_when_valid
+=== RUN   TestIsInvalid/should_return_true_when_invalid_data
+--- PASS: TestIsInvalid (0.00s)
+    --- PASS: TestIsInvalid/should_return_false_when_valid (0.00s)
+    --- PASS: TestIsInvalid/should_return_true_when_invalid_data (0.00s)
+=== RUN   TestSetData
+=== RUN   TestSetData/should_success_set_data
+--- PASS: TestSetData (0.00s)
+    --- PASS: TestSetData/should_success_set_data (0.00s)
+=== RUN   TestGetCustomOrDefaultImage
+=== RUN   TestGetCustomOrDefaultImage/should_success_get_image_with_custom_image
+=== RUN   TestGetCustomOrDefaultImage/should_success_get_image_with_default_image
+--- PASS: TestGetCustomOrDefaultImage (0.00s)
+    --- PASS: TestGetCustomOrDefaultImage/should_success_get_image_with_custom_image (0.00s)
+    --- PASS: TestGetCustomOrDefaultImage/should_success_get_image_with_default_image (0.00s)
+=== RUN   TestSetSlnName
+=== RUN   TestSetSlnName/should_success_set_sln_name
+=== RUN   TestSetSlnName/should_return_not_found_sln_name
+--- PASS: TestSetSlnName (0.00s)
+    --- PASS: TestSetSlnName/should_success_set_sln_name (0.00s)
+    --- PASS: TestSetSlnName/should_return_not_found_sln_name (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/entities/docker	0.031s
+=== RUN   TestDefaultValues
+--- PASS: TestDefaultValues (0.00s)
+=== RUN   TestParseToolsConfig
+=== RUN   TestParseToolsConfig/Should_parse_values_incomplete_correctly_and_return_all_tools
+=== RUN   TestParseToolsConfig/Should_error_on_invalid_configuration_and_use_default_values
+=== RUN   TestParseToolsConfig/Should_parse_using_lower_and_upper_case
+--- PASS: TestParseToolsConfig (0.00s)
+    --- PASS: TestParseToolsConfig/Should_parse_values_incomplete_correctly_and_return_all_tools (0.00s)
+    --- PASS: TestParseToolsConfig/Should_error_on_invalid_configuration_and_use_default_values (0.00s)
+    --- PASS: TestParseToolsConfig/Should_parse_using_lower_and_upper_case (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/entities/toolsconfig	0.033s
+=== RUN   TestDefaultReturnEmptyWorkDir
+--- PASS: TestDefaultReturnEmptyWorkDir (0.00s)
+=== RUN   TestMustParseWorkDir
+=== RUN   TestMustParseWorkDir/Should_successfully_parse_work_dir
+=== RUN   TestMustParseWorkDir/Should_fail_on_parse_invalid_work_dir_and_return_default
+time="2022-07-26T18:08:39-03:00" level=error msg="{HORUSEC_CLI} Error when try parse workdir string to entity.Returning default values" error="json: cannot unmarshal string into Go struct field WorkDir.go of type []string"
+--- PASS: TestMustParseWorkDir (0.00s)
+    --- PASS: TestMustParseWorkDir/Should_successfully_parse_work_dir (0.00s)
+    --- PASS: TestMustParseWorkDir/Should_fail_on_parse_invalid_work_dir_and_return_default (0.00s)
+=== RUN   TestLanguagePaths
+--- PASS: TestLanguagePaths (0.00s)
+=== RUN   TestPathsOfLanguage
+--- PASS: TestPathsOfLanguage (0.00s)
+=== RUN   TestString
+--- PASS: TestString (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/entities/workdir	0.043s
+?   	github.com/ZupIT/horusec/internal/enums/images	[no test files]
+=== RUN   TestToString
+=== RUN   TestToString/Should_success_parse_to_string
+--- PASS: TestToString (0.00s)
+    --- PASS: TestToString/Should_success_parse_to_string (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/enums/outputtype	0.049s
+=== RUN   TestGetDefaultFoldersToIgnore
+=== RUN   TestGetDefaultFoldersToIgnore/should_success_get_5_default_paths_to_ignore
+--- PASS: TestGetDefaultFoldersToIgnore (0.00s)
+    --- PASS: TestGetDefaultFoldersToIgnore/should_success_get_5_default_paths_to_ignore (0.00s)
+=== RUN   TestGetDefaultExtensionsToIgnore
+=== RUN   TestGetDefaultExtensionsToIgnore/should_success_get_38_extensions_to_ignore
+--- PASS: TestGetDefaultExtensionsToIgnore (0.00s)
+    --- PASS: TestGetDefaultExtensionsToIgnore/should_success_get_38_extensions_to_ignore (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/enums/toignore	0.039s
+?   	github.com/ZupIT/horusec/internal/helpers/messages	[no test files]
+=== RUN   TestValidate
+=== RUN   TestValidate/should_return_no_errors_when_valid_custom_rule
+=== RUN   TestValidate/should_return_error_when_empty_custom_rule
+=== RUN   TestValidate/should_return_error_when_invalid_ID
+=== RUN   TestValidate/should_return_error_when_duplicated_ID
+=== RUN   TestValidate/should_return_error_when_not_supported_language
+--- PASS: TestValidate (0.03s)
+    --- PASS: TestValidate/should_return_no_errors_when_valid_custom_rule (0.01s)
+    --- PASS: TestValidate/should_return_error_when_empty_custom_rule (0.00s)
+    --- PASS: TestValidate/should_return_error_when_invalid_ID (0.00s)
+    --- PASS: TestValidate/should_return_error_when_duplicated_ID (0.02s)
+    --- PASS: TestValidate/should_return_error_when_not_supported_language (0.00s)
+=== RUN   TestValidateAllLanguages
+=== RUN   TestValidateAllLanguages/Language_CSharp
+=== RUN   TestValidateAllLanguages/Language_DART
+=== RUN   TestValidateAllLanguages/Language_Java
+=== RUN   TestValidateAllLanguages/Language_Kotlin
+=== RUN   TestValidateAllLanguages/Language_YAML
+=== RUN   TestValidateAllLanguages/Language_Leaks
+=== RUN   TestValidateAllLanguages/Language_JavaScript
+=== RUN   TestValidateAllLanguages/Language_Nginx
+=== RUN   TestValidateAllLanguages/Error_due_to_invalid_ID
+=== RUN   TestValidateAllLanguages/Language_Nginx_-_Error_due_to_invalid_Language
+--- PASS: TestValidateAllLanguages (0.13s)
+    --- PASS: TestValidateAllLanguages/Language_CSharp (0.04s)
+    --- PASS: TestValidateAllLanguages/Language_DART (0.02s)
+    --- PASS: TestValidateAllLanguages/Language_Java (0.04s)
+    --- PASS: TestValidateAllLanguages/Language_Kotlin (0.01s)
+    --- PASS: TestValidateAllLanguages/Language_YAML (0.00s)
+    --- PASS: TestValidateAllLanguages/Language_Leaks (0.01s)
+    --- PASS: TestValidateAllLanguages/Language_JavaScript (0.01s)
+    --- PASS: TestValidateAllLanguages/Language_Nginx (0.00s)
+    --- PASS: TestValidateAllLanguages/Error_due_to_invalid_ID (0.00s)
+    --- PASS: TestValidateAllLanguages/Language_Nginx_-_Error_due_to_invalid_Language (0.00s)
+=== RUN   TestGetRuleType
+=== RUN   TestGetRuleType/should_return_regular_type
+=== RUN   TestGetRuleType/should_return_regular_type#01
+=== RUN   TestGetRuleType/should_return_OR_type
+=== RUN   TestGetRuleType/should_return_AND_type
+=== RUN   TestGetRuleType/should_return_NOT_type
+--- PASS: TestGetRuleType (0.00s)
+    --- PASS: TestGetRuleType/should_return_regular_type (0.00s)
+    --- PASS: TestGetRuleType/should_return_regular_type#01 (0.00s)
+    --- PASS: TestGetRuleType/should_return_OR_type (0.00s)
+    --- PASS: TestGetRuleType/should_return_AND_type (0.00s)
+    --- PASS: TestGetRuleType/should_return_NOT_type (0.00s)
+=== RUN   TestGetExpressions
+=== RUN   TestGetExpressions/successful_get_regex_expressions
+=== RUN   TestGetExpressions/should_log_an_error_when_expression_fails_to_complie
+time="2022-07-26T18:08:40-03:00" level=error msg="{HORUSEC_CLI} failed to compile custom rule regex: ^\\/(?!\\/)(.*?)" error="error parsing regexp: invalid or unsupported Perl syntax: `(?!`"
+--- PASS: TestGetExpressions (0.00s)
+    --- PASS: TestGetExpressions/successful_get_regex_expressions (0.00s)
+    --- PASS: TestGetExpressions/should_log_an_error_when_expression_fails_to_complie (0.00s)
+=== RUN   TestToString
+=== RUN   TestToString/should_log_an_error_when_failed_to_compile_expression
+=== RUN   TestToString/successful_conversion_to_a_string
+--- PASS: TestToString (0.00s)
+    --- PASS: TestToString/should_log_an_error_when_failed_to_compile_expression (0.00s)
+    --- PASS: TestToString/successful_conversion_to_a_string (0.00s)
+=== RUN   TestNewCustomRulesService
+--- PASS: TestNewCustomRulesService (0.00s)
+=== RUN   TestGetCustomRulesByTool
+=== RUN   TestGetCustomRulesByTool/should_success_load_custom_rules_from_file
+=== RUN   TestGetCustomRulesByTool/should_use_empty_rules_for_all_languages_when_file_does_not_exists
+time="2022-07-26T18:08:40-03:00" level=error msg="{HORUSEC_CLI} failed to get custom rules: " error="open test.json: no such file or directory"
+=== RUN   TestGetCustomRulesByTool/should_use_empty_rules_for_all_languages_when_file_is_in_invalid_format
+time="2022-07-26T18:08:40-03:00" level=error msg="{HORUSEC_CLI} invalid custom rule: {\"id\":\"test\",\"name\":\"test\",\"description\":\"test\",\"language\":\"\",\"severity\":\"test\",\"confidence\":\"test\",\"type\":\"test\",\"expressions\":[\"test\"]}" error="confidence: must be a valid value; id: test should match language name ; language: cannot be blank; severity: must be a valid value; type: must be a valid value."
+--- PASS: TestGetCustomRulesByTool (0.12s)
+    --- PASS: TestGetCustomRulesByTool/should_success_load_custom_rules_from_file (0.12s)
+    --- PASS: TestGetCustomRulesByTool/should_use_empty_rules_for_all_languages_when_file_does_not_exists (0.00s)
+    --- PASS: TestGetCustomRulesByTool/should_use_empty_rules_for_all_languages_when_file_is_in_invalid_format (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/services/custom_rules	0.351s
+=== RUN   TestDockerAPI_CreateLanguageAnalysisContainer
+=== RUN   TestDockerAPI_CreateLanguageAnalysisContainer/Should_return_error_when_DefaultImage_is_empty
+=== RUN   TestDockerAPI_CreateLanguageAnalysisContainer/Should_return_error_when_cmd_is_empty
+=== RUN   TestDockerAPI_CreateLanguageAnalysisContainer/Should_return_error_when_pull_image_aleatory
+time="2022-07-26T18:08:40-03:00" level=error msg="{HORUSEC_CLI} Error when create container of analysis: " error="Error response from daemon: invalid mount config for type \"bind\": invalid mount path: '.horusec/3dabfa92-2cbe-42d5-8ecc-0a3841356f7a' mount path must be absolute"
+=== RUN   TestDockerAPI_CreateLanguageAnalysisContainer/Should_create_valid_canonical_image_path
+time="2022-07-26T18:08:40-03:00" level=error msg="{HORUSEC_CLI} Error when create container of analysis: " error="Error response from daemon: invalid mount config for type \"bind\": invalid mount path: '.horusec/35740c63-136c-42dd-8085-7358043636c8' mount path must be absolute"
+=== RUN   TestDockerAPI_CreateLanguageAnalysisContainer/Should_return_error_when_list_image_to_check_if_exist
+time="2022-07-26T18:08:40-03:00" level=error msg="{HORUSEC_CLI} Error when list all images enable: " error="some error generic"
+time="2022-07-26T18:08:40-03:00" level=error msg="{HORUSEC_CLI} Failed to pull docker image -> " error="some error generic"
+=== RUN   TestDockerAPI_CreateLanguageAnalysisContainer/Should_return_error_when_pull_new_image
+time="2022-07-26T18:08:40-03:00" level=error msg="{HORUSEC_CLI} Error when pull new image: " error="some error generic"
+time="2022-07-26T18:08:40-03:00" level=error msg="{HORUSEC_CLI} Failed to pull docker image -> " error="some error generic"
+=== RUN   TestDockerAPI_CreateLanguageAnalysisContainer/Should_return_error_when_create_container
+time="2022-07-26T18:08:40-03:00" level=error msg="{HORUSEC_CLI} Error when create container of analysis: " error="some error generic"
+=== RUN   TestDockerAPI_CreateLanguageAnalysisContainer/Should_return_error_when_start_container
+time="2022-07-26T18:08:40-03:00" level=error msg="{HORUSEC_CLI} Error when start container of analysis: " error="some error generic"
+=== RUN   TestDockerAPI_CreateLanguageAnalysisContainer/Should_return_error_when_wait_container
+=== RUN   TestDockerAPI_CreateLanguageAnalysisContainer/Should_return_error_when_read_container_logs
+=== RUN   TestDockerAPI_CreateLanguageAnalysisContainer/Should_return_analysis_with_success
+=== RUN   TestDockerAPI_CreateLanguageAnalysisContainer/Should_pull_image_from_registry_when_not_exists_on_cache
+=== RUN   TestDockerAPI_CreateLanguageAnalysisContainer/Should_not_pull_image_from_registry_when_exists_on_cache
+--- PASS: TestDockerAPI_CreateLanguageAnalysisContainer (0.02s)
+    --- PASS: TestDockerAPI_CreateLanguageAnalysisContainer/Should_return_error_when_DefaultImage_is_empty (0.00s)
+    --- PASS: TestDockerAPI_CreateLanguageAnalysisContainer/Should_return_error_when_cmd_is_empty (0.00s)
+    --- PASS: TestDockerAPI_CreateLanguageAnalysisContainer/Should_return_error_when_pull_image_aleatory (0.01s)
+    --- PASS: TestDockerAPI_CreateLanguageAnalysisContainer/Should_create_valid_canonical_image_path (0.00s)
+    --- PASS: TestDockerAPI_CreateLanguageAnalysisContainer/Should_return_error_when_list_image_to_check_if_exist (0.00s)
+    --- PASS: TestDockerAPI_CreateLanguageAnalysisContainer/Should_return_error_when_pull_new_image (0.00s)
+    --- PASS: TestDockerAPI_CreateLanguageAnalysisContainer/Should_return_error_when_create_container (0.00s)
+    --- PASS: TestDockerAPI_CreateLanguageAnalysisContainer/Should_return_error_when_start_container (0.00s)
+    --- PASS: TestDockerAPI_CreateLanguageAnalysisContainer/Should_return_error_when_wait_container (0.00s)
+    --- PASS: TestDockerAPI_CreateLanguageAnalysisContainer/Should_return_error_when_read_container_logs (0.00s)
+    --- PASS: TestDockerAPI_CreateLanguageAnalysisContainer/Should_return_analysis_with_success (0.00s)
+    --- PASS: TestDockerAPI_CreateLanguageAnalysisContainer/Should_pull_image_from_registry_when_not_exists_on_cache (0.00s)
+    --- PASS: TestDockerAPI_CreateLanguageAnalysisContainer/Should_not_pull_image_from_registry_when_exists_on_cache (0.00s)
+=== RUN   TestDeleteContainersFromAPI
+=== RUN   TestDeleteContainersFromAPI/should_not_panics
+=== RUN   TestDeleteContainersFromAPI/should_not_panics_but_return_error_when_container_list
+time="2022-07-26T18:08:40-03:00" level=error msg="{HORUSEC_CLI} Error when list all containers of analysis: " error=test
+=== RUN   TestDeleteContainersFromAPI/Test_Replace_docker_bind_folder_to_windows_o.s
+--- PASS: TestDeleteContainersFromAPI (0.00s)
+    --- PASS: TestDeleteContainersFromAPI/should_not_panics (0.00s)
+    --- PASS: TestDeleteContainersFromAPI/should_not_panics_but_return_error_when_container_list (0.00s)
+    --- PASS: TestDeleteContainersFromAPI/Test_Replace_docker_bind_folder_to_windows_o.s (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/services/docker	0.134s
+=== RUN   TestNewDockerAPI
+=== RUN   TestNewDockerAPI/Should_not_panic_when_success_connect_to_docker
+=== RUN   TestNewDockerAPI/Should_use_docker_host_from_environment_variable
+--- PASS: TestNewDockerAPI (0.00s)
+    --- PASS: TestNewDockerAPI/Should_not_panic_when_success_connect_to_docker (0.00s)
+    --- PASS: TestNewDockerAPI/Should_use_docker_host_from_environment_variable (0.00s)
+=== RUN   TestMock
+=== RUN   TestMock/Should_return_expected_data_to_ContainerCreate
+=== RUN   TestMock/Should_return_expected_data_to_ContainerStart
+=== RUN   TestMock/Should_return_expected_data_to_ContainerWait
+=== RUN   TestMock/Should_return_expected_data_to_ContainerLogs
+=== RUN   TestMock/Should_return_expected_data_to_ContainerRemove
+=== RUN   TestMock/Should_return_expected_data_to_ImageList
+=== RUN   TestMock/Should_return_expected_data_to_ImagePull
+=== RUN   TestMock/Should_return_expected_data_to_Ping
+=== RUN   TestMock/Should_return_expected_data_to_Ping#01
+--- PASS: TestMock (0.01s)
+    --- PASS: TestMock/Should_return_expected_data_to_ContainerCreate (0.00s)
+    --- PASS: TestMock/Should_return_expected_data_to_ContainerStart (0.00s)
+    --- PASS: TestMock/Should_return_expected_data_to_ContainerWait (0.00s)
+    --- PASS: TestMock/Should_return_expected_data_to_ContainerLogs (0.00s)
+    --- PASS: TestMock/Should_return_expected_data_to_ContainerRemove (0.00s)
+    --- PASS: TestMock/Should_return_expected_data_to_ImageList (0.00s)
+    --- PASS: TestMock/Should_return_expected_data_to_ImagePull (0.00s)
+    --- PASS: TestMock/Should_return_expected_data_to_Ping (0.00s)
+    --- PASS: TestMock/Should_return_expected_data_to_Ping#01 (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/services/docker/client	0.168s
+=== RUN   TestGetRules
+=== RUN   TestGetRules/Javascript
+=== RUN   TestGetRules/Nginx
+=== RUN   TestGetRules/Leaks
+=== RUN   TestGetRules/Kubernetes
+=== RUN   TestGetRules/Kotlin
+=== RUN   TestGetRules/Java
+=== RUN   TestGetRules/Dart
+=== RUN   TestGetRules/Csharp
+=== RUN   TestGetRules/Swift
+--- PASS: TestGetRules (0.16s)
+    --- PASS: TestGetRules/Javascript (0.00s)
+    --- PASS: TestGetRules/Nginx (0.00s)
+    --- PASS: TestGetRules/Leaks (0.00s)
+    --- PASS: TestGetRules/Kubernetes (0.00s)
+    --- PASS: TestGetRules/Kotlin (0.00s)
+    --- PASS: TestGetRules/Java (0.00s)
+    --- PASS: TestGetRules/Dart (0.00s)
+    --- PASS: TestGetRules/Csharp (0.00s)
+    --- PASS: TestGetRules/Swift (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/services/engines	0.235s
+=== RUN   TestRulesVulnerableCode
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-1
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-2
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-3
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-4
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-5
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-6
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-7
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-8
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-9
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-10
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-11
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-12
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-13
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-14
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-15
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-16
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-17
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-18
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-19
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-20
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-21
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-22
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-23
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-24
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-25
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-26
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-27
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-28
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-29
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-30
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-31
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-32
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-33
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-34
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-35
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-36
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-37
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-38
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-39
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-40
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-41
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-42
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-43
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-44
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-45
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-46
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-47
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-48
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-49
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-50
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-51
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-52
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-53
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-54
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-55
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-56
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-57
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-58
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-59
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-60
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-61
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-62
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-63
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-64
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-65
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-66
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-67
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-68
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-69
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-70
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-71
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-72
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-73
+=== RUN   TestRulesVulnerableCode/HS-CSHARP-74
+--- PASS: TestRulesVulnerableCode (1.40s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-1 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-2 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-3 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-4 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-5 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-6 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-7 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-8 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-9 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-10 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-11 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-12 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-13 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-14 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-15 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-16 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-17 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-18 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-19 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-20 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-21 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-22 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-23 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-24 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-25 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-26 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-27 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-28 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-29 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-30 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-31 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-32 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-33 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-34 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-35 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-36 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-37 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-38 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-39 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-40 (0.03s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-41 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-42 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-43 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-44 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-45 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-46 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-47 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-48 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-49 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-50 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-51 (0.04s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-52 (0.10s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-53 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-54 (0.19s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-55 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-56 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-57 (0.03s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-58 (0.14s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-59 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-60 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-61 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-62 (0.06s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-63 (0.04s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-64 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-65 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-66 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-67 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-68 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-69 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-70 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-71 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-72 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-73 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-CSHARP-74 (0.03s)
+=== RUN   TestRulesSafeCode
+=== RUN   TestRulesSafeCode/HS-CSHARP-1
+=== RUN   TestRulesSafeCode/HS-CSHARP-2
+=== RUN   TestRulesSafeCode/HS-CSHARP-3
+=== RUN   TestRulesSafeCode/HS-CSHARP-4
+=== RUN   TestRulesSafeCode/HS-CSHARP-5
+=== RUN   TestRulesSafeCode/HS-CSHARP-6
+=== RUN   TestRulesSafeCode/HS-CSHARP-7
+=== RUN   TestRulesSafeCode/HS-CSHARP-8
+=== RUN   TestRulesSafeCode/HS-CSHARP-9
+=== RUN   TestRulesSafeCode/HS-CSHARP-10
+=== RUN   TestRulesSafeCode/HS-CSHARP-11
+=== RUN   TestRulesSafeCode/HS-CSHARP-12
+=== RUN   TestRulesSafeCode/HS-CSHARP-13
+=== RUN   TestRulesSafeCode/HS-CSHARP-14
+=== RUN   TestRulesSafeCode/HS-CSHARP-15
+=== RUN   TestRulesSafeCode/HS-CSHARP-16
+=== RUN   TestRulesSafeCode/HS-CSHARP-17
+=== RUN   TestRulesSafeCode/HS-CSHARP-18
+=== RUN   TestRulesSafeCode/HS-CSHARP-19
+=== RUN   TestRulesSafeCode/HS-CSHARP-20
+=== RUN   TestRulesSafeCode/HS-CSHARP-21
+=== RUN   TestRulesSafeCode/HS-CSHARP-22
+=== RUN   TestRulesSafeCode/HS-CSHARP-23
+=== RUN   TestRulesSafeCode/HS-CSHARP-24
+=== RUN   TestRulesSafeCode/HS-CSHARP-25
+=== RUN   TestRulesSafeCode/HS-CSHARP-26
+=== RUN   TestRulesSafeCode/HS-CSHARP-27
+=== RUN   TestRulesSafeCode/HS-CSHARP-28
+=== RUN   TestRulesSafeCode/HS-CSHARP-29
+=== RUN   TestRulesSafeCode/HS-CSHARP-30
+=== RUN   TestRulesSafeCode/HS-CSHARP-31
+=== RUN   TestRulesSafeCode/HS-CSHARP-32
+=== RUN   TestRulesSafeCode/HS-CSHARP-33
+=== RUN   TestRulesSafeCode/HS-CSHARP-34
+=== RUN   TestRulesSafeCode/HS-CSHARP-35
+=== RUN   TestRulesSafeCode/HS-CSHARP-36
+=== RUN   TestRulesSafeCode/HS-CSHARP-37
+=== RUN   TestRulesSafeCode/HS-CSHARP-38
+=== RUN   TestRulesSafeCode/HS-CSHARP-39
+=== RUN   TestRulesSafeCode/HS-CSHARP-40
+=== RUN   TestRulesSafeCode/HS-CSHARP-41
+=== RUN   TestRulesSafeCode/HS-CSHARP-42
+=== RUN   TestRulesSafeCode/HS-CSHARP-43
+=== RUN   TestRulesSafeCode/HS-CSHARP-44
+=== RUN   TestRulesSafeCode/HS-CSHARP-45
+=== RUN   TestRulesSafeCode/HS-CSHARP-46
+=== RUN   TestRulesSafeCode/HS-CSHARP-47
+=== RUN   TestRulesSafeCode/HS-CSHARP-48
+=== RUN   TestRulesSafeCode/HS-CSHARP-49
+=== RUN   TestRulesSafeCode/HS-CSHARP-50
+=== RUN   TestRulesSafeCode/HS-CSHARP-51
+=== RUN   TestRulesSafeCode/HS-CSHARP-52
+=== RUN   TestRulesSafeCode/HS-CSHARP-53
+=== RUN   TestRulesSafeCode/HS-CSHARP-54
+=== RUN   TestRulesSafeCode/HS-CSHARP-55
+=== RUN   TestRulesSafeCode/HS-CSHARP-56
+=== RUN   TestRulesSafeCode/HS-CSHARP-57
+=== RUN   TestRulesSafeCode/HS-CSHARP-58
+=== RUN   TestRulesSafeCode/HS-CSHARP-59
+=== RUN   TestRulesSafeCode/HS-CSHARP-60
+=== RUN   TestRulesSafeCode/HS-CSHARP-61
+=== RUN   TestRulesSafeCode/HS-CSHARP-62
+=== RUN   TestRulesSafeCode/HS-CSHARP-63
+=== RUN   TestRulesSafeCode/HS-CSHARP-64
+=== RUN   TestRulesSafeCode/HS-CSHARP-65
+=== RUN   TestRulesSafeCode/HS-CSHARP-66
+=== RUN   TestRulesSafeCode/HS-CSHARP-67
+=== RUN   TestRulesSafeCode/HS-CSHARP-68
+=== RUN   TestRulesSafeCode/HS-CSHARP-69
+=== RUN   TestRulesSafeCode/HS-CSHARP-70
+=== RUN   TestRulesSafeCode/HS-CSHARP-71
+=== RUN   TestRulesSafeCode/HS-CSHARP-72
+=== RUN   TestRulesSafeCode/HS-CSHARP-73
+=== RUN   TestRulesSafeCode/HS-CSHARP-74
+--- PASS: TestRulesSafeCode (1.16s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-1 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-2 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-3 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-4 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-5 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-6 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-7 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-8 (0.10s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-9 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-10 (0.00s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-11 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-12 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-13 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-14 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-15 (0.00s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-16 (0.03s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-17 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-18 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-19 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-20 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-21 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-22 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-23 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-24 (0.05s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-25 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-26 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-27 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-28 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-29 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-30 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-31 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-32 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-33 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-34 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-35 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-36 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-37 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-38 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-39 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-40 (0.04s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-41 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-42 (0.03s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-43 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-44 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-45 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-46 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-47 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-48 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-49 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-50 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-51 (0.00s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-52 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-53 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-54 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-55 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-56 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-57 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-58 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-59 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-60 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-61 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-62 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-63 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-64 (0.00s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-65 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-66 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-67 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-68 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-69 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-70 (0.00s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-71 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-72 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-73 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-CSHARP-74 (0.01s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/services/engines/csharp	2.969s
+=== RUN   TestRulesVulnerableCode
+=== RUN   TestRulesVulnerableCode/HS-DART-1
+=== RUN   TestRulesVulnerableCode/HS-DART-2
+=== RUN   TestRulesVulnerableCode/HS-DART-3
+=== RUN   TestRulesVulnerableCode/HS-DART-4
+=== RUN   TestRulesVulnerableCode/HS-DART-5
+=== RUN   TestRulesVulnerableCode/HS-DART-6
+=== RUN   TestRulesVulnerableCode/HS-DART-7
+=== RUN   TestRulesVulnerableCode/HS-DART-8
+=== RUN   TestRulesVulnerableCode/HS-DART-9
+=== RUN   TestRulesVulnerableCode/HS-DART-10
+=== RUN   TestRulesVulnerableCode/HS-DART-11
+=== RUN   TestRulesVulnerableCode/HS-DART-12
+=== RUN   TestRulesVulnerableCode/HS-DART-13
+=== RUN   TestRulesVulnerableCode/HS-DART-14
+=== RUN   TestRulesVulnerableCode/HS-DART-15
+=== RUN   TestRulesVulnerableCode/HS-DART-16
+=== RUN   TestRulesVulnerableCode/HS-DART-17
+--- PASS: TestRulesVulnerableCode (0.53s)
+    --- PASS: TestRulesVulnerableCode/HS-DART-1 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-DART-2 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-DART-3 (0.35s)
+    --- PASS: TestRulesVulnerableCode/HS-DART-4 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-DART-5 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-DART-6 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-DART-7 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-DART-8 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-DART-9 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-DART-10 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-DART-11 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-DART-12 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-DART-13 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-DART-14 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-DART-15 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-DART-16 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-DART-17 (0.01s)
+=== RUN   TestRulesSafeCode
+=== RUN   TestRulesSafeCode/HS-DART-1
+=== RUN   TestRulesSafeCode/HS-DART-2
+=== RUN   TestRulesSafeCode/HS-DART-3
+=== RUN   TestRulesSafeCode/HS-DART-4
+=== RUN   TestRulesSafeCode/HS-DART-5
+=== RUN   TestRulesSafeCode/HS-DART-6
+=== RUN   TestRulesSafeCode/HS-DART-7
+=== RUN   TestRulesSafeCode/HS-DART-8
+=== RUN   TestRulesSafeCode/HS-DART-9
+=== RUN   TestRulesSafeCode/HS-DART-10
+=== RUN   TestRulesSafeCode/HS-DART-11
+=== RUN   TestRulesSafeCode/HS-DART-12
+=== RUN   TestRulesSafeCode/HS-DART-13
+=== RUN   TestRulesSafeCode/HS-DART-14
+=== RUN   TestRulesSafeCode/HS-DART-15
+=== RUN   TestRulesSafeCode/HS-DART-16
+=== RUN   TestRulesSafeCode/HS-DART-17
+--- PASS: TestRulesSafeCode (0.18s)
+    --- PASS: TestRulesSafeCode/HS-DART-1 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-DART-2 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-DART-3 (0.00s)
+    --- PASS: TestRulesSafeCode/HS-DART-4 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-DART-5 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-DART-6 (0.00s)
+    --- PASS: TestRulesSafeCode/HS-DART-7 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-DART-8 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-DART-9 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-DART-10 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-DART-11 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-DART-12 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-DART-13 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-DART-14 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-DART-15 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-DART-16 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-DART-17 (0.01s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/services/engines/dart	0.772s
+=== RUN   TestRulesVulnerableCode
+=== RUN   TestRulesVulnerableCode/HS-JAVA-1
+=== RUN   TestRulesVulnerableCode/HS-JAVA-2
+=== RUN   TestRulesVulnerableCode/HS-JAVA-3
+=== RUN   TestRulesVulnerableCode/HS-JAVA-4
+=== RUN   TestRulesVulnerableCode/HS-JAVA-5
+=== RUN   TestRulesVulnerableCode/HS-JAVA-7
+=== RUN   TestRulesVulnerableCode/HS-JAVA-8
+=== RUN   TestRulesVulnerableCode/HS-JAVA-9
+=== RUN   TestRulesVulnerableCode/HS-JAVA-10
+=== RUN   TestRulesVulnerableCode/HS-JAVA-11
+=== RUN   TestRulesVulnerableCode/HS-JAVA-12
+=== RUN   TestRulesVulnerableCode/HS-JAVA-13
+=== RUN   TestRulesVulnerableCode/HS-JAVA-14
+=== RUN   TestRulesVulnerableCode/HS-JAVA-18
+=== RUN   TestRulesVulnerableCode/HS-JAVA-19
+=== RUN   TestRulesVulnerableCode/HS-JAVA-22
+=== RUN   TestRulesVulnerableCode/HS-JAVA-23
+=== RUN   TestRulesVulnerableCode/HS-JAVA-24
+=== RUN   TestRulesVulnerableCode/HS-JAVA-25
+=== RUN   TestRulesVulnerableCode/HS-JAVA-26
+=== RUN   TestRulesVulnerableCode/HS-JAVA-28
+=== RUN   TestRulesVulnerableCode/HS-JAVA-111
+=== RUN   TestRulesVulnerableCode/HS-JAVA-111#01
+=== RUN   TestRulesVulnerableCode/HS-JAVA-111#02
+=== RUN   TestRulesVulnerableCode/HS-JAVA-111#03
+=== RUN   TestRulesVulnerableCode/HS-JAVA-134
+=== RUN   TestRulesVulnerableCode/HS-JAVA-144
+=== RUN   TestRulesVulnerableCode/HS-JAVA-145
+=== RUN   TestRulesVulnerableCode/HS-JAVA-146
+=== RUN   TestRulesVulnerableCode/HS-JAVA-147
+=== RUN   TestRulesVulnerableCode/HS-JAVA-148
+=== RUN   TestRulesVulnerableCode/HS-JAVA-149
+=== RUN   TestRulesVulnerableCode/HS-JAVA-150
+=== RUN   TestRulesVulnerableCode/HS-JAVA-150#01
+=== RUN   TestRulesVulnerableCode/HS-JAVA-150#02
+=== RUN   TestRulesVulnerableCode/HS-JAVA-150#03
+=== RUN   TestRulesVulnerableCode/HS-JAVA-150#04
+=== RUN   TestRulesVulnerableCode/HS-JAVA-151
+=== RUN   TestRulesVulnerableCode/HS-JAVA-151#01
+=== RUN   TestRulesVulnerableCode/HS-JAVA-151#02
+=== RUN   TestRulesVulnerableCode/HS-JAVA-151#03
+=== RUN   TestRulesVulnerableCode/HS-JAVA-151#04
+=== RUN   TestRulesVulnerableCode/HS-JAVA-152
+=== RUN   TestRulesVulnerableCode/HS-JAVA-152#01
+=== RUN   TestRulesVulnerableCode/HS-JAVA-152#02
+--- PASS: TestRulesVulnerableCode (0.83s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-1 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-2 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-3 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-4 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-5 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-7 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-8 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-9 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-10 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-11 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-12 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-13 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-14 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-18 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-19 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-22 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-23 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-24 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-25 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-26 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-28 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-111 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-111#01 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-111#02 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-111#03 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-134 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-144 (0.03s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-145 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-146 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-147 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-148 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-149 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-150 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-150#01 (0.03s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-150#02 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-150#03 (0.03s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-150#04 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-151 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-151#01 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-151#02 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-151#03 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-151#04 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-152 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-152#01 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVA-152#02 (0.00s)
+=== RUN   TestRulesSafeCode
+=== RUN   TestRulesSafeCode/HS-JAVA-1
+=== RUN   TestRulesSafeCode/HS-JAVA-1#01
+=== RUN   TestRulesSafeCode/HS-JAVA-2
+=== RUN   TestRulesSafeCode/HS-JAVA-2#01
+=== RUN   TestRulesSafeCode/HS-JAVA-3
+=== RUN   TestRulesSafeCode/HS-JAVA-3#01
+=== RUN   TestRulesSafeCode/HS-JAVA-4
+=== RUN   TestRulesSafeCode/HS-JAVA-4#01
+=== RUN   TestRulesSafeCode/HS-JAVA-5
+=== RUN   TestRulesSafeCode/HS-JAVA-5#01
+=== RUN   TestRulesSafeCode/HS-JAVA-7
+=== RUN   TestRulesSafeCode/HS-JAVA-8
+=== RUN   TestRulesSafeCode/HS-JAVA-9
+=== RUN   TestRulesSafeCode/HS-JAVA-10
+=== RUN   TestRulesSafeCode/HS-JAVA-11
+=== RUN   TestRulesSafeCode/HS-JAVA-12
+=== RUN   TestRulesSafeCode/HS-JAVA-13
+=== RUN   TestRulesSafeCode/HS-JAVA-14
+=== RUN   TestRulesSafeCode/HS-JAVA-18
+=== RUN   TestRulesSafeCode/HS-JAVA-19
+=== RUN   TestRulesSafeCode/HS-JAVA-22
+=== RUN   TestRulesSafeCode/HS-JAVA-23
+=== RUN   TestRulesSafeCode/HS-JAVA-24
+=== RUN   TestRulesSafeCode/HS-JAVA-25
+=== RUN   TestRulesSafeCode/HS-JAVA-26
+=== RUN   TestRulesSafeCode/HS-JAVA-28
+=== RUN   TestRulesSafeCode/HS-JAVA-111
+=== RUN   TestRulesSafeCode/HS-JAVA-111#01
+=== RUN   TestRulesSafeCode/HS-JAVA-111#02
+=== RUN   TestRulesSafeCode/HS-JAVA-111#03
+=== RUN   TestRulesSafeCode/HS-JAVA-134
+=== RUN   TestRulesSafeCode/HS-JAVA-144
+=== RUN   TestRulesSafeCode/HS-JAVA-145
+=== RUN   TestRulesSafeCode/HS-JAVA-146
+=== RUN   TestRulesSafeCode/HS-JAVA-147
+=== RUN   TestRulesSafeCode/HS-JAVA-148
+=== RUN   TestRulesSafeCode/HS-JAVA-149
+=== RUN   TestRulesSafeCode/HS-JAVA-150
+=== RUN   TestRulesSafeCode/HS-JAVA-150#01
+=== RUN   TestRulesSafeCode/HS-JAVA-150#02
+=== RUN   TestRulesSafeCode/HS-JAVA-150#03
+=== RUN   TestRulesSafeCode/HS-JAVA-150#04
+=== RUN   TestRulesSafeCode/HS-JAVA-151
+=== RUN   TestRulesSafeCode/HS-JAVA-151#01
+=== RUN   TestRulesSafeCode/HS-JAVA-151#02
+=== RUN   TestRulesSafeCode/HS-JAVA-151#03
+=== RUN   TestRulesSafeCode/HS-JAVA-151#04
+=== RUN   TestRulesSafeCode/HS-JAVA-152
+=== RUN   TestRulesSafeCode/HS-JAVA-152#01
+=== RUN   TestRulesSafeCode/HS-JAVA-152#02
+--- PASS: TestRulesSafeCode (1.36s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-1 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-1#01 (0.00s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-2 (0.09s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-2#01 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-3 (0.19s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-3#01 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-4 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-4#01 (0.04s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-5 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-5#01 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-7 (0.11s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-8 (0.08s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-9 (0.03s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-10 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-11 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-12 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-13 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-14 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-18 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-19 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-22 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-23 (0.03s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-24 (0.03s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-25 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-26 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-28 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-111 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-111#01 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-111#02 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-111#03 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-134 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-144 (0.05s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-145 (0.17s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-146 (0.00s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-147 (0.00s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-148 (0.00s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-149 (0.00s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-150 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-150#01 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-150#02 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-150#03 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-150#04 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-151 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-151#01 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-151#02 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-151#03 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-151#04 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-152 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-152#01 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVA-152#02 (0.01s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/services/engines/java	2.240s
+=== RUN   TestRulesVulnerableCode
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-1
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-2
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-3
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-4
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-5
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-6
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-7
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-8
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-9
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-10
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-11
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-12
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-13
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-14
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-15
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-16
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-17
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-18
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-19
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-20
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-21
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-22
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-23
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-24
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-25
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-26
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-27
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-28
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-29
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-30
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-31
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-32
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-33
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-34
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-35
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-36
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-37
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-38
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-39
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-40
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-41
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-42
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-43
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-44
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-45
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-46
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-47
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-48
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-49
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-50
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-51
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-52
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-53
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-54
+=== RUN   TestRulesVulnerableCode/HS-JAVASCRIPT-55
+--- PASS: TestRulesVulnerableCode (1.08s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-1 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-2 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-3 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-4 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-5 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-6 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-7 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-8 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-9 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-10 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-11 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-12 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-13 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-14 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-15 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-16 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-17 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-18 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-19 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-20 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-21 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-22 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-23 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-24 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-25 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-26 (0.03s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-27 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-28 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-29 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-30 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-31 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-32 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-33 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-34 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-35 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-36 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-37 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-38 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-39 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-40 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-41 (0.05s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-42 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-43 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-44 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-45 (0.08s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-46 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-47 (0.19s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-48 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-49 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-50 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-51 (0.05s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-52 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-53 (0.09s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-54 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JAVASCRIPT-55 (0.05s)
+=== RUN   TestRulesSafeCode
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-1
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-2
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-3
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-4
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-5
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-6
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-7
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-9
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-10
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-11
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-12
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-16
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-17
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-19
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-21
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-22
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-23
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-24
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-25
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-26
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-27
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-29
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-30
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-31
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-32
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-33
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-35
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-37
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-38
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-39
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-40
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-41
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-42
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-43
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-44
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-45
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-46
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-47
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-48
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-49
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-50
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-51
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-52
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-53
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-54
+=== RUN   TestRulesSafeCode/HS-JAVASCRIPT-55
+--- PASS: TestRulesSafeCode (0.63s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-1 (0.03s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-2 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-3 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-4 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-5 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-6 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-7 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-9 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-10 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-11 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-12 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-16 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-17 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-19 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-21 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-22 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-23 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-24 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-25 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-26 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-27 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-29 (0.00s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-30 (0.00s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-31 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-32 (0.05s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-33 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-35 (0.03s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-37 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-38 (0.03s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-39 (0.03s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-40 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-41 (0.03s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-42 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-43 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-44 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-45 (0.00s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-46 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-47 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-48 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-49 (0.00s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-50 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-51 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-52 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-53 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-54 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JAVASCRIPT-55 (0.01s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/services/engines/javascript	1.766s
+=== RUN   TestRulesVulnerableCode
+=== RUN   TestRulesVulnerableCode/HS-JVM-1
+=== RUN   TestRulesVulnerableCode/HS-JVM-2
+=== RUN   TestRulesVulnerableCode/HS-JVM-3
+=== RUN   TestRulesVulnerableCode/HS-JVM-4
+=== RUN   TestRulesVulnerableCode/HS-JVM-5
+=== RUN   TestRulesVulnerableCode/HS-JVM-6
+=== RUN   TestRulesVulnerableCode/HS-JVM-7
+=== RUN   TestRulesVulnerableCode/HS-JVM-8
+=== RUN   TestRulesVulnerableCode/HS-JVM-9
+=== RUN   TestRulesVulnerableCode/HS-JVM-10
+=== RUN   TestRulesVulnerableCode/HS-JVM-11
+=== RUN   TestRulesVulnerableCode/HS-JVM-12
+=== RUN   TestRulesVulnerableCode/HS-JVM-13
+=== RUN   TestRulesVulnerableCode/HS-JVM-14
+=== RUN   TestRulesVulnerableCode/HS-JVM-15
+=== RUN   TestRulesVulnerableCode/HS-JVM-16
+=== RUN   TestRulesVulnerableCode/HS-JVM-17
+=== RUN   TestRulesVulnerableCode/HS-JVM-18
+=== RUN   TestRulesVulnerableCode/HS-JVM-19
+=== RUN   TestRulesVulnerableCode/HS-JVM-20
+=== RUN   TestRulesVulnerableCode/HS-JVM-21
+--- PASS: TestRulesVulnerableCode (0.24s)
+    --- PASS: TestRulesVulnerableCode/HS-JVM-1 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-JVM-2 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JVM-3 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-JVM-4 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JVM-5 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JVM-6 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JVM-7 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JVM-8 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JVM-9 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JVM-10 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JVM-11 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-JVM-12 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JVM-13 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-JVM-14 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-JVM-15 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JVM-16 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JVM-17 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JVM-18 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JVM-19 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JVM-20 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-JVM-21 (0.02s)
+=== RUN   TestRulesSafeCode
+=== RUN   TestRulesSafeCode/HS-JVM-1
+=== RUN   TestRulesSafeCode/HS-JVM-2
+=== RUN   TestRulesSafeCode/HS-JVM-3
+=== RUN   TestRulesSafeCode/HS-JVM-4
+=== RUN   TestRulesSafeCode/HS-JVM-5
+=== RUN   TestRulesSafeCode/HS-JVM-6
+=== RUN   TestRulesSafeCode/HS-JVM-7
+=== RUN   TestRulesSafeCode/HS-JVM-8
+=== RUN   TestRulesSafeCode/HS-JVM-9
+=== RUN   TestRulesSafeCode/HS-JVM-10
+=== RUN   TestRulesSafeCode/HS-JVM-11
+=== RUN   TestRulesSafeCode/HS-JVM-12
+=== RUN   TestRulesSafeCode/HS-JVM-13
+=== RUN   TestRulesSafeCode/HS-JVM-14
+=== RUN   TestRulesSafeCode/HS-JVM-15
+=== RUN   TestRulesSafeCode/HS-JVM-16
+=== RUN   TestRulesSafeCode/HS-JVM-17
+=== RUN   TestRulesSafeCode/HS-JVM-18
+=== RUN   TestRulesSafeCode/HS-JVM-19
+=== RUN   TestRulesSafeCode/HS-JVM-20
+=== RUN   TestRulesSafeCode/HS-JVM-21
+--- PASS: TestRulesSafeCode (0.27s)
+    --- PASS: TestRulesSafeCode/HS-JVM-1 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-JVM-2 (0.00s)
+    --- PASS: TestRulesSafeCode/HS-JVM-3 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JVM-4 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JVM-5 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-JVM-6 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JVM-7 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JVM-8 (0.00s)
+    --- PASS: TestRulesSafeCode/HS-JVM-9 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JVM-10 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JVM-11 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JVM-12 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JVM-13 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JVM-14 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JVM-15 (0.00s)
+    --- PASS: TestRulesSafeCode/HS-JVM-16 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JVM-17 (0.06s)
+    --- PASS: TestRulesSafeCode/HS-JVM-18 (0.00s)
+    --- PASS: TestRulesSafeCode/HS-JVM-19 (0.00s)
+    --- PASS: TestRulesSafeCode/HS-JVM-20 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-JVM-21 (0.01s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/services/engines/jvm	0.547s
+?   	github.com/ZupIT/horusec/internal/services/engines/kotlin	[no test files]
+=== RUN   TestRulesVulnerableCode
+=== RUN   TestRulesVulnerableCode/HS-KUBERNETES-1
+=== RUN   TestRulesVulnerableCode/HS-KUBERNETES-2
+=== RUN   TestRulesVulnerableCode/HS-KUBERNETES-3
+=== RUN   TestRulesVulnerableCode/HS-KUBERNETES-4
+=== RUN   TestRulesVulnerableCode/HS-KUBERNETES-5
+=== RUN   TestRulesVulnerableCode/HS-KUBERNETES-6
+=== RUN   TestRulesVulnerableCode/HS-KUBERNETES-7
+=== RUN   TestRulesVulnerableCode/HS-KUBERNETES-8
+=== RUN   TestRulesVulnerableCode/HS-KUBERNETES-9
+--- PASS: TestRulesVulnerableCode (0.11s)
+    --- PASS: TestRulesVulnerableCode/HS-KUBERNETES-1 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-KUBERNETES-2 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-KUBERNETES-3 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-KUBERNETES-4 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-KUBERNETES-5 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-KUBERNETES-6 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-KUBERNETES-7 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-KUBERNETES-8 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-KUBERNETES-9 (0.01s)
+=== RUN   TestRulesSafeCode
+=== RUN   TestRulesSafeCode/HS-KUBERNETES-1
+=== RUN   TestRulesSafeCode/HS-KUBERNETES-2
+=== RUN   TestRulesSafeCode/HS-KUBERNETES-3
+=== RUN   TestRulesSafeCode/HS-KUBERNETES-4
+=== RUN   TestRulesSafeCode/HS-KUBERNETES-5
+=== RUN   TestRulesSafeCode/HS-KUBERNETES-6
+=== RUN   TestRulesSafeCode/HS-KUBERNETES-7
+=== RUN   TestRulesSafeCode/HS-KUBERNETES-8
+=== RUN   TestRulesSafeCode/HS-KUBERNETES-9
+--- PASS: TestRulesSafeCode (0.14s)
+    --- PASS: TestRulesSafeCode/HS-KUBERNETES-1 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-KUBERNETES-2 (0.00s)
+    --- PASS: TestRulesSafeCode/HS-KUBERNETES-3 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-KUBERNETES-4 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-KUBERNETES-5 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-KUBERNETES-6 (0.04s)
+    --- PASS: TestRulesSafeCode/HS-KUBERNETES-7 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-KUBERNETES-8 (0.00s)
+    --- PASS: TestRulesSafeCode/HS-KUBERNETES-9 (0.02s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/services/engines/kubernetes	0.293s
+=== RUN   TestRulesVulnerableCode
+=== RUN   TestRulesVulnerableCode/HS-LEAKS-1
+=== RUN   TestRulesVulnerableCode/HS-LEAKS-2
+=== RUN   TestRulesVulnerableCode/HS-LEAKS-3
+=== RUN   TestRulesVulnerableCode/HS-LEAKS-4
+=== RUN   TestRulesVulnerableCode/HS-LEAKS-5
+=== RUN   TestRulesVulnerableCode/HS-LEAKS-6
+=== RUN   TestRulesVulnerableCode/HS-LEAKS-7
+=== RUN   TestRulesVulnerableCode/HS-LEAKS-8
+=== RUN   TestRulesVulnerableCode/HS-LEAKS-9
+=== RUN   TestRulesVulnerableCode/HS-LEAKS-10
+=== RUN   TestRulesVulnerableCode/HS-LEAKS-11
+=== RUN   TestRulesVulnerableCode/HS-LEAKS-12
+=== RUN   TestRulesVulnerableCode/HS-LEAKS-13
+=== RUN   TestRulesVulnerableCode/HS-LEAKS-14
+=== RUN   TestRulesVulnerableCode/HS-LEAKS-15
+=== RUN   TestRulesVulnerableCode/HS-LEAKS-16
+=== RUN   TestRulesVulnerableCode/HS-LEAKS-17
+=== RUN   TestRulesVulnerableCode/HS-LEAKS-18
+=== RUN   TestRulesVulnerableCode/HS-LEAKS-19
+=== RUN   TestRulesVulnerableCode/HS-LEAKS-20
+=== RUN   TestRulesVulnerableCode/HS-LEAKS-21
+=== RUN   TestRulesVulnerableCode/HS-LEAKS-22
+=== RUN   TestRulesVulnerableCode/HS-LEAKS-23
+=== RUN   TestRulesVulnerableCode/HS-LEAKS-24
+=== RUN   TestRulesVulnerableCode/HS-LEAKS-25
+=== RUN   TestRulesVulnerableCode/HS-LEAKS-26
+=== RUN   TestRulesVulnerableCode/HS-LEAKS-27
+=== RUN   TestRulesVulnerableCode/HS-LEAKS-28
+=== RUN   TestRulesVulnerableCode/HS-PRIVACY-1
+=== RUN   TestRulesVulnerableCode/HS-PRIVACY-2
+--- PASS: TestRulesVulnerableCode (0.57s)
+    --- PASS: TestRulesVulnerableCode/HS-LEAKS-1 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-LEAKS-2 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-LEAKS-3 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-LEAKS-4 (0.06s)
+    --- PASS: TestRulesVulnerableCode/HS-LEAKS-5 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-LEAKS-6 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-LEAKS-7 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-LEAKS-8 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-LEAKS-9 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-LEAKS-10 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-LEAKS-11 (0.03s)
+    --- PASS: TestRulesVulnerableCode/HS-LEAKS-12 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-LEAKS-13 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-LEAKS-14 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-LEAKS-15 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-LEAKS-16 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-LEAKS-17 (0.03s)
+    --- PASS: TestRulesVulnerableCode/HS-LEAKS-18 (0.00s)
+    --- PASS: TestRulesVulnerableCode/HS-LEAKS-19 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-LEAKS-20 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-LEAKS-21 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-LEAKS-22 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-LEAKS-23 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-LEAKS-24 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-LEAKS-25 (0.03s)
+    --- PASS: TestRulesVulnerableCode/HS-LEAKS-26 (0.03s)
+    --- PASS: TestRulesVulnerableCode/HS-LEAKS-27 (0.03s)
+    --- PASS: TestRulesVulnerableCode/HS-LEAKS-28 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-PRIVACY-1 (0.06s)
+    --- PASS: TestRulesVulnerableCode/HS-PRIVACY-2 (0.01s)
+=== RUN   TestRulesSafeCode
+=== RUN   TestRulesSafeCode/HS-LEAKS-1
+=== RUN   TestRulesSafeCode/HS-LEAKS-2
+=== RUN   TestRulesSafeCode/HS-LEAKS-3
+=== RUN   TestRulesSafeCode/HS-LEAKS-4
+=== RUN   TestRulesSafeCode/HS-LEAKS-5
+=== RUN   TestRulesSafeCode/HS-LEAKS-6
+=== RUN   TestRulesSafeCode/HS-LEAKS-7
+=== RUN   TestRulesSafeCode/HS-LEAKS-8
+=== RUN   TestRulesSafeCode/HS-LEAKS-9
+=== RUN   TestRulesSafeCode/HS-LEAKS-10
+=== RUN   TestRulesSafeCode/HS-LEAKS-11
+=== RUN   TestRulesSafeCode/HS-LEAKS-12
+=== RUN   TestRulesSafeCode/HS-LEAKS-13
+=== RUN   TestRulesSafeCode/HS-LEAKS-14
+=== RUN   TestRulesSafeCode/HS-LEAKS-15
+=== RUN   TestRulesSafeCode/HS-LEAKS-16
+=== RUN   TestRulesSafeCode/HS-LEAKS-17
+=== RUN   TestRulesSafeCode/HS-LEAKS-18
+=== RUN   TestRulesSafeCode/HS-LEAKS-19
+=== RUN   TestRulesSafeCode/HS-LEAKS-20
+=== RUN   TestRulesSafeCode/HS-LEAKS-21
+=== RUN   TestRulesSafeCode/HS-LEAKS-22
+=== RUN   TestRulesSafeCode/HS-LEAKS-23
+=== RUN   TestRulesSafeCode/HS-LEAKS-24
+=== RUN   TestRulesSafeCode/HS-LEAKS-25
+=== RUN   TestRulesSafeCode/HS-LEAKS-26
+=== RUN   TestRulesSafeCode/HS-LEAKS-27
+=== RUN   TestRulesSafeCode/HS-LEAKS-28
+=== RUN   TestRulesSafeCode/HS-PRIVACY-1
+=== RUN   TestRulesSafeCode/HS-PRIVACY-2
+--- PASS: TestRulesSafeCode (0.50s)
+    --- PASS: TestRulesSafeCode/HS-LEAKS-1 (0.03s)
+    --- PASS: TestRulesSafeCode/HS-LEAKS-2 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-LEAKS-3 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-LEAKS-4 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-LEAKS-5 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-LEAKS-6 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-LEAKS-7 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-LEAKS-8 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-LEAKS-9 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-LEAKS-10 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-LEAKS-11 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-LEAKS-12 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-LEAKS-13 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-LEAKS-14 (0.03s)
+    --- PASS: TestRulesSafeCode/HS-LEAKS-15 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-LEAKS-16 (0.03s)
+    --- PASS: TestRulesSafeCode/HS-LEAKS-17 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-LEAKS-18 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-LEAKS-19 (0.00s)
+    --- PASS: TestRulesSafeCode/HS-LEAKS-20 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-LEAKS-21 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-LEAKS-22 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-LEAKS-23 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-LEAKS-24 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-LEAKS-25 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-LEAKS-26 (0.03s)
+    --- PASS: TestRulesSafeCode/HS-LEAKS-27 (0.03s)
+    --- PASS: TestRulesSafeCode/HS-LEAKS-28 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-PRIVACY-1 (0.03s)
+    --- PASS: TestRulesSafeCode/HS-PRIVACY-2 (0.02s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/services/engines/leaks	1.119s
+=== RUN   TestRulesVulnerableCode
+=== RUN   TestRulesVulnerableCode/HS-NGINX-1
+=== RUN   TestRulesVulnerableCode/HS-NGINX-2
+=== RUN   TestRulesVulnerableCode/HS-NGINX-3
+=== RUN   TestRulesVulnerableCode/HS-NGINX-4
+--- PASS: TestRulesVulnerableCode (0.05s)
+    --- PASS: TestRulesVulnerableCode/HS-NGINX-1 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-NGINX-2 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-NGINX-3 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-NGINX-4 (0.02s)
+=== RUN   TestRulesSafeCode
+=== RUN   TestRulesSafeCode/HS-NGINX-1
+=== RUN   TestRulesSafeCode/HS-NGINX-2
+=== RUN   TestRulesSafeCode/HS-NGINX-3
+=== RUN   TestRulesSafeCode/HS-NGINX-4
+--- PASS: TestRulesSafeCode (0.05s)
+    --- PASS: TestRulesSafeCode/HS-NGINX-1 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-NGINX-2 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-NGINX-3 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-NGINX-4 (0.01s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/services/engines/nginx	0.176s
+=== RUN   TestRulesVulnerableCode
+=== RUN   TestRulesVulnerableCode/HS-SWIFT-2
+=== RUN   TestRulesVulnerableCode/HS-SWIFT-3
+=== RUN   TestRulesVulnerableCode/HS-SWIFT-4
+=== RUN   TestRulesVulnerableCode/HS-SWIFT-5
+=== RUN   TestRulesVulnerableCode/HS-SWIFT-6
+=== RUN   TestRulesVulnerableCode/HS-SWIFT-7
+=== RUN   TestRulesVulnerableCode/HS-SWIFT-8
+=== RUN   TestRulesVulnerableCode/HS-SWIFT-9
+=== RUN   TestRulesVulnerableCode/HS-SWIFT-10
+=== RUN   TestRulesVulnerableCode/HS-SWIFT-11
+=== RUN   TestRulesVulnerableCode/HS-SWIFT-12
+=== RUN   TestRulesVulnerableCode/HS-SWIFT-13
+=== RUN   TestRulesVulnerableCode/HS-SWIFT-14
+=== RUN   TestRulesVulnerableCode/HS-SWIFT-15
+=== RUN   TestRulesVulnerableCode/HS-SWIFT-16
+=== RUN   TestRulesVulnerableCode/HS-SWIFT-17
+=== RUN   TestRulesVulnerableCode/HS-SWIFT-18
+=== RUN   TestRulesVulnerableCode/HS-SWIFT-19
+=== RUN   TestRulesVulnerableCode/HS-SWIFT-20
+=== RUN   TestRulesVulnerableCode/HS-SWIFT-21
+=== RUN   TestRulesVulnerableCode/HS-SWIFT-22
+=== RUN   TestRulesVulnerableCode/HS-SWIFT-23
+=== RUN   TestRulesVulnerableCode/HS-SWIFT-24
+--- PASS: TestRulesVulnerableCode (0.37s)
+    --- PASS: TestRulesVulnerableCode/HS-SWIFT-2 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-SWIFT-3 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-SWIFT-4 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-SWIFT-5 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-SWIFT-6 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-SWIFT-7 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-SWIFT-8 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-SWIFT-9 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-SWIFT-10 (0.02s)
+    --- PASS: TestRulesVulnerableCode/HS-SWIFT-11 (0.03s)
+    --- PASS: TestRulesVulnerableCode/HS-SWIFT-12 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-SWIFT-13 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-SWIFT-14 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-SWIFT-15 (0.03s)
+    --- PASS: TestRulesVulnerableCode/HS-SWIFT-16 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-SWIFT-17 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-SWIFT-18 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-SWIFT-19 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-SWIFT-20 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-SWIFT-21 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-SWIFT-22 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-SWIFT-23 (0.01s)
+    --- PASS: TestRulesVulnerableCode/HS-SWIFT-24 (0.01s)
+=== RUN   TestRulesSafeCode
+=== RUN   TestRulesSafeCode/HS-SWIFT-2
+=== RUN   TestRulesSafeCode/HS-SWIFT-3
+=== RUN   TestRulesSafeCode/HS-SWIFT-4
+=== RUN   TestRulesSafeCode/HS-SWIFT-5
+=== RUN   TestRulesSafeCode/HS-SWIFT-6
+=== RUN   TestRulesSafeCode/HS-SWIFT-7
+=== RUN   TestRulesSafeCode/HS-SWIFT-8
+=== RUN   TestRulesSafeCode/HS-SWIFT-9
+=== RUN   TestRulesSafeCode/HS-SWIFT-10
+=== RUN   TestRulesSafeCode/HS-SWIFT-11
+=== RUN   TestRulesSafeCode/HS-SWIFT-12
+=== RUN   TestRulesSafeCode/HS-SWIFT-13
+=== RUN   TestRulesSafeCode/HS-SWIFT-14
+=== RUN   TestRulesSafeCode/HS-SWIFT-15
+=== RUN   TestRulesSafeCode/HS-SWIFT-16
+=== RUN   TestRulesSafeCode/HS-SWIFT-17
+=== RUN   TestRulesSafeCode/HS-SWIFT-18
+=== RUN   TestRulesSafeCode/HS-SWIFT-19
+=== RUN   TestRulesSafeCode/HS-SWIFT-20
+=== RUN   TestRulesSafeCode/HS-SWIFT-21
+=== RUN   TestRulesSafeCode/HS-SWIFT-22
+=== RUN   TestRulesSafeCode/HS-SWIFT-23
+=== RUN   TestRulesSafeCode/HS-SWIFT-24
+=== RUN   TestRulesSafeCode/HS-SWIFT-24#01
+--- PASS: TestRulesSafeCode (0.27s)
+    --- PASS: TestRulesSafeCode/HS-SWIFT-2 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-SWIFT-3 (0.00s)
+    --- PASS: TestRulesSafeCode/HS-SWIFT-4 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-SWIFT-5 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-SWIFT-6 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-SWIFT-7 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-SWIFT-8 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-SWIFT-9 (0.00s)
+    --- PASS: TestRulesSafeCode/HS-SWIFT-10 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-SWIFT-11 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-SWIFT-12 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-SWIFT-13 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-SWIFT-14 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-SWIFT-15 (0.00s)
+    --- PASS: TestRulesSafeCode/HS-SWIFT-16 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-SWIFT-17 (0.00s)
+    --- PASS: TestRulesSafeCode/HS-SWIFT-18 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-SWIFT-19 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-SWIFT-20 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-SWIFT-21 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-SWIFT-22 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-SWIFT-23 (0.01s)
+    --- PASS: TestRulesSafeCode/HS-SWIFT-24 (0.02s)
+    --- PASS: TestRulesSafeCode/HS-SWIFT-24#01 (0.03s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/services/engines/swift	0.695s
+=== RUN   TestParseFindingsToVulnerabilities
+--- PASS: TestParseFindingsToVulnerabilities (0.00s)
+=== RUN   TestSetAnalysisError
+--- PASS: TestSetAnalysisError (0.00s)
+=== RUN   TestMock_AddWorkDirInCmd
+=== RUN   TestMock_AddWorkDirInCmd/Should_mock_with_success
+--- PASS: TestMock_AddWorkDirInCmd (0.00s)
+    --- PASS: TestMock_AddWorkDirInCmd/Should_mock_with_success (0.00s)
+=== RUN   TestExecuteContainer
+=== RUN   TestExecuteContainer/should_return_no_error_when_execute_container
+=== RUN   TestExecuteContainer/should_return_error_when_execute_container_if_CreateLanguageAnalysisContainer_return_error
+--- PASS: TestExecuteContainer (0.00s)
+    --- PASS: TestExecuteContainer/should_return_no_error_when_execute_container (0.00s)
+    --- PASS: TestExecuteContainer/should_return_error_when_execute_container_if_CreateLanguageAnalysisContainer_return_error (0.00s)
+=== RUN   TestGetAnalysisIDErrorMessage
+=== RUN   TestGetAnalysisIDErrorMessage/should_success_get_error_message_with_replaces
+--- PASS: TestGetAnalysisIDErrorMessage (0.00s)
+    --- PASS: TestGetAnalysisIDErrorMessage/should_success_get_error_message_with_replaces (0.00s)
+=== RUN   TestGetConfigProjectPath
+=== RUN   TestGetConfigProjectPath/should_success_get_project_path
+--- PASS: TestGetConfigProjectPath (0.00s)
+    --- PASS: TestGetConfigProjectPath/should_success_get_project_path (0.00s)
+=== RUN   TestAddWorkDirInCmd
+=== RUN   TestAddWorkDirInCmd/should_success_add_workdir_with_no_errors
+=== RUN   TestAddWorkDirInCmd/should_return_cmd_with_no_workdir
+--- PASS: TestAddWorkDirInCmd (0.00s)
+    --- PASS: TestAddWorkDirInCmd/should_success_add_workdir_with_no_errors (0.00s)
+    --- PASS: TestAddWorkDirInCmd/should_return_cmd_with_no_workdir (0.00s)
+=== RUN   TestLogDebugWithReplace
+=== RUN   TestLogDebugWithReplace/should_log_debug_and_not_panics
+--- PASS: TestLogDebugWithReplace (0.00s)
+    --- PASS: TestLogDebugWithReplace/should_log_debug_and_not_panics (0.00s)
+=== RUN   TestGetAnalysisID
+=== RUN   TestGetAnalysisID/should_success_get_analysis_id
+--- PASS: TestGetAnalysisID (0.00s)
+    --- PASS: TestGetAnalysisID/should_success_get_analysis_id (0.00s)
+=== RUN   TestLogAnalysisError
+=== RUN   TestLogAnalysisError/should_not_panic_when_logging_error
+=== RUN   TestLogAnalysisError/should_not_panic_when_logging_error_and_exists_projectSubPath
+--- PASS: TestLogAnalysisError (0.00s)
+    --- PASS: TestLogAnalysisError/should_not_panic_when_logging_error (0.00s)
+    --- PASS: TestLogAnalysisError/should_not_panic_when_logging_error_and_exists_projectSubPath (0.00s)
+=== RUN   TestToolIsToIgnore
+=== RUN   TestToolIsToIgnore/should_return_true_when_language_is_match
+=== RUN   TestToolIsToIgnore/should_return_true_when_language_is_match_uppercase
+=== RUN   TestToolIsToIgnore/should_return_true_when_language_is_match_lowercase_and_multi_tools
+=== RUN   TestToolIsToIgnore/should_return_false_when_language_is_not_match
+=== RUN   TestToolIsToIgnore/should_return_false_when_language_not_exists
+--- PASS: TestToolIsToIgnore (0.00s)
+    --- PASS: TestToolIsToIgnore/should_return_true_when_language_is_match (0.00s)
+    --- PASS: TestToolIsToIgnore/should_return_true_when_language_is_match_uppercase (0.00s)
+    --- PASS: TestToolIsToIgnore/should_return_true_when_language_is_match_lowercase_and_multi_tools (0.00s)
+    --- PASS: TestToolIsToIgnore/should_return_false_when_language_is_not_match (0.00s)
+    --- PASS: TestToolIsToIgnore/should_return_false_when_language_not_exists (0.00s)
+=== RUN   TestService_GetCodeWithMaxCharacters
+=== RUN   TestService_GetCodeWithMaxCharacters/should_return_default_code
+=== RUN   TestService_GetCodeWithMaxCharacters/should_return_default_code_if_column_is_negative
+=== RUN   TestService_GetCodeWithMaxCharacters/should_return_4:105_characters_when_text_is_so_bigger
+=== RUN   TestService_GetCodeWithMaxCharacters/should_return_first_100_characters_when_text_is_so_bigger
+=== RUN   TestService_GetCodeWithMaxCharacters/should_return_first_100_characters_when_text_contains_breaking_lines
+=== RUN   TestService_GetCodeWithMaxCharacters/should_return_first_100_characters_when_text_is_so_bigger#01
+=== RUN   TestService_GetCodeWithMaxCharacters/should_return_first_100_characters_when_text_is_so_bigger#02
+--- PASS: TestService_GetCodeWithMaxCharacters (0.00s)
+    --- PASS: TestService_GetCodeWithMaxCharacters/should_return_default_code (0.00s)
+    --- PASS: TestService_GetCodeWithMaxCharacters/should_return_default_code_if_column_is_negative (0.00s)
+    --- PASS: TestService_GetCodeWithMaxCharacters/should_return_4:105_characters_when_text_is_so_bigger (0.00s)
+    --- PASS: TestService_GetCodeWithMaxCharacters/should_return_first_100_characters_when_text_is_so_bigger (0.00s)
+    --- PASS: TestService_GetCodeWithMaxCharacters/should_return_first_100_characters_when_text_contains_breaking_lines (0.00s)
+    --- PASS: TestService_GetCodeWithMaxCharacters/should_return_first_100_characters_when_text_is_so_bigger#01 (0.00s)
+    --- PASS: TestService_GetCodeWithMaxCharacters/should_return_first_100_characters_when_text_is_so_bigger#02 (0.00s)
+=== RUN   TestRemoveSrcFolderFromPath
+=== RUN   TestRemoveSrcFolderFromPath/should_return_path_without_src_prefix
+=== RUN   TestRemoveSrcFolderFromPath/should_return_path_without_src_prefix#01
+=== RUN   TestRemoveSrcFolderFromPath/should_return_path_without_diff_when_src_is_after_4_index_position
+=== RUN   TestRemoveSrcFolderFromPath/should_return_path_without_diff_when_src_is_before_4_index_position
+--- PASS: TestRemoveSrcFolderFromPath (0.00s)
+    --- PASS: TestRemoveSrcFolderFromPath/should_return_path_without_src_prefix (0.00s)
+    --- PASS: TestRemoveSrcFolderFromPath/should_return_path_without_src_prefix#01 (0.00s)
+    --- PASS: TestRemoveSrcFolderFromPath/should_return_path_without_diff_when_src_is_after_4_index_position (0.00s)
+    --- PASS: TestRemoveSrcFolderFromPath/should_return_path_without_diff_when_src_is_before_4_index_position (0.00s)
+=== RUN   TestGetFilepathFromFilename
+=== RUN   TestGetFilepathFromFilename/should_successfully_return_path_from_filename
+=== RUN   TestGetFilepathFromFilename/should_return_empty_when_path_from_filename_is_not_found
+--- PASS: TestGetFilepathFromFilename (0.01s)
+    --- PASS: TestGetFilepathFromFilename/should_successfully_return_path_from_filename (0.01s)
+    --- PASS: TestGetFilepathFromFilename/should_return_empty_when_path_from_filename_is_not_found (0.00s)
+=== RUN   TestGetConfigCMDByFileExtension
+=== RUN   TestGetConfigCMDByFileExtension/should_return_path_when_valid_parameters
+=== RUN   TestGetConfigCMDByFileExtension/should_return_cmd_when_cmd_has_no_workdir
+=== RUN   TestGetConfigCMDByFileExtension/should_return_cmd_with_altered_workdir_when_cmd_has_workdir
+--- PASS: TestGetConfigCMDByFileExtension (0.04s)
+    --- PASS: TestGetConfigCMDByFileExtension/should_return_path_when_valid_parameters (0.04s)
+    --- PASS: TestGetConfigCMDByFileExtension/should_return_cmd_when_cmd_has_no_workdir (0.00s)
+    --- PASS: TestGetConfigCMDByFileExtension/should_return_cmd_with_altered_workdir_when_cmd_has_workdir (0.00s)
+=== RUN   TestStartAnalysis
+=== RUN   TestStartAnalysis/Csharp
+=== RUN   TestStartAnalysis/Csharp/should_success_execute_analysis_without_errors
+=== RUN   TestStartAnalysis/Csharp/should_return_error_when_getting_text_unit
+=== RUN   TestStartAnalysis/Csharp/should_ignore_this_tool
+=== RUN   TestStartAnalysis/Dart
+=== RUN   TestStartAnalysis/Dart/should_success_execute_analysis_without_errors
+=== RUN   TestStartAnalysis/Dart/should_return_error_when_getting_text_unit
+=== RUN   TestStartAnalysis/Dart/should_ignore_this_tool
+=== RUN   TestStartAnalysis/Java
+=== RUN   TestStartAnalysis/Java/should_success_execute_analysis_without_errors
+=== RUN   TestStartAnalysis/Java/should_return_error_when_getting_text_unit
+=== RUN   TestStartAnalysis/Java/should_ignore_this_tool
+=== RUN   TestStartAnalysis/Javascript
+=== RUN   TestStartAnalysis/Javascript/should_success_execute_analysis_without_errors
+=== RUN   TestStartAnalysis/Javascript/should_return_error_when_getting_text_unit
+=== RUN   TestStartAnalysis/Javascript/should_ignore_this_tool
+=== RUN   TestStartAnalysis/Kotlin
+=== RUN   TestStartAnalysis/Kotlin/should_success_execute_analysis_without_errors
+=== RUN   TestStartAnalysis/Kotlin/should_return_error_when_getting_text_unit
+=== RUN   TestStartAnalysis/Kotlin/should_ignore_this_tool
+=== RUN   TestStartAnalysis/Leaks
+=== RUN   TestStartAnalysis/Leaks/should_success_execute_analysis_without_errors
+=== RUN   TestStartAnalysis/Leaks/should_return_error_when_getting_text_unit
+=== RUN   TestStartAnalysis/Leaks/should_ignore_this_tool
+=== RUN   TestStartAnalysis/Nginx
+=== RUN   TestStartAnalysis/Nginx/should_success_execute_analysis_without_errors
+=== RUN   TestStartAnalysis/Nginx/should_return_error_when_getting_text_unit
+=== RUN   TestStartAnalysis/Nginx/should_ignore_this_tool
+=== RUN   TestStartAnalysis/Kubernetes
+=== RUN   TestStartAnalysis/Kubernetes/should_success_execute_analysis_without_errors
+=== RUN   TestStartAnalysis/Kubernetes/should_return_error_when_getting_text_unit
+=== RUN   TestStartAnalysis/Kubernetes/should_ignore_this_tool
+=== RUN   TestStartAnalysis/Swift
+=== RUN   TestStartAnalysis/Swift/should_success_execute_analysis_without_errors
+=== RUN   TestStartAnalysis/Swift/should_return_error_when_getting_text_unit
+=== RUN   TestStartAnalysis/Swift/should_ignore_this_tool
+--- PASS: TestStartAnalysis (57.53s)
+    --- PASS: TestStartAnalysis/Csharp (0.25s)
+        --- PASS: TestStartAnalysis/Csharp/should_success_execute_analysis_without_errors (0.18s)
+        --- PASS: TestStartAnalysis/Csharp/should_return_error_when_getting_text_unit (0.05s)
+        --- PASS: TestStartAnalysis/Csharp/should_ignore_this_tool (0.03s)
+    --- PASS: TestStartAnalysis/Dart (0.03s)
+        --- PASS: TestStartAnalysis/Dart/should_success_execute_analysis_without_errors (0.01s)
+        --- PASS: TestStartAnalysis/Dart/should_return_error_when_getting_text_unit (0.01s)
+        --- PASS: TestStartAnalysis/Dart/should_ignore_this_tool (0.00s)
+    --- PASS: TestStartAnalysis/Java (0.39s)
+        --- PASS: TestStartAnalysis/Java/should_success_execute_analysis_without_errors (0.09s)
+        --- PASS: TestStartAnalysis/Java/should_return_error_when_getting_text_unit (0.21s)
+        --- PASS: TestStartAnalysis/Java/should_ignore_this_tool (0.09s)
+    --- PASS: TestStartAnalysis/Javascript (0.05s)
+        --- PASS: TestStartAnalysis/Javascript/should_success_execute_analysis_without_errors (0.02s)
+        --- PASS: TestStartAnalysis/Javascript/should_return_error_when_getting_text_unit (0.01s)
+        --- PASS: TestStartAnalysis/Javascript/should_ignore_this_tool (0.02s)
+    --- PASS: TestStartAnalysis/Kotlin (0.04s)
+        --- PASS: TestStartAnalysis/Kotlin/should_success_execute_analysis_without_errors (0.01s)
+        --- PASS: TestStartAnalysis/Kotlin/should_return_error_when_getting_text_unit (0.01s)
+        --- PASS: TestStartAnalysis/Kotlin/should_ignore_this_tool (0.01s)
+    --- PASS: TestStartAnalysis/Leaks (56.75s)
+        --- PASS: TestStartAnalysis/Leaks/should_success_execute_analysis_without_errors (30.86s)
+        --- PASS: TestStartAnalysis/Leaks/should_return_error_when_getting_text_unit (25.89s)
+        --- PASS: TestStartAnalysis/Leaks/should_ignore_this_tool (0.00s)
+    --- PASS: TestStartAnalysis/Nginx (0.01s)
+        --- PASS: TestStartAnalysis/Nginx/should_success_execute_analysis_without_errors (0.00s)
+        --- PASS: TestStartAnalysis/Nginx/should_return_error_when_getting_text_unit (0.00s)
+        --- PASS: TestStartAnalysis/Nginx/should_ignore_this_tool (0.00s)
+    --- PASS: TestStartAnalysis/Kubernetes (0.01s)
+        --- PASS: TestStartAnalysis/Kubernetes/should_success_execute_analysis_without_errors (0.00s)
+        --- PASS: TestStartAnalysis/Kubernetes/should_return_error_when_getting_text_unit (0.00s)
+        --- PASS: TestStartAnalysis/Kubernetes/should_ignore_this_tool (0.00s)
+    --- PASS: TestStartAnalysis/Swift (0.01s)
+        --- PASS: TestStartAnalysis/Swift/should_success_execute_analysis_without_errors (0.00s)
+        --- PASS: TestStartAnalysis/Swift/should_return_error_when_getting_text_unit (0.01s)
+        --- PASS: TestStartAnalysis/Swift/should_ignore_this_tool (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/services/formatters	57.697s
+=== RUN   TestStartCFlawfinder
+=== RUN   TestStartCFlawfinder/should_run_analysis_successfully_when_output_is_empty
+=== RUN   TestStartCFlawfinder/should_add_error_on_analysis_when_invalid_output
+=== RUN   TestStartCFlawfinder/should_run_analysis_and_add_error_from_Docker_on_Analysis
+=== RUN   TestStartCFlawfinder/Should_not_execute_tool_because_it's_ignored
+--- PASS: TestStartCFlawfinder (0.03s)
+    --- PASS: TestStartCFlawfinder/should_run_analysis_successfully_when_output_is_empty (0.01s)
+    --- PASS: TestStartCFlawfinder/should_add_error_on_analysis_when_invalid_output (0.00s)
+    --- PASS: TestStartCFlawfinder/should_run_analysis_and_add_error_from_Docker_on_Analysis (0.00s)
+    --- PASS: TestStartCFlawfinder/Should_not_execute_tool_because_it's_ignored (0.00s)
+=== RUN   TestGetDetails
+=== RUN   TestGetDetails/should_success_get_details
+--- PASS: TestGetDetails (0.00s)
+    --- PASS: TestGetDetails/should_success_get_details (0.00s)
+=== RUN   TestGetSeverity
+=== RUN   TestGetSeverity/should_get_severities_low
+=== RUN   TestGetSeverity/should_get_severities_medium
+=== RUN   TestGetSeverity/should_get_severities_high
+=== RUN   TestGetSeverity/should_get_severities_critical
+--- PASS: TestGetSeverity (0.01s)
+    --- PASS: TestGetSeverity/should_get_severities_low (0.00s)
+    --- PASS: TestGetSeverity/should_get_severities_medium (0.00s)
+    --- PASS: TestGetSeverity/should_get_severities_high (0.00s)
+    --- PASS: TestGetSeverity/should_get_severities_critical (0.00s)
+=== RUN   TestGetFilename
+=== RUN   TestGetFilename/should_success_get_filename
+--- PASS: TestGetFilename (0.00s)
+    --- PASS: TestGetFilename/should_success_get_filename (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/services/formatters/c/flawfinder	0.112s
+=== RUN   TestSetName
+=== RUN   TestSetName/should_success_set_name
+--- PASS: TestSetName (0.00s)
+    --- PASS: TestSetName/should_success_set_name (0.00s)
+=== RUN   TestSetVersion
+=== RUN   TestSetVersion/should_success_set_version
+--- PASS: TestSetVersion (0.00s)
+    --- PASS: TestSetVersion/should_success_set_version (0.00s)
+=== RUN   TestSetDescription
+=== RUN   TestSetDescription/should_success_set_description
+--- PASS: TestSetDescription (0.00s)
+    --- PASS: TestSetDescription/should_success_set_description (0.00s)
+=== RUN   TestSetSeverity
+=== RUN   TestSetSeverity/should_success_set_severity
+--- PASS: TestSetSeverity (0.00s)
+    --- PASS: TestSetSeverity/should_success_set_severity (0.00s)
+=== RUN   TestGetSeverity
+=== RUN   TestGetSeverity/should_success_get_severity
+--- PASS: TestGetSeverity (0.00s)
+    --- PASS: TestGetSeverity/should_success_get_severity (0.00s)
+=== RUN   TestParseOutput
+=== RUN   TestParseOutput/should_add_3_vulnerability_on_analysis_with_no_errors
+    formatter_test.go:59: 
+        	Error Trace:	formatter_test.go:59
+        	Error:      	Not equal: 
+        	            	expected: "NetCoreVulnerabilities/NetCoreVulnerabilities.csproj"
+        	            	actual  : ".horusec/2af22671-d152-4c91-9fd5-52583e50d36e/NetCoreVulnerabilities/NetCoreVulnerabilities.csproj"
+        	            	
+        	            	Diff:
+        	            	--- Expected
+        	            	+++ Actual
+        	            	@@ -1 +1 @@
+        	            	-NetCoreVulnerabilities/NetCoreVulnerabilities.csproj
+        	            	+.horusec/2af22671-d152-4c91-9fd5-52583e50d36e/NetCoreVulnerabilities/NetCoreVulnerabilities.csproj
+        	Test:       	TestParseOutput/should_add_3_vulnerability_on_analysis_with_no_errors
+        	Messages:   	Expected equals file name
+    formatter_test.go:59: 
+        	Error Trace:	formatter_test.go:59
+        	Error:      	Not equal: 
+        	            	expected: "NetCoreVulnerabilities/NetCoreVulnerabilities.csproj"
+        	            	actual  : ".horusec/2af22671-d152-4c91-9fd5-52583e50d36e/NetCoreVulnerabilities/NetCoreVulnerabilities.csproj"
+        	            	
+        	            	Diff:
+        	            	--- Expected
+        	            	+++ Actual
+        	            	@@ -1 +1 @@
+        	            	-NetCoreVulnerabilities/NetCoreVulnerabilities.csproj
+        	            	+.horusec/2af22671-d152-4c91-9fd5-52583e50d36e/NetCoreVulnerabilities/NetCoreVulnerabilities.csproj
+        	Test:       	TestParseOutput/should_add_3_vulnerability_on_analysis_with_no_errors
+        	Messages:   	Expected equals file name
+    formatter_test.go:59: 
+        	Error Trace:	formatter_test.go:59
+        	Error:      	Not equal: 
+        	            	expected: "NetCoreVulnerabilities/NetCoreVulnerabilities.csproj"
+        	            	actual  : ".horusec/2af22671-d152-4c91-9fd5-52583e50d36e/NetCoreVulnerabilities/NetCoreVulnerabilities.csproj"
+        	            	
+        	            	Diff:
+        	            	--- Expected
+        	            	+++ Actual
+        	            	@@ -1 +1 @@
+        	            	-NetCoreVulnerabilities/NetCoreVulnerabilities.csproj
+        	            	+.horusec/2af22671-d152-4c91-9fd5-52583e50d36e/NetCoreVulnerabilities/NetCoreVulnerabilities.csproj
+        	Test:       	TestParseOutput/should_add_3_vulnerability_on_analysis_with_no_errors
+        	Messages:   	Expected equals file name
+--- FAIL: TestParseOutput (0.06s)
+    --- FAIL: TestParseOutput/should_add_3_vulnerability_on_analysis_with_no_errors (0.06s)
+FAIL
+FAIL	github.com/ZupIT/horusec/internal/services/formatters/csharp/dotnet_cli	0.117s
+?   	github.com/ZupIT/horusec/internal/services/formatters/csharp/horuseccsharp	[no test files]
+=== RUN   TestParseOutput
+=== RUN   TestParseOutput/should_success_get_first_run_of_the_array
+=== RUN   TestParseOutput/should_return_nil_when_empty_slice
+--- PASS: TestParseOutput (0.00s)
+    --- PASS: TestParseOutput/should_success_get_first_run_of_the_array (0.00s)
+    --- PASS: TestParseOutput/should_return_nil_when_empty_slice (0.00s)
+=== RUN   TestMapVulnerabilitiesByID
+=== RUN   TestMapVulnerabilitiesByID/should_success_map_vulnerabilities_by_id
+--- PASS: TestMapVulnerabilitiesByID (0.00s)
+    --- PASS: TestMapVulnerabilitiesByID/should_success_map_vulnerabilities_by_id (0.00s)
+=== RUN   TestGetLine
+=== RUN   TestGetLine/should_success_get_line
+=== RUN   TestGetLine/should_return_empty_string
+--- PASS: TestGetLine (0.00s)
+    --- PASS: TestGetLine/should_success_get_line (0.00s)
+    --- PASS: TestGetLine/should_return_empty_string (0.00s)
+=== RUN   TestGetColumn
+=== RUN   TestGetColumn/should_success_get_column
+=== RUN   TestGetColumn/should_return_empty_string
+--- PASS: TestGetColumn (0.00s)
+    --- PASS: TestGetColumn/should_success_get_column (0.00s)
+    --- PASS: TestGetColumn/should_return_empty_string (0.00s)
+=== RUN   TestGetVulnName
+=== RUN   TestGetVulnName/should_success_get_vulnerability_name
+--- PASS: TestGetVulnName (0.00s)
+    --- PASS: TestGetVulnName/should_success_get_vulnerability_name (0.00s)
+=== RUN   TestGetFile
+=== RUN   TestGetFile/should_success_get_file
+=== RUN   TestGetFile/should_return_empty_string
+--- PASS: TestGetFile (0.00s)
+    --- PASS: TestGetFile/should_success_get_file (0.00s)
+    --- PASS: TestGetFile/should_return_empty_string (0.00s)
+=== RUN   TestGetDescription
+=== RUN   TestGetDescription/should_return_empty_string
+--- PASS: TestGetDescription (0.00s)
+    --- PASS: TestGetDescription/should_return_empty_string (0.00s)
+=== RUN   TestMapCriticalValues
+=== RUN   TestMapCriticalValues/should_success_return_a_critical_severity_map
+--- PASS: TestMapCriticalValues (0.00s)
+    --- PASS: TestMapCriticalValues/should_success_return_a_critical_severity_map (0.00s)
+=== RUN   TestMapHighValues
+=== RUN   TestMapHighValues/should_success_return_a_high_severity_map
+--- PASS: TestMapHighValues (0.00s)
+    --- PASS: TestMapHighValues/should_success_return_a_high_severity_map (0.00s)
+=== RUN   TestMapLowValues
+=== RUN   TestMapLowValues/should_success_return_a_low_severity_map
+--- PASS: TestMapLowValues (0.00s)
+    --- PASS: TestMapLowValues/should_success_return_a_low_severity_map (0.00s)
+=== RUN   TestMapMediumValues
+=== RUN   TestMapMediumValues/should_success_return_a_medium_severity_map
+--- PASS: TestMapMediumValues (0.00s)
+    --- PASS: TestMapMediumValues/should_success_return_a_medium_severity_map (0.00s)
+=== RUN   TestParseOutput
+=== RUN   TestParseOutput/should_add_4_vulnerabilities_on_analysis_with_no_errors
+=== RUN   TestParseOutput/should_add_error_on_analysis_when_parse_invalid_output
+=== RUN   TestParseOutput/should_add_build_error_on_analysis
+=== RUN   TestParseOutput/should_add_error_of_not_found_solution_file_on_analysis
+=== RUN   TestParseOutput/should_add_error_of_executing_container_on_analysis
+=== RUN   TestParseOutput/should_not_execute_tool_because_it's_ignored
+--- PASS: TestParseOutput (0.76s)
+    --- PASS: TestParseOutput/should_add_4_vulnerabilities_on_analysis_with_no_errors (0.05s)
+    --- PASS: TestParseOutput/should_add_error_on_analysis_when_parse_invalid_output (0.30s)
+    --- PASS: TestParseOutput/should_add_build_error_on_analysis (0.17s)
+    --- PASS: TestParseOutput/should_add_error_of_not_found_solution_file_on_analysis (0.13s)
+    --- PASS: TestParseOutput/should_add_error_of_executing_container_on_analysis (0.11s)
+    --- PASS: TestParseOutput/should_not_execute_tool_because_it's_ignored (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/services/formatters/csharp/scs	0.853s
+?   	github.com/ZupIT/horusec/internal/services/formatters/dart/horusecdart	[no test files]
+=== RUN   TestStartCFlawfinder
+=== RUN   TestStartCFlawfinder/should_add_1_vulnerability_on_analysis_with_no_errors
+=== RUN   TestStartCFlawfinder/should_not_add_error_on_analysis_when_parse_empty_output
+=== RUN   TestStartCFlawfinder/should_add_error_on_analysis_when_get_error_executing_container
+=== RUN   TestStartCFlawfinder/should_not_execute_tool_because_it's_ignored
+--- PASS: TestStartCFlawfinder (1.44s)
+    --- PASS: TestStartCFlawfinder/should_add_1_vulnerability_on_analysis_with_no_errors (0.86s)
+    --- PASS: TestStartCFlawfinder/should_not_add_error_on_analysis_when_parse_empty_output (0.28s)
+    --- PASS: TestStartCFlawfinder/should_add_error_on_analysis_when_get_error_executing_container (0.30s)
+    --- PASS: TestStartCFlawfinder/should_not_execute_tool_because_it's_ignored (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/services/formatters/elixir/mixaudit	1.488s
+=== RUN   TestSobelowStartAnalysis
+=== RUN   TestSobelowStartAnalysis/should_add_4_vulnerabilities_on_analysis_with_no_errors
+=== RUN   TestSobelowStartAnalysis/should_not_add_error_on_analysis_when_empty_output
+=== RUN   TestSobelowStartAnalysis/should_return_error_when_executing_container
+=== RUN   TestSobelowStartAnalysis/should_not_execute_tool_because_it's_ignored
+--- PASS: TestSobelowStartAnalysis (1.27s)
+    --- PASS: TestSobelowStartAnalysis/should_add_4_vulnerabilities_on_analysis_with_no_errors (0.61s)
+    --- PASS: TestSobelowStartAnalysis/should_not_add_error_on_analysis_when_empty_output (0.30s)
+    --- PASS: TestSobelowStartAnalysis/should_return_error_when_executing_container (0.36s)
+    --- PASS: TestSobelowStartAnalysis/should_not_execute_tool_because_it's_ignored (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/services/formatters/elixir/sobelow	1.366s
+=== RUN   TestGetVulnerability
+=== RUN   TestGetVulnerability/should_success_get_vulnerability_without_cwe
+=== RUN   TestGetVulnerability/should_success_get_vulnerability_with_cwe
+=== RUN   TestGetVulnerability/should_return_nil_when_do_not_contains_vulnerability
+--- PASS: TestGetVulnerability (0.00s)
+    --- PASS: TestGetVulnerability/should_success_get_vulnerability_without_cwe (0.00s)
+    --- PASS: TestGetVulnerability/should_success_get_vulnerability_with_cwe (0.00s)
+    --- PASS: TestGetVulnerability/should_return_nil_when_do_not_contains_vulnerability (0.00s)
+=== RUN   TestGetFile
+=== RUN   TestGetFile/should_success_get_file
+=== RUN   TestGetFile/should_success_get_file#01
+--- PASS: TestGetFile (0.00s)
+    --- PASS: TestGetFile/should_success_get_file (0.00s)
+    --- PASS: TestGetFile/should_success_get_file#01 (0.00s)
+=== RUN   TestStartGenericOwaspDependencyCheck
+=== RUN   TestStartGenericOwaspDependencyCheck/Should_success_parse_output_to_analysis
+=== RUN   TestStartGenericOwaspDependencyCheck/should_add_error_on_analysis_when_parse_invalid_output
+=== RUN   TestStartGenericOwaspDependencyCheck/should_add_error_from_docker_on_analysis
+=== RUN   TestStartGenericOwaspDependencyCheck/should_parse_empty_output_without_errors
+=== RUN   TestStartGenericOwaspDependencyCheck/should_not_execute_tool_because_it's_ignored
+--- PASS: TestStartGenericOwaspDependencyCheck (0.01s)
+    --- PASS: TestStartGenericOwaspDependencyCheck/Should_success_parse_output_to_analysis (0.01s)
+    --- PASS: TestStartGenericOwaspDependencyCheck/should_add_error_on_analysis_when_parse_invalid_output (0.00s)
+    --- PASS: TestStartGenericOwaspDependencyCheck/should_add_error_from_docker_on_analysis (0.00s)
+    --- PASS: TestStartGenericOwaspDependencyCheck/should_parse_empty_output_without_errors (0.00s)
+    --- PASS: TestStartGenericOwaspDependencyCheck/should_not_execute_tool_because_it's_ignored (0.00s)
+=== RUN   TestGetSeverity
+=== RUN   TestGetSeverity/should_success_severity
+--- PASS: TestGetSeverity (0.00s)
+    --- PASS: TestGetSeverity/should_success_severity (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/services/formatters/generic/dependency_check	0.048s
+=== RUN   TestParseOutput
+=== RUN   TestParseOutput/Should_return_1_vulnerabilities_with_no_errors
+=== RUN   TestParseOutput/Should_return_1_vulnerabilities_with_no_errors#01
+=== RUN   TestParseOutput/Should_return_1_vulnerabilities_with_no_errors#02
+=== RUN   TestParseOutput/Should_return_error_when_invalid_output
+=== RUN   TestParseOutput/Should_return_error_when_executing_container
+=== RUN   TestParseOutput/Should_not_execute_tool_because_it's_ignored
+--- PASS: TestParseOutput (0.01s)
+    --- PASS: TestParseOutput/Should_return_1_vulnerabilities_with_no_errors (0.00s)
+    --- PASS: TestParseOutput/Should_return_1_vulnerabilities_with_no_errors#01 (0.00s)
+    --- PASS: TestParseOutput/Should_return_1_vulnerabilities_with_no_errors#02 (0.00s)
+    --- PASS: TestParseOutput/Should_return_error_when_invalid_output (0.00s)
+    --- PASS: TestParseOutput/Should_return_error_when_executing_container (0.00s)
+    --- PASS: TestParseOutput/Should_not_execute_tool_because_it's_ignored (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/services/formatters/generic/semgrep	0.098s
+=== RUN   TestTrivyParseOutput
+=== RUN   TestTrivyParseOutput/Should_add_153_vulnerabilities_from_FileSystemOutput_and_ConfigOutput_on_analysis_without_errors
+=== RUN   TestTrivyParseOutput/Should_add_error_on_analysis_when_invalid_output
+=== RUN   TestTrivyParseOutput/Should_not_execute_tool_because_it's_ignored
+--- PASS: TestTrivyParseOutput (1.38s)
+    --- PASS: TestTrivyParseOutput/Should_add_153_vulnerabilities_from_FileSystemOutput_and_ConfigOutput_on_analysis_without_errors (1.38s)
+    --- PASS: TestTrivyParseOutput/Should_add_error_on_analysis_when_invalid_output (0.00s)
+    --- PASS: TestTrivyParseOutput/Should_not_execute_tool_because_it's_ignored (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/services/formatters/generic/trivy	1.488s
+=== RUN   TestGosecStartAnalysis
+=== RUN   TestGosecStartAnalysis/Should_run_analysis_successfully_when_output_is_empty
+=== RUN   TestGosecStartAnalysis/Should_run_analysis_successfully_and_add_vulnerability_on_Analysis
+=== RUN   TestGosecStartAnalysis/Should_run_analysis_and_add_error_from_Docker_on_Analysis
+=== RUN   TestGosecStartAnalysis/Should_run_analysis_and_return_error_for_an_invalid_output
+time="2022-07-26T18:08:49-03:00" level=error msg="{HORUSEC_CLI} Error to execute tool GoSec | analysisID -> 00000000-0000-0000-0000-000000000000 | output -> is some a text aleatory" error="invalid character 'i' looking for beginning of value"
+=== RUN   TestGosecStartAnalysis/Should_not_execute_gosec_because_it's_ignored
+--- PASS: TestGosecStartAnalysis (0.01s)
+    --- PASS: TestGosecStartAnalysis/Should_run_analysis_successfully_when_output_is_empty (0.00s)
+    --- PASS: TestGosecStartAnalysis/Should_run_analysis_successfully_and_add_vulnerability_on_Analysis (0.00s)
+    --- PASS: TestGosecStartAnalysis/Should_run_analysis_and_add_error_from_Docker_on_Analysis (0.00s)
+    --- PASS: TestGosecStartAnalysis/Should_run_analysis_and_return_error_for_an_invalid_output (0.00s)
+    --- PASS: TestGosecStartAnalysis/Should_not_execute_gosec_because_it's_ignored (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/services/formatters/go/gosec	0.074s
+=== RUN   TestParseOutput
+=== RUN   TestParseOutput/should_success_parse_output_to_analysis
+    formatter_test.go:70: 
+        	Error Trace:	formatter_test.go:70
+        	Error:      	Condition failed!
+        	Test:       	TestParseOutput/should_success_parse_output_to_analysis
+        	Messages:   	Expected vulnerability file "/tmp/TestParseOutputshould_success_parse_output_to_analysis4184367307/001/.horusec/09f92fb5-8507-43d0-85f8-a16f3f5e9a0c/go.sum" to be "/tmp/TestParseOutputshould_success_parse_output_to_analysis4184367307/001/go.mod" or "/tmp/TestParseOutputshould_success_parse_output_to_analysis4184367307/001/go.sum"
+    formatter_test.go:70: 
+        	Error Trace:	formatter_test.go:70
+        	Error:      	Condition failed!
+        	Test:       	TestParseOutput/should_success_parse_output_to_analysis
+        	Messages:   	Expected vulnerability file "/tmp/TestParseOutputshould_success_parse_output_to_analysis4184367307/001/.horusec/09f92fb5-8507-43d0-85f8-a16f3f5e9a0c/go.sum" to be "/tmp/TestParseOutputshould_success_parse_output_to_analysis4184367307/001/go.mod" or "/tmp/TestParseOutputshould_success_parse_output_to_analysis4184367307/001/go.sum"
+    formatter_test.go:70: 
+        	Error Trace:	formatter_test.go:70
+        	Error:      	Condition failed!
+        	Test:       	TestParseOutput/should_success_parse_output_to_analysis
+        	Messages:   	Expected vulnerability file "/tmp/TestParseOutputshould_success_parse_output_to_analysis4184367307/001/.horusec/09f92fb5-8507-43d0-85f8-a16f3f5e9a0c/go.mod" to be "/tmp/TestParseOutputshould_success_parse_output_to_analysis4184367307/001/go.mod" or "/tmp/TestParseOutputshould_success_parse_output_to_analysis4184367307/001/go.sum"
+    formatter_test.go:70: 
+        	Error Trace:	formatter_test.go:70
+        	Error:      	Condition failed!
+        	Test:       	TestParseOutput/should_success_parse_output_to_analysis
+        	Messages:   	Expected vulnerability file "/tmp/TestParseOutputshould_success_parse_output_to_analysis4184367307/001/.horusec/09f92fb5-8507-43d0-85f8-a16f3f5e9a0c/go.mod" to be "/tmp/TestParseOutputshould_success_parse_output_to_analysis4184367307/001/go.mod" or "/tmp/TestParseOutputshould_success_parse_output_to_analysis4184367307/001/go.sum"
+--- FAIL: TestParseOutput (0.23s)
+    --- FAIL: TestParseOutput/should_success_parse_output_to_analysis (0.23s)
+FAIL
+FAIL	github.com/ZupIT/horusec/internal/services/formatters/go/nancy	0.358s
+=== RUN   TestGetDetails
+=== RUN   TestGetDetails/should_success_get_result_details
+--- PASS: TestGetDetails (0.00s)
+    --- PASS: TestGetDetails/should_success_get_result_details (0.00s)
+=== RUN   TestGetStartLine
+=== RUN   TestGetStartLine/should_success_get_start_line
+--- PASS: TestGetStartLine (0.00s)
+    --- PASS: TestGetStartLine/should_success_get_start_line (0.00s)
+=== RUN   TestGetCode
+=== RUN   TestGetCode/should_success_get_code
+--- PASS: TestGetCode (0.00s)
+    --- PASS: TestGetCode/should_success_get_code (0.00s)
+=== RUN   TestCheckovParseOutput
+=== RUN   TestCheckovParseOutput/should_add_1_vulnerability_on_analysis_with_no_errors
+=== RUN   TestCheckovParseOutput/should_add_error_on_analysis_when_invalid_output
+=== RUN   TestCheckovParseOutput/should_add_error_from_executing_container_on_analysis
+=== RUN   TestCheckovParseOutput/Should_not_execute_tool_because_it's_ignored
+--- PASS: TestCheckovParseOutput (0.01s)
+    --- PASS: TestCheckovParseOutput/should_add_1_vulnerability_on_analysis_with_no_errors (0.01s)
+    --- PASS: TestCheckovParseOutput/should_add_error_on_analysis_when_invalid_output (0.00s)
+    --- PASS: TestCheckovParseOutput/should_add_error_from_executing_container_on_analysis (0.00s)
+    --- PASS: TestCheckovParseOutput/Should_not_execute_tool_because_it's_ignored (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/services/formatters/hcl/checkov	0.123s
+=== RUN   TestTFSecParseOutput
+=== RUN   TestTFSecParseOutput/should_add_5_vulnerabilities_on_analysis_with_no_errors
+=== RUN   TestTFSecParseOutput/should_add_error_on_analysis_when_invalid_output
+=== RUN   TestTFSecParseOutput/should_add_error_of_executing_container_on_analysis
+=== RUN   TestTFSecParseOutput/Should_not_execute_tool_because_it's_ignored
+--- PASS: TestTFSecParseOutput (0.04s)
+    --- PASS: TestTFSecParseOutput/should_add_5_vulnerabilities_on_analysis_with_no_errors (0.02s)
+    --- PASS: TestTFSecParseOutput/should_add_error_on_analysis_when_invalid_output (0.00s)
+    --- PASS: TestTFSecParseOutput/should_add_error_of_executing_container_on_analysis (0.00s)
+    --- PASS: TestTFSecParseOutput/Should_not_execute_tool_because_it's_ignored (0.00s)
+=== RUN   TestGetDetails
+=== RUN   TestGetDetails/should_success_get_result_details
+--- PASS: TestGetDetails (0.00s)
+    --- PASS: TestGetDetails/should_success_get_result_details (0.00s)
+=== RUN   TestGetStartLine
+=== RUN   TestGetStartLine/should_success_get_start_line
+--- PASS: TestGetStartLine (0.00s)
+    --- PASS: TestGetStartLine/should_success_get_start_line (0.00s)
+=== RUN   TestGetCode
+=== RUN   TestGetCode/should_success_get_code
+--- PASS: TestGetCode (0.00s)
+    --- PASS: TestGetCode/should_success_get_code (0.00s)
+=== RUN   TestGetFilename
+=== RUN   TestGetFilename/should_success_get_filename
+--- PASS: TestGetFilename (0.00s)
+    --- PASS: TestGetFilename/should_success_get_filename (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/services/formatters/hcl/tfsec	0.120s
+?   	github.com/ZupIT/horusec/internal/services/formatters/java/horusecjava	[no test files]
+?   	github.com/ZupIT/horusec/internal/services/formatters/javascript/horusecjavascript	[no test files]
+=== RUN   TestNpmAuditParseOutput
+=== RUN   TestNpmAuditParseOutput/should_add_1_vulnerabilities_on_analysis_with_no_errors
+=== RUN   TestNpmAuditParseOutput/Should_parse_output_empty_with_no_errors
+=== RUN   TestNpmAuditParseOutput/Should_add_error_on_analysis_when_parse_output_with_not_found_error
+=== RUN   TestNpmAuditParseOutput/Should_add_error_on_analysis_when_parse_invalid_output
+=== RUN   TestNpmAuditParseOutput/should_add_error_of_executing_container_on_analysis
+=== RUN   TestNpmAuditParseOutput/Should_not_execute_tool_because_it's_ignored
+--- PASS: TestNpmAuditParseOutput (0.06s)
+    --- PASS: TestNpmAuditParseOutput/should_add_1_vulnerabilities_on_analysis_with_no_errors (0.02s)
+    --- PASS: TestNpmAuditParseOutput/Should_parse_output_empty_with_no_errors (0.01s)
+    --- PASS: TestNpmAuditParseOutput/Should_add_error_on_analysis_when_parse_output_with_not_found_error (0.01s)
+    --- PASS: TestNpmAuditParseOutput/Should_add_error_on_analysis_when_parse_invalid_output (0.01s)
+    --- PASS: TestNpmAuditParseOutput/should_add_error_of_executing_container_on_analysis (0.01s)
+    --- PASS: TestNpmAuditParseOutput/Should_not_execute_tool_because_it's_ignored (0.00s)
+=== RUN   TestGetVersion
+=== RUN   TestGetVersion/should_return_finding_version
+=== RUN   TestGetVersion/should_return_no_version
+--- PASS: TestGetVersion (0.00s)
+    --- PASS: TestGetVersion/should_return_finding_version (0.00s)
+    --- PASS: TestGetVersion/should_return_no_version (0.00s)
+=== RUN   TestGetSeverity
+=== RUN   TestGetSeverity/should_return_a_low_severity
+=== RUN   TestGetSeverity/should_return_a_medium_severity
+=== RUN   TestGetSeverity/should_return_a_critical_severity
+=== RUN   TestGetSeverity/should_return_a_info_severity
+=== RUN   TestGetSeverity/should_return_a_unknown_severity
+--- PASS: TestGetSeverity (0.01s)
+    --- PASS: TestGetSeverity/should_return_a_low_severity (0.00s)
+    --- PASS: TestGetSeverity/should_return_a_medium_severity (0.00s)
+    --- PASS: TestGetSeverity/should_return_a_critical_severity (0.00s)
+    --- PASS: TestGetSeverity/should_return_a_info_severity (0.00s)
+    --- PASS: TestGetSeverity/should_return_a_unknown_severity (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/services/formatters/javascript/npmaudit	0.119s
+=== RUN   TestYarnAuditParseOutput
+=== RUN   TestYarnAuditParseOutput/should_add_1_vulnerabilities_on_analysis_with_no_errors
+=== RUN   TestYarnAuditParseOutput/Should_parse_output_empty_with_no_errors
+=== RUN   TestYarnAuditParseOutput/Should_add_error_on_analysis_with_not_found_error
+=== RUN   TestYarnAuditParseOutput/Should_add_error_on_analysis_with_audit_error
+=== RUN   TestYarnAuditParseOutput/Should_add_error_on_analysis_when_parse_invalid_output
+=== RUN   TestYarnAuditParseOutput/should_add_error_of_executing_container_on_analysis
+=== RUN   TestYarnAuditParseOutput/Should_not_execute_tool_because_it's_ignored
+--- PASS: TestYarnAuditParseOutput (1.67s)
+    --- PASS: TestYarnAuditParseOutput/should_add_1_vulnerabilities_on_analysis_with_no_errors (0.36s)
+    --- PASS: TestYarnAuditParseOutput/Should_parse_output_empty_with_no_errors (0.21s)
+    --- PASS: TestYarnAuditParseOutput/Should_add_error_on_analysis_with_not_found_error (0.19s)
+    --- PASS: TestYarnAuditParseOutput/Should_add_error_on_analysis_with_audit_error (0.23s)
+    --- PASS: TestYarnAuditParseOutput/Should_add_error_on_analysis_when_parse_invalid_output (0.31s)
+    --- PASS: TestYarnAuditParseOutput/should_add_error_of_executing_container_on_analysis (0.20s)
+    --- PASS: TestYarnAuditParseOutput/Should_not_execute_tool_because_it's_ignored (0.17s)
+=== RUN   TestGetVersion
+=== RUN   TestGetVersion/should_return_finding_version
+=== RUN   TestGetVersion/should_return_no_version
+--- PASS: TestGetVersion (0.00s)
+    --- PASS: TestGetVersion/should_return_finding_version (0.00s)
+    --- PASS: TestGetVersion/should_return_no_version (0.00s)
+=== RUN   TestGetSeverity
+=== RUN   TestGetSeverity/should_return_a_low_severity
+=== RUN   TestGetSeverity/should_return_a_medium_severity
+=== RUN   TestGetSeverity/should_return_a_critical_severity
+=== RUN   TestGetSeverity/should_return_a_info_severity
+=== RUN   TestGetSeverity/should_return_a_unknown_severity
+--- PASS: TestGetSeverity (0.00s)
+    --- PASS: TestGetSeverity/should_return_a_low_severity (0.00s)
+    --- PASS: TestGetSeverity/should_return_a_medium_severity (0.00s)
+    --- PASS: TestGetSeverity/should_return_a_critical_severity (0.00s)
+    --- PASS: TestGetSeverity/should_return_a_info_severity (0.00s)
+    --- PASS: TestGetSeverity/should_return_a_unknown_severity (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/services/formatters/javascript/yarnaudit	1.726s
+?   	github.com/ZupIT/horusec/internal/services/formatters/kotlin/horuseckotlin	[no test files]
+=== RUN   TestLeaks_StartAnalysis
+=== RUN   TestLeaks_StartAnalysis/Should_run_analysis_without_panics_and_save_on_cache_with_success
+=== RUN   TestLeaks_StartAnalysis/Should_run_no_error_when_empty_output
+=== RUN   TestLeaks_StartAnalysis/Should_run_analysis_and_return_error_and_up_docker_api_and_save_on_cache_with_error
+=== RUN   TestLeaks_StartAnalysis/Should_run_analysis_and_return_error_and_up_docker_api_and_save_on_cache_with_error#01
+=== RUN   TestLeaks_StartAnalysis/Should_not_execute_tool_because_it's_ignored
+--- PASS: TestLeaks_StartAnalysis (0.01s)
+    --- PASS: TestLeaks_StartAnalysis/Should_run_analysis_without_panics_and_save_on_cache_with_success (0.00s)
+    --- PASS: TestLeaks_StartAnalysis/Should_run_no_error_when_empty_output (0.00s)
+    --- PASS: TestLeaks_StartAnalysis/Should_run_analysis_and_return_error_and_up_docker_api_and_save_on_cache_with_error (0.00s)
+    --- PASS: TestLeaks_StartAnalysis/Should_run_analysis_and_return_error_and_up_docker_api_and_save_on_cache_with_error#01 (0.00s)
+    --- PASS: TestLeaks_StartAnalysis/Should_not_execute_tool_because_it's_ignored (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/services/formatters/leaks/gitleaks	0.106s
+?   	github.com/ZupIT/horusec/internal/services/formatters/leaks/horusecleaks	[no test files]
+?   	github.com/ZupIT/horusec/internal/services/formatters/nginx/horusecnginx	[no test files]
+=== RUN   TestStartPHPCodeSniffer
+=== RUN   TestStartPHPCodeSniffer/should_success_execute_container_and_process_output
+=== RUN   TestStartPHPCodeSniffer/should_ignore_the_problems_with_contains_fail_in_your_scan
+=== RUN   TestStartPHPCodeSniffer/should_return_error_when_invalid_output
+=== RUN   TestStartPHPCodeSniffer/should_return_error_when_executing_container
+=== RUN   TestStartPHPCodeSniffer/Should_not_execute_tool_because_it's_ignored
+--- PASS: TestStartPHPCodeSniffer (0.42s)
+    --- PASS: TestStartPHPCodeSniffer/should_success_execute_container_and_process_output (0.41s)
+    --- PASS: TestStartPHPCodeSniffer/should_ignore_the_problems_with_contains_fail_in_your_scan (0.00s)
+    --- PASS: TestStartPHPCodeSniffer/should_return_error_when_invalid_output (0.00s)
+    --- PASS: TestStartPHPCodeSniffer/should_return_error_when_executing_container (0.00s)
+    --- PASS: TestStartPHPCodeSniffer/Should_not_execute_tool_because_it's_ignored (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/services/formatters/php/phpcs	0.569s
+=== RUN   TestGetLine
+=== RUN   TestGetLine/should_success_get_line
+--- PASS: TestGetLine (0.00s)
+    --- PASS: TestGetLine/should_success_get_line (0.00s)
+=== RUN   TestGetColumn
+=== RUN   TestGetColumn/should_success_get_column
+--- PASS: TestGetColumn (0.00s)
+    --- PASS: TestGetColumn/should_success_get_column (0.00s)
+=== RUN   TestIsValidMessage
+=== RUN   TestIsValidMessage/should_return_true_if_valid_error_message
+=== RUN   TestIsValidMessage/should_return_true_if_valid_warning_message
+=== RUN   TestIsValidMessage/should_return_false_if_invalid_type_message
+--- PASS: TestIsValidMessage (0.00s)
+    --- PASS: TestIsValidMessage/should_return_true_if_valid_error_message (0.00s)
+    --- PASS: TestIsValidMessage/should_return_true_if_valid_warning_message (0.00s)
+    --- PASS: TestIsValidMessage/should_return_false_if_invalid_type_message (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/services/formatters/php/phpcs/entities	0.121s
+=== RUN   TestNewFormatter
+--- PASS: TestNewFormatter (0.00s)
+=== RUN   TestFormatter_StartSafety
+=== RUN   TestFormatter_StartSafety/Should_return_error_when_start_analysis
+=== RUN   TestFormatter_StartSafety/Should_return_analysis_bandit_without_error
+=== RUN   TestFormatter_StartSafety/Should_return_analysis_bandit_without_error#01
+=== RUN   TestFormatter_StartSafety/Should_return_analysis_bandit_without_error_with_issue_of_informative
+time="2022-07-26T18:08:52-03:00" level=warning msg="{HORUSEC_CLI} CAUTION! In your project was found 1 details of type informative"
+=== RUN   TestFormatter_StartSafety/Should_return_nil_when_output_is_wrong_format_analysis
+=== RUN   TestFormatter_StartSafety/Should_not_execute_tool_because_it's_ignored
+--- PASS: TestFormatter_StartSafety (0.01s)
+    --- PASS: TestFormatter_StartSafety/Should_return_error_when_start_analysis (0.00s)
+    --- PASS: TestFormatter_StartSafety/Should_return_analysis_bandit_without_error (0.00s)
+    --- PASS: TestFormatter_StartSafety/Should_return_analysis_bandit_without_error#01 (0.00s)
+    --- PASS: TestFormatter_StartSafety/Should_return_analysis_bandit_without_error_with_issue_of_informative (0.01s)
+    --- PASS: TestFormatter_StartSafety/Should_return_nil_when_output_is_wrong_format_analysis (0.00s)
+    --- PASS: TestFormatter_StartSafety/Should_not_execute_tool_because_it's_ignored (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/services/formatters/python/bandit	0.055s
+?   	github.com/ZupIT/horusec/internal/services/formatters/python/bandit/entities	[no test files]
+=== RUN   TestNewFormatter
+--- PASS: TestNewFormatter (0.00s)
+=== RUN   TestFormatter_StartSafety
+=== RUN   TestFormatter_StartSafety/Should_return_error_when_start_analysis
+time="2022-07-26T18:08:52-03:00" level=error msg="Error to walk on path" error="lstat .horusec/045be45d-7ded-4e54-a712-cf4b9cf66af6: no such file or directory" ext=requirements.txt path=.horusec/045be45d-7ded-4e54-a712-cf4b9cf66af6 projectPath=.horusec/045be45d-7ded-4e54-a712-cf4b9cf66af6 subPath=
+=== RUN   TestFormatter_StartSafety/Should_execute_analysis_without_error
+=== RUN   TestFormatter_StartSafety/Should_return_nil_when_output_is_empty_analysis
+time="2022-07-26T18:08:53-03:00" level=error msg="Error to walk on path" error="lstat .horusec/081c7623-be10-4135-8eb2-122a45efc105: no such file or directory" ext=requirements.txt path=.horusec/081c7623-be10-4135-8eb2-122a45efc105 projectPath=.horusec/081c7623-be10-4135-8eb2-122a45efc105 subPath=
+=== RUN   TestFormatter_StartSafety/Should_return_nil_when_output_is_wrong_format_analysis
+time="2022-07-26T18:08:53-03:00" level=error msg="Error to walk on path" error="lstat .horusec/bf6e4c72-b800-4439-b074-5a7b04c1903a: no such file or directory" ext=requirements.txt path=.horusec/bf6e4c72-b800-4439-b074-5a7b04c1903a projectPath=.horusec/bf6e4c72-b800-4439-b074-5a7b04c1903a subPath=
+=== RUN   TestFormatter_StartSafety/Should_not_execute_tool_because_it's_ignored
+--- PASS: TestFormatter_StartSafety (0.22s)
+    --- PASS: TestFormatter_StartSafety/Should_return_error_when_start_analysis (0.00s)
+    --- PASS: TestFormatter_StartSafety/Should_execute_analysis_without_error (0.22s)
+    --- PASS: TestFormatter_StartSafety/Should_return_nil_when_output_is_empty_analysis (0.00s)
+    --- PASS: TestFormatter_StartSafety/Should_return_nil_when_output_is_wrong_format_analysis (0.00s)
+    --- PASS: TestFormatter_StartSafety/Should_not_execute_tool_because_it's_ignored (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/services/formatters/python/safety	0.269s
+?   	github.com/ZupIT/horusec/internal/services/formatters/python/safety/entities	[no test files]
+=== RUN   TestParseBrakemanOutput
+=== RUN   TestParseBrakemanOutput/Should_success_parse_output_to_analysis
+=== RUN   TestParseBrakemanOutput/Should_success_parse_output_empty_to_analysis
+=== RUN   TestParseBrakemanOutput/Should_add_error_rails_not_found_on_analysis_when_parse_output_to_analysis
+=== RUN   TestParseBrakemanOutput/Should_add_error_on_analysis_when_parsing_invalid_output
+=== RUN   TestParseBrakemanOutput/Should_add_error_on_analysis_when_something_went_wrong_in_container
+=== RUN   TestParseBrakemanOutput/Should_not_execute_tool_because_it's_ignored
+--- PASS: TestParseBrakemanOutput (0.82s)
+    --- PASS: TestParseBrakemanOutput/Should_success_parse_output_to_analysis (0.17s)
+    --- PASS: TestParseBrakemanOutput/Should_success_parse_output_empty_to_analysis (0.17s)
+    --- PASS: TestParseBrakemanOutput/Should_add_error_rails_not_found_on_analysis_when_parse_output_to_analysis (0.14s)
+    --- PASS: TestParseBrakemanOutput/Should_add_error_on_analysis_when_parsing_invalid_output (0.18s)
+    --- PASS: TestParseBrakemanOutput/Should_add_error_on_analysis_when_something_went_wrong_in_container (0.16s)
+    --- PASS: TestParseBrakemanOutput/Should_not_execute_tool_because_it's_ignored (0.00s)
+=== RUN   TestGetDetails
+=== RUN   TestGetDetails/Should_return_output_details_and_message
+--- PASS: TestGetDetails (0.00s)
+    --- PASS: TestGetDetails/Should_return_output_details_and_message (0.00s)
+=== RUN   TestGetSeverity
+=== RUN   TestGetSeverity/Should_return_output_high_severity
+=== RUN   TestGetSeverity/Should_return_output_medium_severity
+=== RUN   TestGetSeverity/Should_return_output_low_severity
+--- PASS: TestGetSeverity (0.00s)
+    --- PASS: TestGetSeverity/Should_return_output_high_severity (0.00s)
+    --- PASS: TestGetSeverity/Should_return_output_medium_severity (0.00s)
+    --- PASS: TestGetSeverity/Should_return_output_low_severity (0.00s)
+=== RUN   TestGetLine
+=== RUN   TestGetLine/Should_parse_line_to_string_and_return
+--- PASS: TestGetLine (0.00s)
+    --- PASS: TestGetLine/Should_parse_line_to_string_and_return (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/services/formatters/ruby/brakeman	0.885s
+=== RUN   TestParseOutput
+=== RUN   TestParseOutput/should_add_39_vulnerabilities_on_analysis_with_no_errors
+=== RUN   TestParseOutput/should_add_error_and_no_vulnerabilities_on_analysis_when_parse_invalid_output
+=== RUN   TestParseOutput/should_add_error_of_the_cannot_connect_in_db
+=== RUN   TestParseOutput/should_not_return_any_vulnerability_if_output_is_empty
+=== RUN   TestParseOutput/Should_add_error_on_analysis_when_something_went_wrong_in_container
+=== RUN   TestParseOutput/Should_not_execute_tool_because_it's_ignored
+--- PASS: TestParseOutput (1.53s)
+    --- PASS: TestParseOutput/should_add_39_vulnerabilities_on_analysis_with_no_errors (0.42s)
+    --- PASS: TestParseOutput/should_add_error_and_no_vulnerabilities_on_analysis_when_parse_invalid_output (0.14s)
+    --- PASS: TestParseOutput/should_add_error_of_the_cannot_connect_in_db (0.43s)
+    --- PASS: TestParseOutput/should_not_return_any_vulnerability_if_output_is_empty (0.37s)
+    --- PASS: TestParseOutput/Should_add_error_on_analysis_when_something_went_wrong_in_container (0.17s)
+    --- PASS: TestParseOutput/Should_not_execute_tool_because_it's_ignored (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/services/formatters/ruby/bundler	1.564s
+=== RUN   TestParseOutput
+=== RUN   TestParseOutput/Should_success_parse_output_to_analysis
+=== RUN   TestParseOutput/Should_success_parse_output_empty_to_analysis
+=== RUN   TestParseOutput/Should_error_rails_not_found_when_parse_output_to_analysis
+=== RUN   TestParseOutput/Should_return_error_when_parsing_invalid_output
+=== RUN   TestParseOutput/Should_return_error_when_something_went_wrong_in_container
+=== RUN   TestParseOutput/Should_not_execute_tool_because_it's_ignored
+--- PASS: TestParseOutput (0.01s)
+    --- PASS: TestParseOutput/Should_success_parse_output_to_analysis (0.00s)
+    --- PASS: TestParseOutput/Should_success_parse_output_empty_to_analysis (0.00s)
+    --- PASS: TestParseOutput/Should_error_rails_not_found_when_parse_output_to_analysis (0.00s)
+    --- PASS: TestParseOutput/Should_return_error_when_parsing_invalid_output (0.00s)
+    --- PASS: TestParseOutput/Should_return_error_when_something_went_wrong_in_container (0.00s)
+    --- PASS: TestParseOutput/Should_not_execute_tool_because_it's_ignored (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/services/formatters/shell/shellcheck	0.085s
+?   	github.com/ZupIT/horusec/internal/services/formatters/shell/shellcheck/entities	[no test files]
+?   	github.com/ZupIT/horusec/internal/services/formatters/swift/horusecswift	[no test files]
+?   	github.com/ZupIT/horusec/internal/services/formatters/yaml/horuseckubernetes	[no test files]
+=== RUN   TestGetCommitAuthor
+=== RUN   TestGetCommitAuthor/Should_success_get_commit_author
+=== RUN   TestGetCommitAuthor/Should_return_commit_author_not_found_when_something_went_wrong_while_executing_cmd
+=== RUN   TestGetCommitAuthor/Should_return_commit_author_not_found_when_line_or_path_not_found
+=== RUN   TestGetCommitAuthor/Should_return_commit_author_not_found_when_parameters_is_empty
+=== RUN   TestGetCommitAuthor/Should_return_commit_author_not_found_when_not_exists_path
+time="2022-07-26T18:08:54-03:00" level=error msg="{HORUSEC_CLI} Error when execute commit author command: " error="exit status 128" line_and_path="-L 1,1:./some_path" stderr="fatal: There is no path some_path in the commit\n"
+=== RUN   TestGetCommitAuthor/Should_return_commit_author_not_found_invalid_output
+time="2022-07-26T18:08:54-03:00" level=error msg="{HORUSEC_CLI} Error when to parse output to commit author struct: {\"invalid\": \"json-schema\"" error="unexpected end of JSON input"
+=== RUN   TestGetCommitAuthor/Should_return_commit_author_not_found_when_disable_commit_author
+=== RUN   TestGetCommitAuthor/Should_return_commit_author_not_found_when_file_has_not_yet_been_commited
+time="2022-07-26T18:08:54-03:00" level=error msg="{HORUSEC_CLI} Error when execute commit author command: " error="exit status 128" line_and_path="-L 1,1:temp-file" stderr="fatal: There is no path temp-file in the commit\n"
+=== RUN   TestGetCommitAuthor/Should_return_commit_author_from_first_line_when_line_is_zero
+=== RUN   TestGetCommitAuthor/Should_return_a_new_service
+=== RUN   TestGetCommitAuthor/Should_not_return_git_diff_in_output
+--- PASS: TestGetCommitAuthor (0.35s)
+    --- PASS: TestGetCommitAuthor/Should_success_get_commit_author (0.13s)
+    --- PASS: TestGetCommitAuthor/Should_return_commit_author_not_found_when_something_went_wrong_while_executing_cmd (0.00s)
+    --- PASS: TestGetCommitAuthor/Should_return_commit_author_not_found_when_line_or_path_not_found (0.00s)
+    --- PASS: TestGetCommitAuthor/Should_return_commit_author_not_found_when_parameters_is_empty (0.00s)
+    --- PASS: TestGetCommitAuthor/Should_return_commit_author_not_found_when_not_exists_path (0.05s)
+    --- PASS: TestGetCommitAuthor/Should_return_commit_author_not_found_invalid_output (0.00s)
+    --- PASS: TestGetCommitAuthor/Should_return_commit_author_not_found_when_disable_commit_author (0.00s)
+    --- PASS: TestGetCommitAuthor/Should_return_commit_author_not_found_when_file_has_not_yet_been_commited (0.04s)
+    --- PASS: TestGetCommitAuthor/Should_return_commit_author_from_first_line_when_line_is_zero (0.07s)
+    --- PASS: TestGetCommitAuthor/Should_return_a_new_service (0.00s)
+    --- PASS: TestGetCommitAuthor/Should_not_return_git_diff_in_output (0.06s)
+=== RUN   TestRepositoryIsShallow
+=== RUN   TestRepositoryIsShallow/NotShallow
+=== RUN   TestRepositoryIsShallow/IsShallow
+--- PASS: TestRepositoryIsShallow (6.79s)
+    --- PASS: TestRepositoryIsShallow/NotShallow (0.00s)
+    --- PASS: TestRepositoryIsShallow/IsShallow (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/services/git	7.203s
+=== RUN   TestServiceSendAnalysis
+=== RUN   TestServiceSendAnalysis/should_not_send_analysis_when_authorization_is_not_set
+=== RUN   TestServiceSendAnalysis/should_send_analysis_with_bad_request_error
+=== RUN   TestServiceSendAnalysis/should_send_analysis_with_internal_server_error
+=== RUN   TestServiceSendAnalysis/should_send_analysis_with_unauthorized_error
+=== RUN   TestServiceSendAnalysis/should_get_error_when_parsing_invalid_certificate
+--- PASS: TestServiceSendAnalysis (0.13s)
+    --- PASS: TestServiceSendAnalysis/should_not_send_analysis_when_authorization_is_not_set (0.01s)
+    --- PASS: TestServiceSendAnalysis/should_send_analysis_with_bad_request_error (0.02s)
+    --- PASS: TestServiceSendAnalysis/should_send_analysis_with_internal_server_error (0.06s)
+    --- PASS: TestServiceSendAnalysis/should_send_analysis_with_unauthorized_error (0.02s)
+    --- PASS: TestServiceSendAnalysis/should_get_error_when_parsing_invalid_certificate (0.01s)
+=== RUN   TestServiceGetAnalysis
+=== RUN   TestServiceGetAnalysis/Should_get_analysis_without_error
+=== RUN   TestServiceGetAnalysis/Should_get_analysis_without_error_when_no_authorization_is_found
+=== RUN   TestServiceGetAnalysis/Should_get_analysis_with_error_when_bad_request
+time="2022-07-26T18:08:54-03:00" level=error msg="{ERROR_HTTP} request returned a error status code" error= status="Bad Request" statusCode=400
+=== RUN   TestServiceGetAnalysis/Should_get_analysis_with_error_when_internal_server_error
+time="2022-07-26T18:08:54-03:00" level=error msg="{ERROR_HTTP} request returned a error status code" error= status="Internal Server Error" statusCode=500
+=== RUN   TestServiceGetAnalysis/Should_get_error_in_analysis_with_TLS_when_invalid_certificate
+=== RUN   TestServiceGetAnalysis/Should_get_analysis_with_error_when_response_body_is_nil
+=== RUN   TestServiceGetAnalysis/Should_get_analysis_with_error_when_response_body_is_invalid
+--- PASS: TestServiceGetAnalysis (0.02s)
+    --- PASS: TestServiceGetAnalysis/Should_get_analysis_without_error (0.00s)
+    --- PASS: TestServiceGetAnalysis/Should_get_analysis_without_error_when_no_authorization_is_found (0.00s)
+    --- PASS: TestServiceGetAnalysis/Should_get_analysis_with_error_when_bad_request (0.00s)
+    --- PASS: TestServiceGetAnalysis/Should_get_analysis_with_error_when_internal_server_error (0.00s)
+    --- PASS: TestServiceGetAnalysis/Should_get_error_in_analysis_with_TLS_when_invalid_certificate (0.01s)
+    --- PASS: TestServiceGetAnalysis/Should_get_analysis_with_error_when_response_body_is_nil (0.00s)
+    --- PASS: TestServiceGetAnalysis/Should_get_analysis_with_error_when_response_body_is_invalid (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/services/horusec_api	0.187s
+=== RUN   TestConvertVulnerabilityDataToSarif
+=== RUN   TestConvertVulnerabilityDataToSarif/should_successfully_parse_analysis_to_sarif_output
+=== RUN   TestConvertVulnerabilityDataToSarif/field_sets_should_be_populated
+--- PASS: TestConvertVulnerabilityDataToSarif (0.00s)
+    --- PASS: TestConvertVulnerabilityDataToSarif/should_successfully_parse_analysis_to_sarif_output (0.00s)
+    --- PASS: TestConvertVulnerabilityDataToSarif/field_sets_should_be_populated (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/services/sarif	0.082s
+=== RUN   TestConvertVulnerabilityDataToSonarQube
+=== RUN   TestConvertVulnerabilityDataToSonarQube/should_success_parse_analysis_to_sonar_output
+=== RUN   TestConvertVulnerabilityDataToSonarQube/issues_should_not_be_nil
+--- PASS: TestConvertVulnerabilityDataToSonarQube (0.00s)
+    --- PASS: TestConvertVulnerabilityDataToSonarQube/should_success_parse_analysis_to_sonar_output (0.00s)
+    --- PASS: TestConvertVulnerabilityDataToSonarQube/issues_should_not_be_nil (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/services/sonarqube	0.057s
+=== RUN   TestValidateConfigs
+=== RUN   TestValidateConfigs/Should_return_no_errors_when_valid
+=== RUN   TestValidateConfigs/Should_return_no_errors_when_is_not_valid_path
+=== RUN   TestValidateConfigs/Should_return_no_errors_when_valid_config_with_ignore
+=== RUN   TestValidateConfigs/Should_return_error_when_invalid_ignore_value
+=== RUN   TestValidateConfigs/Should_return_error_when_invalid_json_output_file_is_empty
+=== RUN   TestValidateConfigs/Should_return_error_when_invalid_json_output_file_is_invalid
+=== RUN   TestValidateConfigs/Should_return_error_when_the_text_output_file_is_invalid
+=== RUN   TestValidateConfigs/Should_not_return_error_when_the_text_output_file_is_valid
+=== RUN   TestValidateConfigs/Should_return_error_when_invalid_workdir
+=== RUN   TestValidateConfigs/Should_return_success_because_exists_path_in_workdir
+=== RUN   TestValidateConfigs/Should_return_error_because_not_exists_path_in_workdir
+=== RUN   TestValidateConfigs/Should_return_error_because_cert_path_is_not_valid
+=== RUN   TestValidateConfigs/Should_return_error_when_is_duplicated_false_positive_and_risk_accepted
+=== RUN   TestValidateConfigs/Should_return_not_error_when_validate_false_positive_and_risk_accepted
+--- PASS: TestValidateConfigs (0.02s)
+    --- PASS: TestValidateConfigs/Should_return_no_errors_when_valid (0.00s)
+    --- PASS: TestValidateConfigs/Should_return_no_errors_when_is_not_valid_path (0.00s)
+    --- PASS: TestValidateConfigs/Should_return_no_errors_when_valid_config_with_ignore (0.00s)
+    --- PASS: TestValidateConfigs/Should_return_error_when_invalid_ignore_value (0.00s)
+    --- PASS: TestValidateConfigs/Should_return_error_when_invalid_json_output_file_is_empty (0.00s)
+    --- PASS: TestValidateConfigs/Should_return_error_when_invalid_json_output_file_is_invalid (0.00s)
+    --- PASS: TestValidateConfigs/Should_return_error_when_the_text_output_file_is_invalid (0.00s)
+    --- PASS: TestValidateConfigs/Should_not_return_error_when_the_text_output_file_is_valid (0.00s)
+    --- PASS: TestValidateConfigs/Should_return_error_when_invalid_workdir (0.00s)
+    --- PASS: TestValidateConfigs/Should_return_success_because_exists_path_in_workdir (0.00s)
+    --- PASS: TestValidateConfigs/Should_return_error_because_not_exists_path_in_workdir (0.00s)
+    --- PASS: TestValidateConfigs/Should_return_error_because_cert_path_is_not_valid (0.00s)
+    --- PASS: TestValidateConfigs/Should_return_error_when_is_duplicated_false_positive_and_risk_accepted (0.00s)
+    --- PASS: TestValidateConfigs/Should_return_not_error_when_validate_false_positive_and_risk_accepted (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/usecases/cli	0.121s
+=== RUN   TestCopy
+--- PASS: TestCopy (0.02s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/utils/copy	0.067s
+=== RUN   TestGetFilePathIntoBasePath
+=== RUN   TestGetFilePathIntoBasePath/Should_return_path_correctly
+=== RUN   TestGetFilePathIntoBasePath/Should_return_filePath_because_not_found
+=== RUN   TestGetFilePathIntoBasePath/Should_return_filePath_because_base_path_is_wrong
+time="2022-07-26T18:08:55-03:00" level=error msg="Error to find filepath" basePath="S0M3 N0T E3X1$t" error="lstat S0M3 N0T E3X1$t: no such file or directory" filename=some_other_not_existing_file.go
+--- PASS: TestGetFilePathIntoBasePath (0.17s)
+    --- PASS: TestGetFilePathIntoBasePath/Should_return_path_correctly (0.10s)
+    --- PASS: TestGetFilePathIntoBasePath/Should_return_filePath_because_not_found (0.06s)
+    --- PASS: TestGetFilePathIntoBasePath/Should_return_filePath_because_base_path_is_wrong (0.00s)
+=== RUN   TestGetSubPathByExtension
+=== RUN   TestGetSubPathByExtension/Should_return_sub_path_for_.go
+=== RUN   TestGetSubPathByExtension/Should_return_empty_path_for_not_found_extension
+--- PASS: TestGetSubPathByExtension (0.00s)
+    --- PASS: TestGetSubPathByExtension/Should_return_sub_path_for_.go (0.00s)
+    --- PASS: TestGetSubPathByExtension/Should_return_empty_path_for_not_found_extension (0.00s)
+=== RUN   TestCreateAndWriteFile
+=== RUN   TestCreateAndWriteFile/Should_create_a_file_with_input_and_return_no_error
+=== RUN   TestCreateAndWriteFile/Should_create_a_file_in_current_directory_with_absolute_filepath_with_input_and_return_no_error_when_invalid_filepath
+--- PASS: TestCreateAndWriteFile (0.00s)
+    --- PASS: TestCreateAndWriteFile/Should_create_a_file_with_input_and_return_no_error (0.00s)
+    --- PASS: TestCreateAndWriteFile/Should_create_a_file_in_current_directory_with_absolute_filepath_with_input_and_return_no_error_when_invalid_filepath (0.00s)
+=== RUN   TestGetDependencyCodeFilepathAndLine
+=== RUN   TestGetDependencyCodeFilepathAndLine/Should_run_with_success
+=== RUN   TestGetDependencyCodeFilepathAndLine/Should_return_empty_when_path_is_invalid
+=== RUN   TestGetDependencyCodeFilepathAndLine/Should_return_empty_when_path_is_valid_but_has_no_files
+=== RUN   TestGetDependencyCodeFilepathAndLine/Should_found_the_file_but_not_found_the_code_expected_in_this_file
+--- PASS: TestGetDependencyCodeFilepathAndLine (0.00s)
+    --- PASS: TestGetDependencyCodeFilepathAndLine/Should_run_with_success (0.00s)
+    --- PASS: TestGetDependencyCodeFilepathAndLine/Should_return_empty_when_path_is_invalid (0.00s)
+    --- PASS: TestGetDependencyCodeFilepathAndLine/Should_return_empty_when_path_is_valid_but_has_no_files (0.00s)
+    --- PASS: TestGetDependencyCodeFilepathAndLine/Should_found_the_file_but_not_found_the_code_expected_in_this_file (0.00s)
+=== RUN   TestGetCode
+=== RUN   TestGetCode/Should_get_a_code_from_a_file_with_input_and_return_no_error
+=== RUN   TestGetCode/Should_not_get_a_code_from_a_file_with_input_and_return_error
+=== RUN   TestGetCode/Should_not_get_a_code_from_a_file_with_input_and_return_empty_when_line_is_empty
+=== RUN   TestGetCode/Should_not_get_a_code_from_a_file_with_input_and_return_empty_when_line_is_invalid
+=== RUN   TestGetCode/Should_not_get_a_code_from_a_file_with_input_and_return_error_when_dir_path_is_invalid
+time="2022-07-26T18:08:55-03:00" level=error msg="Error to open file to get code sample" error="open invalidDirPath/someFile: no such file or directory" filename=someFile line=3 projectPath=invalidDirPath
+=== RUN   TestGetCode/Should_not_get_a_code_from_a_file_with_input_and_return_error_when_filename_is_invalid
+time="2022-07-26T18:08:55-03:00" level=error msg="Error to open file to get code sample" error="open /tmp/TestGetCode4122010780/001/invalidFilename: no such file or directory" filename=invalidFilename line=3 projectPath=/tmp/TestGetCode4122010780/001
+--- PASS: TestGetCode (0.00s)
+    --- PASS: TestGetCode/Should_get_a_code_from_a_file_with_input_and_return_no_error (0.00s)
+    --- PASS: TestGetCode/Should_not_get_a_code_from_a_file_with_input_and_return_error (0.00s)
+    --- PASS: TestGetCode/Should_not_get_a_code_from_a_file_with_input_and_return_empty_when_line_is_empty (0.00s)
+    --- PASS: TestGetCode/Should_not_get_a_code_from_a_file_with_input_and_return_empty_when_line_is_invalid (0.00s)
+    --- PASS: TestGetCode/Should_not_get_a_code_from_a_file_with_input_and_return_error_when_dir_path_is_invalid (0.00s)
+    --- PASS: TestGetCode/Should_not_get_a_code_from_a_file_with_input_and_return_error_when_filename_is_invalid (0.00s)
+=== RUN   TestGetFilenameByExt
+=== RUN   TestGetFilenameByExt/Should_get_a_filename_by_extension_with_no_error
+=== RUN   TestGetFilenameByExt/Should_get_a_empty_filename_by_extension_when_ext_is_not_found
+=== RUN   TestGetFilenameByExt/Should_get_a_empty_filename_by_extension_and_error_when_path_is_valid
+time="2022-07-26T18:08:55-03:00" level=error msg="Error to walk on path" error="lstat invalidPath: no such file or directory" ext=.go path=invalidPath projectPath=invalidPath subPath=
+--- PASS: TestGetFilenameByExt (0.00s)
+    --- PASS: TestGetFilenameByExt/Should_get_a_filename_by_extension_with_no_error (0.00s)
+    --- PASS: TestGetFilenameByExt/Should_get_a_empty_filename_by_extension_when_ext_is_not_found (0.00s)
+    --- PASS: TestGetFilenameByExt/Should_get_a_empty_filename_by_extension_and_error_when_path_is_valid (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/utils/file	0.245s
+=== RUN   TestConvertInterfaceToMapString
+=== RUN   TestConvertInterfaceToMapString/should_success_parse_interface_to_map_string
+--- PASS: TestConvertInterfaceToMapString (0.00s)
+    --- PASS: TestConvertInterfaceToMapString/should_success_parse_interface_to_map_string (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/utils/json	0.028s
+=== RUN   TestPrompt_Ask
+=== RUN   TestPrompt_Ask/Should_run_command_ask_without_panics
+[?25l[2K[1m[32m✔[0m [1m[0m[1m:[0m |
+[1A[2K[2K
+[?25h--- PASS: TestPrompt_Ask (0.00s)
+    --- PASS: TestPrompt_Ask/Should_run_command_ask_without_panics (0.00s)
+=== RUN   TestMock_Ask
+--- PASS: TestMock_Ask (0.00s)
+=== RUN   TestMock_Select
+--- PASS: TestMock_Select (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/utils/prompt	0.042s
+?   	github.com/ZupIT/horusec/internal/utils/testutil	[no test files]
+=== RUN   TestGetStringValueOrDefault
+=== RUN   TestGetStringValueOrDefault/should_return_string_value
+=== RUN   TestGetStringValueOrDefault/should_return_default_value
+--- PASS: TestGetStringValueOrDefault (0.00s)
+    --- PASS: TestGetStringValueOrDefault/should_return_string_value (0.00s)
+    --- PASS: TestGetStringValueOrDefault/should_return_default_value (0.00s)
+=== RUN   TestGetInt64ValueOrDefault
+=== RUN   TestGetInt64ValueOrDefault/should_return_int_value
+=== RUN   TestGetInt64ValueOrDefault/should_return_default_value
+--- PASS: TestGetInt64ValueOrDefault (0.00s)
+    --- PASS: TestGetInt64ValueOrDefault/should_return_int_value (0.00s)
+    --- PASS: TestGetInt64ValueOrDefault/should_return_default_value (0.00s)
+=== RUN   TestGetSliceStringValueOrDefault
+=== RUN   TestGetSliceStringValueOrDefault/should_return_slice_string_value
+=== RUN   TestGetSliceStringValueOrDefault/should_return_slice_default_value
+--- PASS: TestGetSliceStringValueOrDefault (0.00s)
+    --- PASS: TestGetSliceStringValueOrDefault/should_return_slice_string_value (0.00s)
+    --- PASS: TestGetSliceStringValueOrDefault/should_return_slice_default_value (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/utils/valueordefault	0.066s
+=== RUN   TestBind
+--- PASS: TestBind (0.00s)
+=== RUN   TestToOneLine
+=== RUN   TestToOneLine/should_compress_an_string_to_a_one_line_string_wihtout_whitespaces
+--- PASS: TestToOneLine (0.00s)
+    --- PASS: TestToOneLine/should_compress_an_string_to_a_one_line_string_wihtout_whitespaces (0.00s)
+PASS
+ok  	github.com/ZupIT/horusec/internal/utils/vuln_hash	0.042s
+FAIL


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
Developing rules related to #1107 

Created two rules related to Brazil specific law.
- HS-PRIVACY-1: For handling the log/print of users documents (CPF and RG)
- HS-PRIVACY-2: For handling the hardcoded usage of those same documents.

**- How to verify it**

- **HS-PRIVACY-1**:

Creates a file

```touch index.js```

Use a log function to print the sensitive data

```javascript
console.log("CPF: " + client.doc);
```

Run horusec on folder

```horusec start```

Should point out the vulnerability **HS-PRIVACY-1**

- **HS-PRIVACY-2**:

Creates a file

```touch main.py```

Hard code the sensible data on the code:

```python
client = {
    "cpf": "123.456.789-10"
}
```

Run horusec

```horusec start```

Should point out the HS-PRIVACY-2

**Obs**

My objective is expanding this **feature** maybe adding a flag to Horusec to control which country/region we want our applications to conform with (like discussed on #1107)

This is, in my opinion, the first step on building a greater feature.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- Adding Privacy related rules to LEAKS