### PR TITLE
use short arguments in install script #1158 

### DIFF
--- a/deployments/scripts/install.sh
+++ b/deployments/scripts/install.sh
@@ -17,8 +17,8 @@ URL_DOWNLOAD=""
 VERSION_DOWNLOAD=$1
 # Contains the value of the latest stable release launched by horusec cli.
 LATEST=$(curl -sL https://api.github.com/repos/ZupIT/horusec/releases/latest | jq -r ".tag_name")
-LATEST_RC=$(git ls-remote --exit-code --sort='v:refname' --tags https://github.com/ZupIT/horusec.git --ref 'v*.*.*-rc.*' | cut --delimiter='/' --fields=3 | tail --lines=1 | sed 's/.*\///; s/\^{}//')
-LATEST_BETA=$(git ls-remote --exit-code --sort='v:refname' --tags https://github.com/ZupIT/horusec.git --ref 'v*.*.*-beta.*' | cut --delimiter='/' --fields=3 | tail --lines=1 | sed 's/.*\///; s/\^{}//')
+LATEST_RC=$(git ls-remote --exit-code --sort='v:refname' --tags https://github.com/ZupIT/horusec.git --ref 'v*.*.*-rc.*' | cut -d '/' -f 3 | tail -n 1 | sed 's/.*\///; s/\^{}//')
+LATEST_BETA=$(git ls-remote --exit-code --sort='v:refname' --tags https://github.com/ZupIT/horusec.git --ref 'v*.*.*-beta.*' | cut -d '/' -f 3 | tail -n 1 | sed 's/.*\///; s/\^{}//')
 IS_NEW_URL=false
 
 regex='^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'


### PR DESCRIPTION
**- What I did**
Fix for [https://github.com/ZupIT/horusec/issues/1158](https://github.com/ZupIT/horusec/issues/1158)
In some machines, there is an issue with installation scripts.
For example on some mac we get error:
```
cut: illegal option -- -
...
```
and
```
tail: illegal option -- -
...
```

This comes from: `cut --delimiter='/' --fields=3 | tail --lines=1`

This is due to the versions of cut and tail installed on different systems. For example [https://ss64.com/osx/cut.html](https://ss64.com/osx/cut.html)

To solve the issue, we should replace the long name of parameters with shorthands like -d instead of --delimeter, -f instead of --fields, -n instead of --lines

**- How to verify it**
You can test it by running install.sh script

**- Description for the changelog**
support different releases of cut and tail in install.sh
