### PR TITLE
#1129 fix getVersionAndSubVersion to use podman

### DIFF
--- a/internal/controllers/requirements/docker/docker.go
+++ b/internal/controllers/requirements/docker/docker.go
@@ -73,7 +73,7 @@ func validateIfDockerIsRunningInMinVersion(response string) error {
 		logger.LogErrorWithLevel(messages.MsgErrorWhenDockerIsLowerVersion, ErrMinVersion)
 		return err
 	}
-	if version <= MinVersionDockerAccept && subversion < MinSubVersionDockerAccept {
+	if version <= MinVersionDockerAccept || subversion < MinSubVersionDockerAccept {
 		fmt.Print("\n")
 		logger.LogInfo(messages.MsgInfoDockerLowerVersion)
 		fmt.Print("\n")
@@ -83,11 +83,12 @@ func validateIfDockerIsRunningInMinVersion(response string) error {
 }
 
 func getVersionAndSubVersion(fullVersion string) (int, int, error) {
-	version, err := strconv.Atoi(fullVersion[0:2])
+	splited := strings.Split(fullVersion, ".");
+	version, err := strconv.Atoi(splited[0])
 	if err != nil {
 		return 0, 0, ErrDockerNotInstalled
 	}
-	subversion, err := strconv.Atoi(strings.Split(fullVersion[3:5], ".")[0])
+	subversion, err := strconv.Atoi(splited[1])
 	if err != nil {
 		return 0, 0, ErrDockerNotInstalled
 	}

--- a/internal/controllers/requirements/docker/docker.go
+++ b/internal/controllers/requirements/docker/docker.go
@@ -73,7 +73,7 @@ func validateIfDockerIsRunningInMinVersion(response string) error {
 		logger.LogErrorWithLevel(messages.MsgErrorWhenDockerIsLowerVersion, ErrMinVersion)
 		return err
 	}
-	if version <= MinVersionDockerAccept || subversion < MinSubVersionDockerAccept {
+	if version < MinVersionDockerAccept || (version == MinVersionDockerAccept && subversion < MinSubVersionDockerAccept) {
 		fmt.Print("\n")
 		logger.LogInfo(messages.MsgInfoDockerLowerVersion)
 		fmt.Print("\n")


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
Update "getVersionAndSubVersion" to be able to manage all version numbers (not only one that start with 2 digits);

**- How to verify it**
Simply starting Horusec using Podman instead of Docker.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
