### PR TITLE
Fixed Windows install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,12 +94,12 @@ horusec version
 ### **Windows**
 - **amd64**
     ```sh
-    curl -k "https://github.com/ZupIT/horusec/releases/latest/download/horusec_win_amd64.exe" -o "./horusec.exe" -L
+    curl "https://github.com/ZupIT/horusec/releases/latest/download/horusec_win_amd64.exe" -o "./horusec.exe"
     ```
 
 - **arm64**
     ```sh
-    curl -k "https://github.com/ZupIT/horusec/releases/latest/download/horusec_win_arm64.exe" -o "./horusec.exe" -L
+    curl "https://github.com/ZupIT/horusec/releases/latest/download/horusec_win_arm64.exe" -o "./horusec.exe"
     ```
 
 #### **Check the installation**


### PR DESCRIPTION
`curl` does not have a `-k` or `-L` flag on Windows, these slightly simplified commands work perfectly well and accomplish the same task.