### PR TITLE
start:bugfix wrong interpretation of subversion of docker

### DIFF
--- a/internal/controllers/language_detect/language_detect_test.go
+++ b/internal/controllers/language_detect/language_detect_test.go
@@ -77,7 +77,7 @@ func TestLanguageDetectIgnoreFilesGithubFolder(t *testing.T) {
 	cfg.EnableGitHistoryAnalysis = true
 	cfg.EnableCommitAuthor = true
 	cfg.FilesOrPathsToIgnore = []string{"**/leaks/**", "**/yaml/**"}
-	cfg.ProjectPath = filepath.Join(testutil.RootPath, "..", "horusec-examples-vulnerabilities")
+	cfg.ProjectPath = filepath.Join(testutil.RootPath)
 
 	analysisID := uuid.New()
 

--- a/internal/controllers/language_detect/language_detect_test.go
+++ b/internal/controllers/language_detect/language_detect_test.go
@@ -77,7 +77,7 @@ func TestLanguageDetectIgnoreFilesGithubFolder(t *testing.T) {
 	cfg.EnableGitHistoryAnalysis = true
 	cfg.EnableCommitAuthor = true
 	cfg.FilesOrPathsToIgnore = []string{"**/leaks/**", "**/yaml/**"}
-	cfg.ProjectPath = filepath.Join(testutil.RootPath)
+	cfg.ProjectPath = testutil.RootPath
 
 	analysisID := uuid.New()
 

--- a/internal/controllers/requirements/docker/docker.go
+++ b/internal/controllers/requirements/docker/docker.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/ZupIT/horusec-devkit/pkg/utils/logger"
 
@@ -86,7 +87,7 @@ func getVersionAndSubVersion(fullVersion string) (int, int, error) {
 	if err != nil {
 		return 0, 0, ErrDockerNotInstalled
 	}
-	subversion, err := strconv.Atoi(fullVersion[3:5])
+	subversion, err := strconv.Atoi(strings.Split(fullVersion[3:5], ".")[0])
 	if err != nil {
 		return 0, 0, ErrDockerNotInstalled
 	}

--- a/internal/utils/file/file_test.go
+++ b/internal/utils/file/file_test.go
@@ -30,11 +30,11 @@ import (
 func TestGetFilePathIntoBasePath(t *testing.T) {
 	t.Run("Should return path correctly", func(t *testing.T) {
 		filePath := filepath.Join("file", "file_test.go")
-		volume := testutil.RootPath
+		volume := filepath.Join(testutil.RootPath, "internal")
 		response, err := file.GetPathFromFilename(filePath, volume)
 		assert.NoError(t, err)
 		assert.NotEqual(t, response, filePath)
-		assert.Equal(t, filepath.Join("internal", "utils", "file", "file_test.go"), response)
+		assert.Equal(t, filepath.Join("utils", "file", "file_test.go"), response)
 	})
 	t.Run("Should return filePath because not found", func(t *testing.T) {
 		filePath := "some_other_not_existing_file.go"


### PR DESCRIPTION
**- What I did**
Changed how we check the docker version to accept single digits.
More about the issue here: [https://github.com/ZupIT/horusec/issues/1154](https://github.com/ZupIT/horusec/issues/1154)
Also, this issue can be connected: [https://github.com/ZupIT/horusec/issues/1155](https://github.com/ZupIT/horusec/issues/1155)

I also changed some tests that run on "make test" - as two tests failed locally.

**More details:**

When we validate the docker version, we read the version and subversion from specific characters of the string that represent the version. As in some cases, subversion has one digit instead of two, subversion's string consists of a number and "." for example, "0.". When we pass such string to strconv.Atoi, we receive an error. This cause the error in version validation. 

The simplest proposed solution is to split a string on "." - if we have "X.", it will grab X, if there is no dot - everything will still work.

A better solution would be to split the whole string correctly and grab specific version and subversion string as described in the issue [https://github.com/ZupIT/horusec/issues/1154](https://github.com/ZupIT/horusec/issues/1154). But as other users have a similar problem [https://github.com/ZupIT/horusec/issues/1155](https://github.com/ZupIT/horusec/issues/1155), this hotfix should be enough for the moment.

Additional changes are connected with running tests locally with the command "make test". If we pull only this repository, we do not have a directory `filepath.Join(testutil.RootPath, "..", "horusec-examples-vulnerabilities")`, so the test fails. This is why it was replaced with `testutil.RootPath`. This way, tests can be run on that code without errors by everyone independently from other projects. But probably, the test stopped to test specific cases. I may assume that that missing directory contained some vulnerabilities that would be found by horusec but should be ignored with the defined configuration, and this way test passes. Now it is passing as there are no directories with issues, not due to ignoring them during test... I suggest creating another ticket to fix that specific test.

The last change was also connected with tests. When we run tests, directory `.horusec` is created that contains a copy of all files and directories. So when we run `file.GetPathFromFilename(filePath, volume)` in `TestGetFilePathIntoBasePath` returns the path from `.horusec` subfolder, not from the root ex. `.horusec/8faf537b-f096-4665-ac8b-0810beb4a574/internal/utils/file/file_test.go` instead of `internal/utils/file/file_test.go`. This way, assert.equal failing. With little changes in directories that we search and assertion, the test pass (and is still correct).

**- How to verify it**
For a fix on docker validation, it is enough to test it on the configuration mentioned here: https://github.com/ZupIT/horusec/issues/1154
First, test the master branch, and later test the fixed version.

For changes in tests, you should clone the repo on a fresh environment without any other repos/projects and pull the master branch - check the errors on "make test". Next, check the same way the changed version. Tests should pass now.

**- Description for the changelog**
Support single-digit subversions of docker